### PR TITLE
Fix XP wallet isolation and GraphQL rate limiting

### DIFF
--- a/extension/background/messageHandlers.ts
+++ b/extension/background/messageHandlers.ts
@@ -10,7 +10,7 @@ import { initializeOnWalletConnect } from "./index"
 import { oauthService } from "./oauth"
 import { groupManager } from "../lib/services/GroupManager"
 import { IntentionGroupsService } from "../lib/database/indexedDB-methods"
-import { xpService, getLevelUpCost } from "../lib/services/XPService"
+import { xpService, XPServiceClass, getLevelUpCost } from "../lib/services/XPService"
 import { sessionTracker, type TrackedUrl, type DomainCluster } from "../lib/services/SessionTracker"
 import { levelUpService } from "../lib/services/LevelUpService"
 
@@ -127,6 +127,8 @@ export function setupMessageHandlers(): void {
             // Update lastActiveWallet
             await chrome.storage.local.set({ lastActiveWallet: walletAddress })
             await chrome.storage.session.set({ walletAddress, walletType })
+            // Migrate XP from non-prefixed keys to wallet-prefixed keys (one-time)
+            await XPServiceClass.migrateToWalletKeys(walletAddress)
             console.log('✅ Wallet connected from external page:', walletAddress, 'type:', walletType)
             await initializeOnWalletConnect()
             sendResponse({ success: true })
@@ -432,7 +434,8 @@ export function setupMessageHandlers(): void {
 
       case "GET_USER_XP":
         try {
-          const xpStats = await xpService.getStats()
+          const { lastActiveWallet: xpWallet } = await chrome.storage.local.get('lastActiveWallet')
+          const xpStats = await xpService.getStats(xpWallet || '')
           sendResponse({ success: true, ...xpStats })
         } catch (error) {
           console.error("❌ GET_USER_XP error:", error)
@@ -528,7 +531,8 @@ export function setupMessageHandlers(): void {
             return true
           }
           const cost = getLevelUpCost(lvlGroup.level)
-          const xpStats = await xpService.getStats()
+          const { lastActiveWallet: lvlWallet } = await chrome.storage.local.get('lastActiveWallet')
+          const xpStats = await xpService.getStats(lvlWallet || '')
           sendResponse({
             success: true,
             cost,

--- a/extension/hooks/useDiscoveryScore.ts
+++ b/extension/hooks/useDiscoveryScore.ts
@@ -73,29 +73,36 @@ export const useDiscoveryScore = (): DiscoveryScoreResult => {
   const [error, setError] = useState<string | null>(null)
   const [claimedDiscoveryXP, setClaimedDiscoveryXP] = useState<number>(0)
 
-  // Load claimed discovery XP from storage on mount
+  // Load claimed discovery XP from storage (per-wallet)
   useEffect(() => {
     const loadClaimedXP = async () => {
+      if (!walletAddress) {
+        setClaimedDiscoveryXP(0)
+        return
+      }
       try {
-        const result = await chrome.storage.local.get(['claimed_discovery_xp'])
-        const xp = result.claimed_discovery_xp || 0
+        const key = `claimed_discovery_xp_${walletAddress}`
+        const result = await chrome.storage.local.get([key])
+        const xp = result[key] || 0
         setClaimedDiscoveryXP(xp)
-        logger.debug('Loaded claimed discovery XP from storage', { xp })
+        logger.debug('Loaded claimed discovery XP from storage', { xp, walletAddress })
       } catch (err) {
         logger.error('Failed to load claimed discovery XP', err)
       }
     }
     loadClaimedXP()
-  }, [])
+  }, [walletAddress])
 
-  // Function to claim XP for a specific discovery
+  // Function to claim XP for a specific discovery (per-wallet)
   const claimDiscoveryXP = useCallback(async (xpAmount: number): Promise<number> => {
+    if (!walletAddress) return claimedDiscoveryXP
+    const key = `claimed_discovery_xp_${walletAddress}`
     const newTotal = claimedDiscoveryXP + xpAmount
-    await chrome.storage.local.set({ claimed_discovery_xp: newTotal })
+    await chrome.storage.local.set({ [key]: newTotal })
     setClaimedDiscoveryXP(newTotal)
-    logger.info('Claimed discovery XP', { xpAmount, newTotal })
+    logger.info('Claimed discovery XP', { xpAmount, newTotal, walletAddress })
     return newTotal
-  }, [claimedDiscoveryXP])
+  }, [claimedDiscoveryXP, walletAddress])
 
   const fetchDiscoveryScore = useCallback(async () => {
     console.log('🔍 [useDiscoveryScore] Starting fetch with:', {

--- a/extension/lib/clients/graphql-client.ts
+++ b/extension/lib/clients/graphql-client.ts
@@ -11,7 +11,11 @@ const queryCache = new Map<string, { data: any; timestamp: number }>()
 
 // Request queue to prevent concurrent requests
 let requestQueue: Promise<any> = Promise.resolve()
-const MIN_REQUEST_INTERVAL_MS = 100 // Minimum 100ms between requests
+const MIN_REQUEST_INTERVAL_MS = 150 // Minimum 150ms between requests
+
+// Retry configuration
+const MAX_RETRIES = 3
+const INITIAL_RETRY_DELAY_MS = 1000 // 1s, then 2s, then 4s (exponential backoff)
 
 // Generate cache key from query and variables
 const getCacheKey = (query: string, variables?: any): string => {
@@ -28,7 +32,7 @@ const cleanCache = () => {
   }
 }
 
-// Simple GraphQL client for queries with rate limiting and caching
+// Simple GraphQL client for queries with rate limiting, retry, and caching
 export const intuitionGraphqlClient = {
   request: async (query: string, variables?: any) => {
     // Check cache first
@@ -46,43 +50,65 @@ export const intuitionGraphqlClient = {
         return cached2.data
       }
 
-      // Add delay to respect rate limits
-      await new Promise(resolve => setTimeout(resolve, MIN_REQUEST_INTERVAL_MS))
-
-      const response = await fetch(API_CONFIG.GRAPHQL_ENDPOINT, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          query,
-          variables,
-        }),
-      })
-
-      if (!response.ok) {
-        // On 429, wait longer before next request
-        if (response.status === 429) {
-          await new Promise(resolve => setTimeout(resolve, 5000))
+      // Retry loop with exponential backoff
+      let lastError: Error | null = null
+      for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        // Add delay to respect rate limits
+        if (attempt === 0) {
+          await new Promise(resolve => setTimeout(resolve, MIN_REQUEST_INTERVAL_MS))
+        } else {
+          // Exponential backoff: 1s, 2s, 4s
+          const backoffDelay = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt - 1)
+          console.warn(`⏳ [GraphQL] Retry ${attempt}/${MAX_RETRIES} after ${backoffDelay}ms...`)
+          await new Promise(resolve => setTimeout(resolve, backoffDelay))
         }
-        throw new Error(`HTTP error! status: ${response.status}`)
+
+        try {
+          const response = await fetch(API_CONFIG.GRAPHQL_ENDPOINT, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              query,
+              variables,
+            }),
+          })
+
+          if (!response.ok) {
+            if (response.status === 429) {
+              lastError = new Error(`HTTP error! status: 429 (rate limited)`)
+              continue // Retry with backoff
+            }
+            throw new Error(`HTTP error! status: ${response.status}`)
+          }
+
+          const json = await response.json()
+
+          if (json.errors) {
+            throw new Error(`GraphQL error: ${json.errors[0].message}`)
+          }
+
+          // Cache the result
+          queryCache.set(cacheKey, { data: json.data, timestamp: Date.now() })
+
+          // Clean old cache entries periodically
+          if (queryCache.size > 50) {
+            cleanCache()
+          }
+
+          return json.data
+        } catch (err) {
+          lastError = err instanceof Error ? err : new Error(String(err))
+          // Only retry on rate limiting (429), not other errors
+          if (!lastError.message.includes('429')) {
+            throw lastError
+          }
+        }
       }
 
-      const json = await response.json()
-
-      if (json.errors) {
-        throw new Error(`GraphQL error: ${json.errors[0].message}`)
-      }
-
-      // Cache the result
-      queryCache.set(cacheKey, { data: json.data, timestamp: Date.now() })
-
-      // Clean old cache entries periodically
-      if (queryCache.size > 50) {
-        cleanCache()
-      }
-
-      return json.data
+      // All retries exhausted
+      throw lastError || new Error('GraphQL request failed after retries')
     }))
 
     return result

--- a/extension/lib/services/GroupManager.ts
+++ b/extension/lib/services/GroupManager.ts
@@ -32,6 +32,14 @@ class GroupManagerService {
   private initialized = false
 
   /**
+   * Get the active wallet address from storage
+   */
+  private async getActiveWallet(): Promise<string> {
+    const result = await chrome.storage.local.get(['lastActiveWallet'])
+    return result.lastActiveWallet || ''
+  }
+
+  /**
    * Initialize the service (load groups from IndexedDB)
    */
   async init(): Promise<void> {
@@ -178,7 +186,8 @@ class GroupManagerService {
     await IntentionGroupsService.saveGroup(group)
 
     // Add XP
-    const xpGained = await xpService.addCertificationXP()
+    const wallet = await this.getActiveWallet()
+    const xpGained = await xpService.addCertificationXP(wallet)
 
     console.log(`✅ [GroupManager] Certified URL as ${certification} in ${groupId} (+${xpGained} XP)`)
 

--- a/extension/lib/services/LevelUpService.ts
+++ b/extension/lib/services/LevelUpService.ts
@@ -35,18 +35,27 @@ export interface LevelUpPreview {
  */
 class LevelUpServiceClass {
   /**
+   * Get the active wallet address from storage
+   */
+  private async getActiveWallet(): Promise<string> {
+    const result = await chrome.storage.local.get(['lastActiveWallet'])
+    return result.lastActiveWallet || ''
+  }
+
+  /**
    * Preview a level up (check if user can afford it)
    * Uses total XP from ALL sources (quests + discovery + certifications)
    * Supports both local groups and virtual (on-chain only) groups
    */
   async previewLevelUp(groupId: string): Promise<LevelUpPreview | null> {
+    const wallet = await this.getActiveWallet()
     let group = await groupManager.getGroup(groupId)
 
     // Handle virtual groups (on-chain only)
     if (!group && groupId.startsWith('onchain-')) {
       // For virtual groups, use default level 1 for preview
       const cost = getLevelUpCost(1)
-      const xpState = await xpService.getXPState()
+      const xpState = await xpService.getXPState(wallet)
 
       return {
         canLevelUp: xpState.totalXP >= cost,
@@ -60,7 +69,7 @@ class LevelUpServiceClass {
     if (!group) return null
 
     const cost = getLevelUpCost(group.level)
-    const xpState = await xpService.getXPState()
+    const xpState = await xpService.getXPState(wallet)
 
     return {
       canLevelUp: xpState.totalXP >= cost,
@@ -124,7 +133,8 @@ class LevelUpServiceClass {
     console.log(`💰 [LevelUpService] Level ${group.level} → ${group.level + 1} costs ${cost} XP`)
 
     // Check XP availability
-    const affordCheck = await xpService.canAffordLevelUp(group.level)
+    const wallet = await this.getActiveWallet()
+    const affordCheck = await xpService.canAffordLevelUp(wallet, group.level)
     if (!affordCheck.canAfford) {
       console.log(`❌ [LevelUpService] Not enough XP: ${affordCheck.available} < ${affordCheck.cost}`)
       return {
@@ -167,7 +177,7 @@ class LevelUpServiceClass {
     console.log(`✨ [LevelUpService] AI generated: "${predicateResult.predicate}"`)
 
     // Spend XP
-    const spendResult = await xpService.spendXP(cost)
+    const spendResult = await xpService.spendXP(wallet, cost)
     if (!spendResult.success) {
       console.error(`❌ [LevelUpService] Failed to spend XP`)
       return {
@@ -255,7 +265,8 @@ class LevelUpServiceClass {
     if (!group) return null
 
     const cost = getLevelUpCost(group.level)
-    const xpState = await xpService.getXPState()
+    const wallet = await this.getActiveWallet()
+    const xpState = await xpService.getXPState(wallet)
     const certificationCount = Object.values(groupManager.getCertificationBreakdown(group))
       .reduce((sum, count) => sum + count, 0)
 

--- a/extension/lib/services/XPService.ts
+++ b/extension/lib/services/XPService.ts
@@ -2,6 +2,7 @@
  * XPService
  * Manages user XP gain and spending via chrome.storage.local
  * Aggregates ALL XP sources: quests, discovery, and group certifications
+ * All keys are wallet-prefixed for multi-wallet support
  */
 
 // XP Configuration
@@ -56,8 +57,16 @@ export function getLevelUpCost(currentLevel: number): number {
 /**
  * XPService - Singleton service for managing XP
  * Aggregates ALL XP sources: quests, discovery, and group certifications
+ * All storage keys are wallet-prefixed (e.g. group_certification_xp_{wallet})
  */
 class XPServiceClass {
+  /**
+   * Build a wallet-prefixed storage key
+   */
+  private getKey(baseKey: string, wallet: string): string {
+    return `${baseKey}_${wallet}`
+  }
+
   /**
    * Calculate quest XP from claimed quests in storage
    */
@@ -71,18 +80,18 @@ class XPServiceClass {
    * Get current XP state from chrome.storage.local
    * Aggregates ALL XP sources: quests + discovery + group certifications - spent
    */
-  async getXPState(): Promise<XPState> {
-    const result = await chrome.storage.local.get([
-      'group_certification_xp',
-      'spent_xp',
-      'claimed_quests',
-      'claimed_discovery_xp'
-    ])
+  async getXPState(walletAddress: string): Promise<XPState> {
+    const groupKey = this.getKey('group_certification_xp', walletAddress)
+    const spentKey = this.getKey('spent_xp', walletAddress)
+    const claimedKey = this.getKey('claimed_quests', walletAddress)
+    const discoveryKey = this.getKey('claimed_discovery_xp', walletAddress)
 
-    const groupCertificationXP = result.group_certification_xp || 0
-    const spentXP = result.spent_xp || 0
-    const claimedQuests: string[] = result.claimed_quests || []
-    const discoveryXP = result.claimed_discovery_xp || 0
+    const result = await chrome.storage.local.get([groupKey, spentKey, claimedKey, discoveryKey])
+
+    const groupCertificationXP = result[groupKey] || 0
+    const spentXP = result[spentKey] || 0
+    const claimedQuests: string[] = result[claimedKey] || []
+    const discoveryXP = result[discoveryKey] || 0
 
     // Calculate quest XP from claimed quests
     const questXP = this.calculateQuestXP(claimedQuests)
@@ -104,12 +113,13 @@ class XPServiceClass {
   /**
    * Add XP from group certification
    */
-  async addCertificationXP(amount: number = XP_PER_CERTIFICATION): Promise<number> {
-    const result = await chrome.storage.local.get(['group_certification_xp'])
-    const currentXP = result.group_certification_xp || 0
+  async addCertificationXP(walletAddress: string, amount: number = XP_PER_CERTIFICATION): Promise<number> {
+    const key = this.getKey('group_certification_xp', walletAddress)
+    const result = await chrome.storage.local.get([key])
+    const currentXP = result[key] || 0
     const newTotal = currentXP + amount
 
-    await chrome.storage.local.set({ group_certification_xp: newTotal })
+    await chrome.storage.local.set({ [key]: newTotal })
     console.log(`✨ [XPService] Added ${amount} certification XP (new total: ${newTotal})`)
 
     return newTotal
@@ -119,8 +129,8 @@ class XPServiceClass {
    * Spend XP for level up
    * Checks total available XP from ALL sources before spending
    */
-  async spendXP(amount: number): Promise<XPResult> {
-    const state = await this.getXPState()
+  async spendXP(walletAddress: string, amount: number): Promise<XPResult> {
+    const state = await this.getXPState(walletAddress)
 
     // Check if user has enough total XP
     if (state.totalXP < amount) {
@@ -132,8 +142,9 @@ class XPServiceClass {
       }
     }
 
+    const spentKey = this.getKey('spent_xp', walletAddress)
     const newSpentTotal = state.spentXP + amount
-    await chrome.storage.local.set({ spent_xp: newSpentTotal })
+    await chrome.storage.local.set({ [spentKey]: newSpentTotal })
 
     const newBalance = state.totalXP - amount
     console.log(`💸 [XPService] Spent ${amount} XP (new balance: ${newBalance})`)
@@ -147,9 +158,9 @@ class XPServiceClass {
   /**
    * Check if user can afford a level up (uses total XP from ALL sources)
    */
-  async canAffordLevelUp(currentLevel: number): Promise<{ canAfford: boolean; cost: number; available: number }> {
+  async canAffordLevelUp(walletAddress: string, currentLevel: number): Promise<{ canAfford: boolean; cost: number; available: number }> {
     const cost = getLevelUpCost(currentLevel)
-    const state = await this.getXPState()
+    const state = await this.getXPState(walletAddress)
 
     return {
       canAfford: state.totalXP >= cost,
@@ -161,10 +172,12 @@ class XPServiceClass {
   /**
    * Reset XP (for testing/debugging)
    */
-  async resetXP(): Promise<void> {
+  async resetXP(walletAddress: string): Promise<void> {
+    const groupKey = this.getKey('group_certification_xp', walletAddress)
+    const spentKey = this.getKey('spent_xp', walletAddress)
     await chrome.storage.local.set({
-      group_certification_xp: 0,
-      spent_xp: 0
+      [groupKey]: 0,
+      [spentKey]: 0
     })
     console.log('🧹 [XPService] XP reset (note: quest/discovery XP not reset)')
   }
@@ -172,14 +185,14 @@ class XPServiceClass {
   /**
    * Get XP stats for debugging
    */
-  async getStats(): Promise<{
+  async getStats(walletAddress: string): Promise<{
     questXP: number
     discoveryXP: number
     certificationXP: number
     spentXP: number
     totalXP: number
   }> {
-    const state = await this.getXPState()
+    const state = await this.getXPState(walletAddress)
     return {
       questXP: state.questXP,
       discoveryXP: state.discoveryXP,
@@ -188,12 +201,40 @@ class XPServiceClass {
       totalXP: state.totalXP
     }
   }
+
+  /**
+   * One-time migration: copy XP data from non-prefixed keys to wallet-prefixed keys
+   */
+  static async migrateToWalletKeys(walletAddress: string): Promise<void> {
+    if (!walletAddress) return
+    const oldKeys = ['group_certification_xp', 'spent_xp', 'claimed_discovery_xp']
+    const result = await chrome.storage.local.get(oldKeys)
+
+    const updates: Record<string, number> = {}
+    let hasMigration = false
+    for (const key of oldKeys) {
+      if (result[key] && result[key] > 0) {
+        const newKey = `${key}_${walletAddress}`
+        const existing = await chrome.storage.local.get([newKey])
+        if (!existing[newKey]) {
+          updates[newKey] = result[key]
+          hasMigration = true
+        }
+      }
+    }
+
+    if (hasMigration) {
+      await chrome.storage.local.set(updates)
+      await chrome.storage.local.remove(oldKeys)
+      console.log('🔄 [XPService] Migrated XP data to wallet-prefixed keys:', updates)
+    }
+  }
 }
 
 // Singleton instance
 export const xpService = new XPServiceClass()
 
-// Export class for testing
+// Export class for testing and migration
 export { XPServiceClass }
 
 // Export constants


### PR DESCRIPTION
- Fix XP storage key mismatch: useDiscoveryScore and XPService now use wallet-prefixed keys, aligned with useQuestSystem
- Add one-time migration for existing users (non-prefixed keys → wallet-prefixed)
- Add GraphQL retry with exponential backoff (3 retries, 1s→2s→4s) on 429 rate limiting
- Harden PulseTab: type safety, safe URL parsing, error guards
- Add Pulse Analysis CTA button with loade