### PR TITLE
Fix Quest highlight desync between BottomNavigation and AccountTab

### DIFF
--- a/extension/hooks/useQuestSystem.ts
+++ b/extension/hooks/useQuestSystem.ts
@@ -133,6 +133,31 @@ export const useQuestSystem = (targetWalletAddress?: string): QuestSystemResult 
     loadAndSync()
   }, [walletAddress, onChainSyncDone, isReadOnlyMode])
 
+  // ─── Sync quest state across hook instances via storage changes ───
+  useEffect(() => {
+    if (isReadOnlyMode || !walletAddress) return
+
+    const claimedKey = getWalletKey('claimed_quests', walletAddress.toLowerCase())
+    const completedKey = getWalletKey('completed_quests', walletAddress.toLowerCase())
+    const progressKey = getWalletKey('quest_progress_cache', walletAddress.toLowerCase())
+
+    const handleStorageChange = (changes: { [key: string]: chrome.storage.StorageChange }, area: string) => {
+      if (area !== 'local') return
+      if (changes[claimedKey]?.newValue) {
+        setClaimedQuestIds(new Set(changes[claimedKey].newValue))
+      }
+      if (changes[completedKey]?.newValue) {
+        setCompletedQuestIds(new Set(changes[completedKey].newValue))
+      }
+      if (changes[progressKey]?.newValue) {
+        setUserProgress(changes[progressKey].newValue)
+      }
+    }
+
+    chrome.storage.onChanged.addListener(handleStorageChange)
+    return () => chrome.storage.onChanged.removeListener(handleStorageChange)
+  }, [walletAddress, isReadOnlyMode])
+
   // ─── Refresh progress data + on-chain sync ───
   const refreshQuests = async () => {
     if (!walletAddress) {


### PR DESCRIPTION
**Branch:** `fix/quest-highlight-sync` -> `dev`

## Summary

- Fix the gold glow highlight on the Profile dock icon not updating when quests are claimed or become claimable
- Add `chrome.storage.onChanged` listener in `useQuestSystem` to sync state across independent hook instances

## Problem

`useQuestSystem()` is called independently in `BottomNavigation` (dock icon highlight) and `AccountTab` (sub-tab highlight). Each instance has its own React state. When a quest is claimed in AccountTab, the other instance in BottomNavigation keeps stale `claimedQuestIds` — the gold glow persists. Same issue in reverse: when a quest becomes claimable after an action, the dock icon doesn't light up until the next manual refresh.

## Fix

Added a single `useEffect` in `useQuestSystem` that listens to `chrome.storage.onChanged` for 3 keys:

| Storage key | State synced | Effect |
|---|---|---|
| `claimed_quests_{wallet}` | `claimedQuestIds` | Highlight disappears after claim |
| `completed_quests_{wallet}` | `completedQuestIds` | Completed status propagates |
| `quest_progress_cache_{wallet}` | `userProgress` | Highlight appears when quest becomes claimable |

These keys are already written to by `QuestBadgeService.saveClaimedQuestIds()` and `QuestProgressService.saveCachedProgress()` — no write-side changes needed.

**Files:**
- `extension/hooks/useQuestSystem.ts` — Added `chrome.storage.onChanged` listener (~20 lines)

## Why not a singleton store?

Considered converting to a `useSyncExternalStore` singleton (like `DiscoveryScoreService`), but rejected it:
- Only 2 consumers, unlikely to grow — quest system is a profile feature
- Users claim 1-2 quests at a time max
- The `claimQuestXP` flow depends on `useCreateAtom()` (React hook for wallet ops), which can't live in a singleton service
- ~250 lines of new code vs ~20 lines with the storage listener
- `chrome.storage.onChanged` is already used throughout the codebase for cross-instance sync

## Test plan

- [ ] Open Profile > Quests tab > verify claimable quests show gold highlight on both the sub-tab and the dock Profile icon
- [ ] Claim a quest > verify the gold highlight disappears on both the sub-tab and the dock icon
- [ ] Perform an action that unlocks a quest (e.g. certify a page) > verify the gold highlight appears on both locations without manual refresh
- [ ] Switch wallet > verify quest state resets and reloads correctly
