### PR TITLE
Replace all "Loading..." text with SofiaLoader animation

### DIFF
--- a/extension/components/charts/BondingCurveChart.tsx
+++ b/extension/components/charts/BondingCurveChart.tsx
@@ -1,5 +1,6 @@
 import { useBondingCurveData } from '../../hooks'
 import type { CurveType, TimeRange } from '../../types/bonding-curve'
+import SofiaLoader from '../ui/SofiaLoader'
 
 interface BondingCurveChartProps {
   tripleId: string
@@ -36,7 +37,7 @@ export function BondingCurveChart({
   if (isLoading) {
     return (
       <div className={`stake-chart-section ${className}`}>
-        <div className="stake-chart-loading">Loading data...</div>
+        <div className="stake-chart-loading"><SofiaLoader size={40} /></div>
       </div>
     )
   }

--- a/extension/components/pages/CorePage.tsx
+++ b/extension/components/pages/CorePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useTransition, Suspense, lazy, useEffect } from 'react'
+import SofiaLoader from '../ui/SofiaLoader'
 import '../styles/Global.css'
 import '../styles/CorePage.css'
 
@@ -35,7 +36,7 @@ const CorePage = () => {
       </div>
 
       <div className="page-content">
-        <Suspense fallback={<div className="loading-state">Loading...</div>}>
+        <Suspense fallback={<div className="loading-state"><SofiaLoader size={40} /></div>}>
           {activeGraphTab === 'Echoes' && <EchoesTab />}
           {activeGraphTab === 'Pulse' && <PulseTab />}
           {activeGraphTab === 'Bookmarks' && <BookmarkTab />}

--- a/extension/components/pages/ProfilePage.tsx
+++ b/extension/components/pages/ProfilePage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useTransition, Suspense, lazy } from 'react'
 import { useRouter } from '../layout/RouterProvider'
+import SofiaLoader from '../ui/SofiaLoader'
 import '../styles/Global.css'
 import '../styles/CommonPage.css'
 import '../styles/ProfilePage.css'
@@ -37,19 +38,19 @@ const ProfilePage = () => {
     switch (activeTab) {
       case 'account':
         return (
-          <Suspense fallback={<div className="loading-state">Loading...</div>}>
+          <Suspense fallback={<div className="loading-state"><SofiaLoader size={40} /></div>}>
             <AccountTab />
           </Suspense>
         )
       case 'community':
         return (
-          <Suspense fallback={<div className="loading-state">Loading...</div>}>
+          <Suspense fallback={<div className="loading-state"><SofiaLoader size={40} /></div>}>
             <CommunityTab />
           </Suspense>
         )
       case 'history':
         return (
-          <Suspense fallback={<div className="loading-state">Loading...</div>}>
+          <Suspense fallback={<div className="loading-state"><SofiaLoader size={40} /></div>}>
             <HistoryTab
               expandedTriplet={expandedHistoryTriplet}
               setExpandedTriplet={setExpandedHistoryTriplet}

--- a/extension/components/pages/ResonancePage.tsx
+++ b/extension/components/pages/ResonancePage.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy, useState, useTransition } from 'react'
+import SofiaLoader from '../ui/SofiaLoader'
 import '../styles/Global.css'
 import '../styles/CommonPage.css'
 import '../styles/CorePage.css'
@@ -46,7 +47,7 @@ const ResonancePage = () => {
         </button>
       </div>
       <div className="page-content">
-        <Suspense fallback={<div className="loading-state">Loading...</div>}>
+        <Suspense fallback={<div className="loading-state"><SofiaLoader size={40} /></div>}>
           {activeTab === 'activity' && <FeedTab />}
           {activeTab === 'circle' && <CircleFeedTab />}
           {activeTab === 'trending' && <TrendingTab />}

--- a/extension/components/pages/UserProfilePage.tsx
+++ b/extension/components/pages/UserProfilePage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, Suspense, lazy } from "react"
 
 import { useRouter } from "../layout/RouterProvider"
+import SofiaLoader from "../ui/SofiaLoader"
 import {
   useCheckFollowStatus,
   useUserQuests,
@@ -207,7 +208,7 @@ const UserProfilePage = () => {
       </div>
 
       {/* Tab Content */}
-        <Suspense fallback={<div className="loading-state">Loading...</div>}>
+        <Suspense fallback={<div className="loading-state"><SofiaLoader size={40} /></div>}>
           {activeTab === "stats" && (
             <UserStatsTab
               walletAddress={userProfileData.walletAddress}

--- a/extension/components/pages/core-tabs/BookmarkTab.tsx
+++ b/extension/components/pages/core-tabs/BookmarkTab.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
 import { useBookmarks, useIntentionCategories, useIntuitionTriplets } from '../../../hooks'
+import SofiaLoader from '../../ui/SofiaLoader'
 import CategoryDetailView from '../../ui/CategoryDetailView'
 import type { IntentionCategory, IntentionType } from '../../../types/intentionCategories'
 import '../../styles/CoreComponents.css'
@@ -285,7 +286,7 @@ const BookmarkTab = () => {
                     <div className="bookmark-item">
                       <div className="bookmark-header-content">
                         <div className="bookmark-list-info">
-                          <h4>Loading...</h4>
+                          <h4><SofiaLoader size={20} /></h4>
                         </div>
                       </div>
                     </div>

--- a/extension/components/pages/profile-tabs/AccountTab.tsx
+++ b/extension/components/pages/profile-tabs/AccountTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, Suspense, lazy } from 'react'
+import SofiaLoader from '../../ui/SofiaLoader'
 import {
   useWalletFromStorage,
   useQuestSystem,
@@ -201,7 +202,7 @@ const AccountTab = () => {
       )}
 
       {activeTab === 'interest' && (
-        <Suspense fallback={<div className="loading-state">Loading...</div>}>
+        <Suspense fallback={<div className="loading-state"><SofiaLoader size={40} /></div>}>
           <InterestTab />
         </Suspense>
       )}

--- a/extension/components/pages/profile-tabs/AchievementsTab.tsx
+++ b/extension/components/pages/profile-tabs/AchievementsTab.tsx
@@ -10,6 +10,7 @@ import { getAddress } from 'viem'
 import type { Quest } from '../../../types/questTypes'
 import { createHookLogger } from '../../../lib/utils/logger'
 import WeightModal from '../../modals/WeightModal'
+import SofiaLoader from '../../ui/SofiaLoader'
 
 const logger = createHookLogger('AchievementsTab')
 
@@ -217,7 +218,7 @@ const AchievementsTab = ({
   if (loading) {
     return (
       <div className="achievements-tab-content">
-        <div className="achievements-loading">Loading...</div>
+        <div className="achievements-loading"><SofiaLoader size={40} /></div>
       </div>
     )
   }

--- a/extension/components/pages/profile-tabs/StatsTab.tsx
+++ b/extension/components/pages/profile-tabs/StatsTab.tsx
@@ -6,6 +6,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { formatUnits } from 'viem'
 import { useDiscoveryScore, useGlobalStake } from "~/hooks"
+import SofiaLoader from '../../ui/SofiaLoader'
 import { DISCOVERY_GOLD_REWARDS } from "~/types/discovery"
 import { getLevelColor, TIER_BADGES, getTierIndex } from "~/types/interests"
 import pioneerBadge from '../../ui/img/badges/pioneer.png'
@@ -75,8 +76,7 @@ const StatsTab = ({ walletAddress, trustedByCount, level = 1, totalXP = 0, signa
     return (
       <div className="stats-tab-content">
         <div className="stats-loading">
-          <div className="loading-spinner"></div>
-          <span>Loading stats...</span>
+          <SofiaLoader size={40} />
         </div>
       </div>
     )

--- a/extension/components/pages/profile-tabs/UserBookmarksTab.tsx
+++ b/extension/components/pages/profile-tabs/UserBookmarksTab.tsx
@@ -7,6 +7,7 @@
 
 import { useIntentionCategories } from "~/hooks"
 import CategoryDetailView from "../../ui/CategoryDetailView"
+import SofiaLoader from "../../ui/SofiaLoader"
 import "../../styles/BookmarkStyles.css"
 import "../../styles/CategoryStyles.css"
 
@@ -45,7 +46,7 @@ const UserBookmarksTab = ({ walletAddress }: UserBookmarksTabProps) => {
               <div className="bookmark-item">
                 <div className="bookmark-header-content">
                   <div className="bookmark-list-info">
-                    <h4>Loading...</h4>
+                    <h4><SofiaLoader size={20} /></h4>
                   </div>
                 </div>
               </div>

--- a/extension/components/pages/profile-tabs/UserStatsTab.tsx
+++ b/extension/components/pages/profile-tabs/UserStatsTab.tsx
@@ -8,6 +8,7 @@
 import { useState, useRef, useEffect } from "react"
 import { DISCOVERY_GOLD_REWARDS } from "~/types/discovery"
 import type { UserDiscoveryStats } from "~/types/discovery"
+import SofiaLoader from "../../ui/SofiaLoader"
 import { getLevelColor, TIER_BADGES, getTierIndex } from "~/types/interests"
 import pioneerBadge from "../../ui/img/badges/pioneer.png"
 import explorerBadge from "../../ui/img/badges/explorer.png"
@@ -86,8 +87,7 @@ const UserStatsTab = ({
     return (
       <div className="stats-tab-content">
         <div className="stats-loading">
-          <div className="loading-spinner"></div>
-          <span>Loading stats...</span>
+          <SofiaLoader size={40} />
         </div>
       </div>
     )

--- a/extension/components/pages/profile-tabs/follow/ExplorerPanel.tsx
+++ b/extension/components/pages/profile-tabs/follow/ExplorerPanel.tsx
@@ -5,6 +5,7 @@
 
 import { useMemo } from 'react'
 import { useRouter } from '../../../layout/RouterProvider'
+import SofiaLoader from '../../../ui/SofiaLoader'
 import type { AccountAtom } from '../../../../hooks'
 import { useGetTopSofiaAccountsQuery } from '@0xsofia/graphql'
 import { SOFIA_PROXY_ADDRESS } from '../../../../lib/config/chainConfig'
@@ -116,7 +117,7 @@ export function ExplorerPanel({ walletAddress }: ExplorerPanelProps) {
 
         {isLoading && (
           <div className="loading-state">
-            <p>Loading top accounts...</p>
+            <SofiaLoader size={40} />
           </div>
         )}
 

--- a/extension/components/pages/profile-tabs/follow/FollowersPanel.tsx
+++ b/extension/components/pages/profile-tabs/follow/FollowersPanel.tsx
@@ -5,6 +5,7 @@
 import { useEffect } from 'react'
 import { useFollowers, useCheckFollowStatus } from '../../../../hooks'
 import { useRouter } from '../../../layout/RouterProvider'
+import SofiaLoader from '../../../ui/SofiaLoader'
 import TrustAccountButton from '../../../ui/TrustAccountButton'
 import Avatar from '../../../ui/Avatar'
 import UserAtomStats from '../../../ui/UserAtomStats'
@@ -69,7 +70,7 @@ export function FollowersPanel({ walletAddress }: FollowersPanelProps) {
     <div className="follow-panel">
       {loading && (
         <div className="loading-state">
-          <p>Loading followers...</p>
+          <SofiaLoader size={40} />
         </div>
       )}
 

--- a/extension/components/pages/profile-tabs/follow/FollowingPanel.tsx
+++ b/extension/components/pages/profile-tabs/follow/FollowingPanel.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useState } from 'react'
 import { useFollowing, useCheckFollowStatus, useRedeemTriple } from '../../../../hooks'
 import { useRouter } from '../../../layout/RouterProvider'
+import SofiaLoader from '../../../ui/SofiaLoader'
 import type { FollowAccountVM } from '../../../../types/follows'
 import { refetchWithBackoff } from '../../../../lib/utils'
 import { intuitionGraphqlClient } from '../../../../lib/clients/graphql-client'
@@ -134,7 +135,7 @@ export function FollowingPanel({ walletAddress }: FollowingPanelProps) {
     <div className="follow-panel">
       {loading && (
         <div className="loading-state">
-          <p>Loading following...</p>
+          <SofiaLoader size={40} />
         </div>
       )}
 

--- a/extension/components/pages/profile-tabs/follow/TrustCirclePanel.tsx
+++ b/extension/components/pages/profile-tabs/follow/TrustCirclePanel.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useState } from 'react'
 import { useTrustCircle, useWeightOnChain, useRedeemTriple } from '../../../../hooks'
 import { useRouter } from '../../../layout/RouterProvider'
+import SofiaLoader from '../../../ui/SofiaLoader'
 import type { FollowAccountVM } from '../../../../types/follows'
 import { refetchWithBackoff } from '../../../../lib/utils'
 import { intuitionGraphqlClient } from '../../../../lib/clients/graphql-client'
@@ -159,7 +160,7 @@ export function TrustCirclePanel({ walletAddress }: TrustCirclePanelProps) {
     <div className="follow-panel">
       {loading && (
         <div className="loading-state">
-          <p>Loading trust circle...</p>
+          <SofiaLoader size={40} />
         </div>
       )}
 

--- a/extension/components/pages/resonance-tabs/CircleFeedTab.tsx
+++ b/extension/components/pages/resonance-tabs/CircleFeedTab.tsx
@@ -8,6 +8,7 @@ import {
 import { getAddress } from 'viem'
 
 import { useRouter } from '../../layout/RouterProvider'
+import SofiaLoader from '../../ui/SofiaLoader'
 import { useWalletFromStorage, useIntentionCategories, useWeightOnChain } from '~/hooks'
 import { SUBJECT_IDS, PREDICATE_IDS } from '~/lib/config/constants'
 import { SOFIA_PROXY_ADDRESS } from '~/lib/config/chainConfig'
@@ -451,7 +452,7 @@ const CircleFeedTab = () => {
         </div>
 
         {memberCategoriesLoading ? (
-          <div className="circle-loading">Loading certifications...</div>
+          <div className="circle-loading"><SofiaLoader size={150} /></div>
         ) : (
           <div className="circle-categories-grid">
             {memberCategories.map(category => (
@@ -514,7 +515,7 @@ const CircleFeedTab = () => {
 
       {/* Loading */}
       {loading && feedItems.length === 0 && (
-        <div className="circle-loading">Loading Trust Circle activity...</div>
+        <div className="circle-loading"><SofiaLoader size={150} /></div>
       )}
 
       {/* Empty: no trust circle */}

--- a/extension/components/pages/resonance-tabs/FeedTab.tsx
+++ b/extension/components/pages/resonance-tabs/FeedTab.tsx
@@ -7,6 +7,7 @@ import {
 import { getAddress } from 'viem'
 
 import { useWalletFromStorage, useWeightOnChain } from '~/hooks'
+import SofiaLoader from '../../ui/SofiaLoader'
 import { SUBJECT_IDS, PREDICATE_IDS } from '~/lib/config/constants'
 import { SOFIA_PROXY_ADDRESS } from '~/lib/config/chainConfig'
 import { createHookLogger } from '~/lib/utils'
@@ -339,7 +340,7 @@ const FeedTab = () => {
     return (
       <div className="feed-tab">
         <div className="loading-state">
-          <p>Loading feed...</p>
+          <SofiaLoader size={40} />
         </div>
       </div>
     )

--- a/extension/components/pages/resonance-tabs/LeaderboardTab.tsx
+++ b/extension/components/pages/resonance-tabs/LeaderboardTab.tsx
@@ -7,6 +7,7 @@
 import { useState } from "react"
 
 import { useStreakLeaderboard } from "~/hooks"
+import SofiaLoader from "../../ui/SofiaLoader"
 import {
   DAILY_CERTIFICATION_ATOM_ID,
   DAILY_VOTE_ATOM_ID
@@ -112,7 +113,7 @@ const LeaderboardTab = () => {
       </div>
 
       {loading && entries.length === 0 ? (
-        <div className="leaderboard-loading">Loading leaderboard...</div>
+        <div className="leaderboard-loading"><SofiaLoader size={40} /></div>
       ) : error ? (
         <div className="leaderboard-error">
           <p>Failed to load leaderboard</p>

--- a/extension/components/pages/resonance-tabs/TrendingTab.tsx
+++ b/extension/components/pages/resonance-tabs/TrendingTab.tsx
@@ -134,7 +134,7 @@ const TrendingTab = () => {
     return (
       <div className="trending-tab">
         <div className="trending-loading">
-          <SofiaLoader size={60} />
+          <SofiaLoader size={150} />
         </div>
       </div>
     )

--- a/extension/components/styles/AccountTab.css
+++ b/extension/components/styles/AccountTab.css
@@ -804,7 +804,13 @@
   padding: 16px 16px 80px;
 }
 
-.stats-loading,
+.stats-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+}
+
 .stats-error,
 .stats-empty {
   display: flex;
@@ -1932,7 +1938,13 @@
   padding: 12px 16px 80px;
 }
 
-.achievements-loading,
+.achievements-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+}
+
 .achievements-empty {
   display: flex;
   flex-direction: column;

--- a/extension/components/styles/CircleFeedTab.css
+++ b/extension/components/styles/CircleFeedTab.css
@@ -316,10 +316,10 @@
 }
 
 .circle-loading {
-  text-align: center;
-  padding: 48px var(--spacing-xl);
-  color: var(--color-text-placeholder);
-  font-size: var(--font-size-base);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
 }
 
 /* Responsive */

--- a/extension/components/styles/CorePage.css
+++ b/extension/components/styles/CorePage.css
@@ -118,15 +118,10 @@
 
 /* États de chargement - utilise .loading-state de CoreComponents.css comme base */
 .loading-state {
-  text-align: center;
-  color: #F2DED6;
-  font-style: italic;
-  padding: 40px;
-  background-color: rgba(255, 255, 255, 0.05);
-  border-radius: 12px;
-  backdrop-filter: blur(5px) saturate(100%);
-  -webkit-backdrop-filter: blur(5px) saturate(100%);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
 }
 
 /* Reveal Interest CTA */

--- a/extension/components/styles/FeedTab.css
+++ b/extension/components/styles/FeedTab.css
@@ -283,8 +283,10 @@
 
 /* Loading State */
 .loading-state {
-  text-align: center;
-  padding: 60px 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
 }
 
 .loading-state p {

--- a/extension/components/styles/LeaderboardTab.css
+++ b/extension/components/styles/LeaderboardTab.css
@@ -351,7 +351,13 @@
 
 /* ========== STATES ========== */
 
-.leaderboard-loading,
+.leaderboard-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+}
+
 .leaderboard-empty {
   text-align: center;
   padding: var(--spacing-4xl) var(--spacing-xl);

--- a/extension/components/styles/Modal.css
+++ b/extension/components/styles/Modal.css
@@ -1574,7 +1574,13 @@
   margin: 16px 0;
 }
 
-.stake-chart-loading,
+.stake-chart-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+}
+
 .stake-chart-error,
 .stake-chart-no-data {
   text-align: center;

--- a/extension/components/styles/ProfilePage.css
+++ b/extension/components/styles/ProfilePage.css
@@ -76,14 +76,7 @@
 
 .loading-state {
   display: flex;
-  align-items: center;
   justify-content: center;
-  padding: var(--spacing-4xl);
-  font-family: var(--font-family-primary);
-  font-size: var(--font-size-lg);
-  color: var(--color-primary);
-  background-color: var(--color-bg-glass-light);
-  border-radius: var(--radius-lg);
-  backdrop-filter: var(--backdrop-blur-light) var(--backdrop-saturate);
-  -webkit-backdrop-filter: var(--backdrop-blur-light) var(--backdrop-saturate);
+  align-items: center;
+  min-height: 400px;
 }

--- a/extension/components/styles/TrendingTab.css
+++ b/extension/components/styles/TrendingTab.css
@@ -405,7 +405,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 60px 0;
+  min-height: 400px;
 }
 
 @media (max-width: 480px) {

--- a/extension/components/ui/AccountStats.tsx
+++ b/extension/components/ui/AccountStats.tsx
@@ -1,4 +1,5 @@
 import { useAccountStats } from '../../hooks'
+import SofiaLoader from './SofiaLoader'
 import '../styles/AccountStats.css'
 
 interface AccountStatsProps {
@@ -20,7 +21,7 @@ const AccountStats = ({ accountAddress, compact = false }: AccountStatsProps) =>
   if (loading) {
     return (
       <div className={`account-stats-container ${compact ? 'account-stats-compact' : ''}`}>
-        <span className="account-stats-loading-text">Loading stats...</span>
+        <SofiaLoader size={24} />
       </div>
     )
   }

--- a/extension/components/ui/UserAtomStats.tsx
+++ b/extension/components/ui/UserAtomStats.tsx
@@ -1,5 +1,6 @@
 import { useUserAtomStats } from '../../hooks'
 import { createHookLogger } from '../../lib/utils/logger'
+import SofiaLoader from './SofiaLoader'
 import '../styles/AccountStats.css'
 
 const logger = createHookLogger('UserAtomStats')
@@ -43,7 +44,7 @@ const UserAtomStats = ({ termId, accountAddress, compact = false, signalsCount: 
   if (isLoading) {
     return (
       <div className={`account-stats-container ${compact ? 'account-stats-compact' : ''}`}>
-        <span className="account-stats-loading-text">Loading...</span>
+        <SofiaLoader size={24} />
       </div>
     )
   }


### PR DESCRIPTION
## Summary

- Replace every "Loading..." plain text across pages and sections with the `SofiaLoader` animated component for a consistent loading experience
- Center all loading animations vertically within the page content area using `min-height: 400px` + flexbox centering
- Keep "Loading..." text on buttons (Follow, Level Up) unchanged

## Changes

### 20 TSX files — SofiaLoader integration

Replaced all inline "Loading..." text, `<div className="loading-spinner">` spinners, and `<span>Loading stats...</span>` with `<SofiaLoader size={X} />`.

**Suspense fallbacks** (size=40):
- `CorePage.tsx` — Echoes/Pulse/Bookmarks tabs
- `ProfilePage.tsx` — Account/Community/History tabs (3 instances)
- `ResonancePage.tsx` — Activity/Circle/Trending/Streak tabs
- `UserProfilePage.tsx` — Stats/Community tabs
- `AccountTab.tsx` — Interest sub-tab

**Section loading states** (size=40):
- `AchievementsTab.tsx` — Achievements loading
- `StatsTab.tsx` — Stats loading (replaced spinner + text)
- `UserStatsTab.tsx` — User stats loading (replaced spinner + text)
- `FeedTab.tsx` — Feed loading
- `LeaderboardTab.tsx` — Leaderboard loading
- `CircleFeedTab.tsx` — Circle loading (2 instances, size=150)
- `TrendingTab.tsx` — Trending loading (size=150)
- `FollowingPanel.tsx` — Following list loading
- `FollowersPanel.tsx` — Followers list loading
- `TrustCirclePanel.tsx` — Trust circle loading
- `ExplorerPanel.tsx` — Top accounts loading
- `BondingCurveChart.tsx` — Chart data loading

**Inline stats** (size=24):
- `AccountStats.tsx` — Signals/Market Cap loading
- `UserAtomStats.tsx` — User atom stats loading

**Skeleton cards** (size=20):
- `BookmarkTab.tsx` — Bookmark card skeleton
- `UserBookmarksTab.tsx` — User bookmark card skeleton

### 7 CSS files — Centered loading layout

Updated all loading wrapper classes to use `display: flex` + `align-items: center` + `justify-content: center` + `min-height: 400px` so the loader is centered within the page content area:

- `CorePage.css` — `.loading-state`
- `FeedTab.css` — `.loading-state`
- `ProfilePage.css` — `.loading-state`
- `TrendingTab.css` — `.trending-loading`
- `CircleFeedTab.css` — `.circle-loading`
- `LeaderboardTab.css` — `.leaderboard-loading` (split from `.leaderboard-empty`)
- `AccountTab.css` — `.stats-loading` (split from `.stats-error/.stats-empty`) + `.achievements-loading` (split from `.achievements-empty`)
- `Modal.css` — `.stake-chart-loading` (split from `.stake-chart-error/.stake-chart-no-data`, min-height=200px)

## Not touched

- **Buttons**: "Loading..." text on Follow buttons (`UserProfilePage`, `FollowingPanel`, `FollowersPanel`, `FollowSearchBox`) and "Generating signal..." on `GroupDetailView` are intentionally kept as-is
- **Skeleton components**: `Skeleton.tsx` / `Skeleton.css` are not modified
- **HistoryTab**: Already uses `SofiaLoader` with `size={150}` (reference implementation)

## SofiaLoader size conventions

| Context | Size |
|---------|------|
| Full-page loading (Trending, Circle, History) | `150` |
| Suspense fallback / section loading | `40` |
| Inline stats (compact) | `24` |
| Bookmark card skeleton | `20` |

## Test plan

- [ ] `pnpm build` passes without errors
- [ ] Load extension in Chrome, verify SofiaLoader animation appears on each tab/section during loading
- [ ] Verify loading animation is centered vertically within page content
- [ ] Verify Follow buttons still show "Loading..." text (not SofiaLoader)
- [ ] Verify Skeleton shimmer cards are unchanged
