### PR TITLE
Onboarding First Claim Modal

### DIFF
--- a/extension/background/messageHandlers.ts
+++ b/extension/background/messageHandlers.ts
@@ -189,6 +189,27 @@ export function setupMessageHandlers(): void {
       return true
     }
 
+    if (message.type === 'FIRST_CLAIM') {
+      const url = message.data?.url || 'https://sofia.intuition.box'
+      ;(async () => {
+        try {
+          await chrome.storage.session.set({
+            pending_first_claim: { url }
+          })
+          const [tab] = await chrome.tabs.query({ active: true, currentWindow: true })
+          if (tab?.id) {
+            await chrome.sidePanel.open({ tabId: tab.id })
+          }
+          logger.info('First claim intent stored', { url })
+          sendResponse({ success: true })
+        } catch (error) {
+          logger.error('Failed to handle FIRST_CLAIM', error)
+          sendResponse({ success: false, error: error instanceof Error ? error.message : 'Unknown error' })
+        }
+      })()
+      return true
+    }
+
     sendResponse({ success: false, error: 'Unknown message type' })
     return true
   })

--- a/extension/components/layout/RouterProvider.tsx
+++ b/extension/components/layout/RouterProvider.tsx
@@ -21,6 +21,10 @@ interface SearchContext {
   showResults: boolean
 }
 
+export interface FirstClaimData {
+  url: string
+}
+
 interface RouterContextType {
   currentPage: Page
   navigateTo: (page: Page, data?: any) => void
@@ -34,6 +38,8 @@ interface RouterContextType {
   setActiveProfileTab: (tab: string | null) => void
   onboardingBookmarks: BookmarkData[]
   setOnboardingBookmarks: (bookmarks: BookmarkData[]) => void
+  firstClaimData: FirstClaimData | null
+  setFirstClaimData: (data: FirstClaimData | null) => void
 }
 
 const RouterContext = createContext<RouterContextType | undefined>(undefined)
@@ -53,6 +59,7 @@ export const RouterProvider = ({
   const [searchContext, setSearchContext] = useState<SearchContext | null>(null)
   const [activeProfileTab, setActiveProfileTab] = useState<string | null>(null)
   const [onboardingBookmarks, setOnboardingBookmarks] = useState<BookmarkData[]>([])
+  const [firstClaimData, setFirstClaimData] = useState<FirstClaimData | null>(null)
 
   const navigateTo = (page: Page, data?: any) => {
     setCurrentPage(page)
@@ -100,15 +107,37 @@ export const RouterProvider = ({
     }
   }, [])
 
+  // Check for pending first claim from landing page
+  const handlePendingFirstClaim = useCallback(async () => {
+    try {
+      const result = await chrome.storage.session.get('pending_first_claim')
+      const pending = result.pending_first_claim
+      if (pending?.url) {
+        await chrome.storage.session.remove('pending_first_claim')
+        setFirstClaimData({ url: pending.url })
+      }
+    } catch (err) {
+      logger.error('Failed to check pending first claim', err)
+    }
+  }, [])
+
   // Check on mount (delayed to let sidepanel init complete) + listen for storage changes
   useEffect(() => {
     // Delay initial check so sidepanel onboarding/home redirect settles first
-    const timeout = setTimeout(handlePendingProfile, 500)
+    const timeout = setTimeout(() => {
+      handlePendingProfile()
+      handlePendingFirstClaim()
+    }, 500)
 
     // Instant check when side panel is already open and a new deep link arrives
     const listener = (changes: { [key: string]: chrome.storage.StorageChange }, area: string) => {
-      if (area === 'session' && changes.pending_profile_view?.newValue) {
-        handlePendingProfile()
+      if (area === 'session') {
+        if (changes.pending_profile_view?.newValue) {
+          handlePendingProfile()
+        }
+        if (changes.pending_first_claim?.newValue) {
+          handlePendingFirstClaim()
+        }
       }
     }
     chrome.storage.onChanged.addListener(listener)
@@ -116,7 +145,7 @@ export const RouterProvider = ({
       clearTimeout(timeout)
       chrome.storage.onChanged.removeListener(listener)
     }
-  }, [handlePendingProfile])
+  }, [handlePendingProfile, handlePendingFirstClaim])
 
   const value: RouterContextType = {
     currentPage,
@@ -130,7 +159,9 @@ export const RouterProvider = ({
     activeProfileTab,
     setActiveProfileTab,
     onboardingBookmarks,
-    setOnboardingBookmarks
+    setOnboardingBookmarks,
+    firstClaimData,
+    setFirstClaimData
   }
 
   return (

--- a/extension/components/modals/OnboardingClaimModal.tsx
+++ b/extension/components/modals/OnboardingClaimModal.tsx
@@ -1,0 +1,636 @@
+import { useState, useEffect, useMemo, useCallback } from "react"
+import { createPortal } from "react-dom"
+import { useBalance } from "wagmi"
+import { formatUnits, getAddress } from "viem"
+import SofiaLoader from "../ui/SofiaLoader"
+import {
+  useWalletFromStorage,
+  useFeeEstimate,
+  useOnboardingClaim
+} from "~/hooks"
+import { globalStakeService } from "~/lib/services"
+import { EXPLORER_URLS } from "~/lib/config/chainConfig"
+import { getIntentionBadge } from "~/types/intentionCategories"
+import { createHookLogger } from "~/lib/utils"
+import "../styles/OnboardingClaimModal.css"
+
+const logger = createHookLogger("OnboardingClaimModal")
+
+type WeightOption = {
+  id: "minimum" | "default" | "strong" | "high" | "max" | "custom"
+  label: string
+  value: number | null
+  description: string
+}
+
+const weightOptions: WeightOption[] = [
+  { id: "minimum", label: "Minimum", value: 0.01, description: "0.01 TRUST" },
+  { id: "default", label: "Default", value: 0.5, description: "0.5 TRUST" },
+  { id: "strong", label: "Strong", value: 1, description: "1 TRUST" },
+  { id: "high", label: "High", value: 5, description: "5 TRUST" },
+  { id: "max", label: "Max", value: 10, description: "10 TRUST" }
+]
+
+const FEE_DENOMINATOR = 100000
+
+const STEP_HINTS = [
+  "This is your first claim — a trust signal on the Intuition protocol.",
+  "Choose how much TRUST to stake on this signal.",
+  "Allocate a portion to the Beta Season Pool.",
+  "Review the total cost before confirming.",
+  "Confirm your first claim on-chain!"
+]
+
+interface OnboardingClaimModalProps {
+  isOpen: boolean
+  url: string
+  onClose: () => void
+  onComplete: () => void
+}
+
+const OnboardingClaimModal = ({
+  isOpen,
+  url,
+  onClose,
+  onComplete
+}: OnboardingClaimModalProps) => {
+  const {
+    step,
+    nextStep,
+    loading: txLoading,
+    success: txSuccess,
+    error: txError,
+    transactionHash,
+    operationType,
+    submitClaim,
+    reset,
+    hasCompletedFirstClaim,
+    storeFirstTxFlag
+  } = useOnboardingClaim(url)
+
+  const [selectedWeight, setSelectedWeight] =
+    useState<WeightOption["id"] | null>(null)
+  const [customValue, setCustomValue] = useState("")
+  const [processingStep, setProcessingStep] = useState("")
+  const [gsPercentage, setGsPercentage] = useState<number>(() =>
+    globalStakeService.getUserPercentage()
+  )
+  const [gsInteracted, setGsInteracted] = useState(false)
+  const [alreadyClaimed, setAlreadyClaimed] = useState(false)
+
+  const { walletAddress } = useWalletFromStorage()
+  const { estimate } = useFeeEstimate()
+
+  const checksumAddress = walletAddress ? getAddress(walletAddress) : undefined
+  const { data: balanceData } = useBalance({ address: checksumAddress })
+  const userBalance = balanceData
+    ? parseFloat(formatUnits(balanceData.value, balanceData.decimals))
+    : 0
+
+  const gsEnabled = globalStakeService.isEnabled()
+
+  // Check if already claimed on mount
+  useEffect(() => {
+    if (isOpen && walletAddress) {
+      hasCompletedFirstClaim().then((done) => {
+        if (done) {
+          setAlreadyClaimed(true)
+          logger.info("First claim already completed, skipping modal")
+          onClose()
+        }
+      })
+    }
+  }, [isOpen, walletAddress, hasCompletedFirstClaim, onClose])
+
+  // Resync GS preference when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setGsPercentage(globalStakeService.getUserPercentage())
+    }
+  }, [isOpen])
+
+  // Processing animation steps
+  useEffect(() => {
+    if (txLoading) {
+      const steps = [
+        "Preparing triples...",
+        "Creating atoms...",
+        "Publishing to blockchain...",
+        "Confirming transaction..."
+      ]
+      let stepIndex = 0
+      setProcessingStep(steps[0])
+      const interval = setInterval(() => {
+        stepIndex = (stepIndex + 1) % steps.length
+        setProcessingStep(steps[stepIndex])
+      }, 2000)
+      return () => clearInterval(interval)
+    } else {
+      setProcessingStep("")
+    }
+  }, [txLoading])
+
+  // On TX success → store flag + auto-redirect after 2s
+  useEffect(() => {
+    if (txSuccess) {
+      storeFirstTxFlag()
+      const timeout = setTimeout(() => {
+        onComplete()
+      }, 2000)
+      return () => clearTimeout(timeout)
+    }
+  }, [txSuccess, storeFirstTxFlag, onComplete])
+
+  // Compute cost breakdown
+  const breakdown = useMemo(() => {
+    const minimumValue = weightOptions.find((opt) => opt.id === "minimum")!
+      .value!
+    const defaultValue = weightOptions.find((opt) => opt.id === "default")!
+      .value!
+
+    let totalTrust: number
+    if (selectedWeight === null) {
+      totalTrust = 0
+    } else if (selectedWeight === "custom") {
+      totalTrust =
+        customValue && customValue.trim() !== ""
+          ? parseFloat(customValue) || 0
+          : minimumValue
+    } else {
+      const opt = weightOptions.find((o) => o.id === selectedWeight)
+      totalTrust = opt?.value ?? defaultValue
+    }
+
+    const createOpts = { isNewTriple: true, newAtomCount: 1 }
+
+    if (totalTrust <= 0 || !gsEnabled) {
+      const costEstimate = estimate?.(totalTrust, 0, createOpts) ?? null
+      return {
+        totalTrust,
+        signalAmount: totalTrust,
+        poolAmount: 0,
+        belowMinimum: false,
+        creationCost: costEstimate?.creationCost ?? 0,
+        sofiaFixedFee: costEstimate?.sofiaFixedFee ?? 0,
+        sofiaPercentFee: costEstimate?.sofiaPercentFee ?? 0,
+        totalFees: costEstimate?.totalFees ?? 0,
+        totalEstimate: costEstimate?.totalEstimate ?? totalTrust,
+        depositCount: costEstimate?.depositCount ?? 1
+      }
+    }
+
+    const poolAmount = (totalTrust * gsPercentage) / FEE_DENOMINATOR
+    const signalAmount = totalTrust - poolAmount
+    const config = globalStakeService.getConfig()
+    const minDeposit = Number(config.minGlobalDeposit) / 1e18
+    const belowMinimum = poolAmount > 0 && poolAmount < minDeposit
+
+    const effectiveGsPercentage = belowMinimum ? 0 : gsPercentage
+    const costEstimate =
+      estimate?.(totalTrust, effectiveGsPercentage, createOpts) ?? null
+
+    return {
+      totalTrust,
+      signalAmount,
+      poolAmount,
+      belowMinimum,
+      creationCost: costEstimate?.creationCost ?? 0,
+      sofiaFixedFee: costEstimate?.sofiaFixedFee ?? 0,
+      sofiaPercentFee: costEstimate?.sofiaPercentFee ?? 0,
+      totalFees: costEstimate?.totalFees ?? 0,
+      totalEstimate: costEstimate?.totalEstimate ?? totalTrust,
+      depositCount: costEstimate?.depositCount ?? 1
+    }
+  }, [selectedWeight, customValue, gsPercentage, gsEnabled, estimate])
+
+  const handleSubmit = useCallback(async () => {
+    try {
+      if (gsEnabled) {
+        globalStakeService.setUserPercentage(gsPercentage)
+      }
+
+      const minimumValue = weightOptions.find(
+        (opt) => opt.id === "minimum"
+      )!.value!
+      const defaultValue = weightOptions.find(
+        (opt) => opt.id === "default"
+      )!.value!
+
+      let trustValue: number
+      if (selectedWeight === null) {
+        return
+      } else if (selectedWeight === "custom") {
+        trustValue =
+          customValue && customValue.trim() !== ""
+            ? parseFloat(customValue)
+            : minimumValue
+      } else {
+        const option = weightOptions.find((opt) => opt.id === selectedWeight)
+        trustValue =
+          !option || option.value === null ? defaultValue : option.value
+      }
+
+      const weightBigInt = BigInt(Math.floor(trustValue * 1e18))
+      await submitClaim(weightBigInt)
+    } catch (error) {
+      logger.error("Failed to submit onboarding claim", error)
+    }
+  }, [selectedWeight, customValue, gsPercentage, gsEnabled, submitClaim])
+
+  const handleClose = useCallback(() => {
+    reset()
+    setSelectedWeight(null)
+    setCustomValue("")
+    setGsInteracted(false)
+    onClose()
+  }, [reset, onClose])
+
+  // Can continue to next step?
+  const canContinue = useMemo(() => {
+    if (step === 2) return selectedWeight !== null
+    if (step === 3) return gsInteracted
+    return true
+  }, [step, selectedWeight, gsInteracted])
+
+  const handleContinue = useCallback(() => {
+    if (!canContinue) return
+    if (step === 5) {
+      handleSubmit()
+    } else {
+      nextStep()
+    }
+  }, [step, nextStep, handleSubmit, canContinue])
+
+  const formatTrust = (val: number): string => {
+    if (val === 0) return "0"
+    return parseFloat(val.toFixed(4)).toString()
+  }
+
+  const parseErrorMessage = (error: string): string => {
+    if (
+      error.includes("Wallet unavailable:") ||
+      error.includes("navigate to an HTTPS page")
+    ) {
+      return error
+    }
+    const failedMatch = error.match(
+      /(Shares addition failed|Weight addition failed):/i
+    )
+    const failedText = failedMatch ? failedMatch[0] : "Transaction failed:"
+    const detailsMatch = error.match(/Details:\s*(.+?)(?:\n|$)/i)
+    const detailsText = detailsMatch ? `Details: ${detailsMatch[1]}` : ""
+    return detailsText ? `${failedText}\n${detailsText}` : failedText
+  }
+
+  const isFormState = !txSuccess && !txError
+  const badge = getIntentionBadge("trusted")
+
+  if (!isOpen || alreadyClaimed) return null
+
+  return createPortal(
+    <div
+      className={`modal-overlay onboarding-claim-overlay ${txLoading ? "processing" : ""}`}
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !txLoading) handleClose()
+      }}
+    >
+      <div className="modal-content onboarding-claim-modal">
+        <div className="modal-body">
+
+          {/* Step 1+: Triple card (always visible from step 1) */}
+          {isFormState && (
+            <div
+              className={`onboarding-section ${step >= 1 ? "visible" : ""} ${step === 1 ? "highlighted" : ""}`}
+            >
+              <div className="weight-modal-triplet-card">
+                <div className="weight-modal-triplet-text">
+                  {badge ? (
+                    <span
+                      className="weight-modal-cert-target"
+                      style={{
+                        borderColor: `${badge.color}40`,
+                        backgroundColor: `${badge.color}0A`
+                      }}
+                    >
+                      <span className="object">Sofia</span>
+                      <span className="weight-modal-cert-dot">&middot;</span>
+                      <span
+                        className="weight-modal-intention-badge"
+                        style={{ color: badge.color }}
+                      >
+                        {badge.label}
+                      </span>
+                    </span>
+                  ) : (
+                    <>
+                      <span className="subject">I</span>{" "}
+                      <span className="action">trust</span>{" "}
+                      <span className="object">Sofia</span>
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Step 2+: Weight pills */}
+          {isFormState && (
+            <div
+              className={`onboarding-section ${step >= 2 ? "visible" : ""} ${step === 2 ? "highlighted" : ""}`}
+            >
+              <div className="weight-modal-amount-row">
+                <input
+                  type="number"
+                  min="0"
+                  step="0.000001"
+                  value={
+                    selectedWeight === null
+                      ? ""
+                      : selectedWeight === "custom"
+                        ? customValue || ""
+                        : weightOptions.find(
+                              (opt) => opt.id === selectedWeight
+                            )?.value || ""
+                  }
+                  onChange={(e) => {
+                    setSelectedWeight("custom")
+                    setCustomValue(e.target.value)
+                  }}
+                  onFocus={(e) => {
+                    setSelectedWeight("custom")
+                    e.target.select()
+                  }}
+                  className="weight-modal-amount-input"
+                  placeholder="0.01"
+                  disabled={txLoading}
+                />
+                <div className="weight-modal-pills">
+                  {weightOptions.map((option) => (
+                    <button
+                      key={option.id}
+                      onClick={() => setSelectedWeight(option.id)}
+                      className={`weight-modal-pill ${selectedWeight === option.id ? "selected" : ""}`}
+                      disabled={txLoading}
+                    >
+                      {option.value}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Step 3+: Global Stake slider */}
+          {isFormState && gsEnabled && (
+            <div
+              className={`onboarding-section ${step >= 3 ? "visible" : ""} ${step === 3 ? "highlighted" : ""}`}
+            >
+              <div className="gs-slider-section">
+                <div className="gs-slider-header">
+                  <span className="gs-slider-label">Beta Season Pool</span>
+                  <span className="gs-slider-value">
+                    {gsPercentage / 1000}%
+                  </span>
+                </div>
+                <input
+                  type="range"
+                  min={0}
+                  max={50000}
+                  step={1000}
+                  value={gsPercentage}
+                  onChange={(e) => {
+                    setGsPercentage(Number(e.target.value))
+                    setGsInteracted(true)
+                  }}
+                  className="gs-slider-input"
+                  style={
+                    {
+                      "--gs-fill-pct": `${(gsPercentage / 50000) * 100}%`
+                    } as React.CSSProperties
+                  }
+                  disabled={txLoading}
+                />
+                <div className="gs-slider-breakdown">
+                  <div className="gs-slider-breakdown-item">
+                    <span className="gs-slider-breakdown-label">Signal</span>
+                    <span className="gs-slider-breakdown-value">
+                      {formatTrust(breakdown.signalAmount)} TRUST
+                    </span>
+                  </div>
+                  <div className="gs-slider-breakdown-item">
+                    <span className="gs-slider-breakdown-label">
+                      Beta Season Pool
+                    </span>
+                    <span className="gs-slider-breakdown-value pool">
+                      {formatTrust(breakdown.poolAmount)} TRUST
+                    </span>
+                  </div>
+                </div>
+                {breakdown.belowMinimum && (
+                  <span className="gs-slider-minimum-hint">
+                    Below minimum — pool contribution skipped
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Step 4+: Cost breakdown */}
+          {isFormState && (
+            <div
+              className={`onboarding-section ${step >= 4 ? "visible" : ""} ${step === 4 ? "highlighted" : ""}`}
+            >
+              <div className="weight-modal-cost-summary">
+                <div className="weight-modal-cost-row">
+                  <span>Deposit</span>
+                  <span>{formatTrust(breakdown.totalTrust)} TRUST</span>
+                </div>
+                {gsEnabled &&
+                  gsPercentage > 0 &&
+                  !breakdown.belowMinimum && (
+                    <>
+                      <div className="weight-modal-cost-row weight-modal-cost-sub">
+                        <span>Signal</span>
+                        <span>
+                          {formatTrust(breakdown.signalAmount)} TRUST
+                        </span>
+                      </div>
+                      <div className="weight-modal-cost-row weight-modal-cost-sub">
+                        <span>Beta Season Pool</span>
+                        <span>
+                          {formatTrust(breakdown.poolAmount)} TRUST
+                        </span>
+                      </div>
+                    </>
+                  )}
+                {breakdown.totalFees > 0 && (
+                  <>
+                    <div className="weight-modal-cost-divider" />
+                    <div className="weight-modal-cost-row weight-modal-cost-fees-subtotal">
+                      <span>Fees</span>
+                      <span>{formatTrust(breakdown.totalFees)} TRUST</span>
+                    </div>
+                    {(breakdown.sofiaFixedFee > 0 ||
+                      breakdown.sofiaPercentFee > 0) && (
+                      <div className="weight-modal-cost-row weight-modal-cost-sub">
+                        <span>Sofia fee</span>
+                        <span>
+                          {formatTrust(
+                            breakdown.sofiaFixedFee +
+                              breakdown.sofiaPercentFee
+                          )}{" "}
+                          TRUST
+                        </span>
+                      </div>
+                    )}
+                    {breakdown.creationCost > 0 && (
+                      <div className="weight-modal-cost-row weight-modal-cost-sub">
+                        <span>Intuition fee (creation only)</span>
+                        <span>
+                          {formatTrust(breakdown.creationCost)} TRUST
+                        </span>
+                      </div>
+                    )}
+                    <div className="weight-modal-cost-divider" />
+                    <div className="weight-modal-cost-row weight-modal-cost-total">
+                      <span>Total</span>
+                      <span>
+                        {formatTrust(breakdown.totalEstimate)} TRUST
+                      </span>
+                    </div>
+                  </>
+                )}
+                <div
+                  className={`weight-modal-cost-row weight-modal-cost-balance ${breakdown.totalEstimate > userBalance ? "weight-modal-insufficient" : ""}`}
+                >
+                  <span>Balance</span>
+                  <span>{formatTrust(userBalance)} TRUST</span>
+                </div>
+                <p className="weight-modal-cost-note">
+                  * Estimated — actual may vary
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Success State */}
+          {txSuccess && (
+            <div className="modal-success-card">
+              <div className="modal-success-card-glow" />
+              <div className="modal-success-card-inner">
+                <div className="modal-success-left">
+                  <h2 className="modal-success-title">
+                    First Claim
+                    <br />
+                    Validated
+                  </h2>
+                  <p className="modal-success-subtitle">
+                    {operationType === "deposit"
+                      ? "Your trust signal has been reinforced!"
+                      : "Your trust signal has been amplified!"}
+                  </p>
+                  {transactionHash && (
+                    <a
+                      href={`${EXPLORER_URLS.TRANSACTION}${transactionHash}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="modal-tx-link"
+                    >
+                      View on Explorer &rarr;
+                    </a>
+                  )}
+                  <p className="onboarding-redirect-hint">
+                    Redirecting to tutorial...
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Error State */}
+          {txError && !txSuccess && (
+            <div className="modal-error-section">
+              <div className="modal-error-icon">&#10060;</div>
+              <div className="modal-error-text">
+                <p className="modal-error-title">Transaction Failed</p>
+                <p className="modal-error-message">
+                  {parseErrorMessage(txError)}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Processing State */}
+          {txLoading && !txSuccess && (
+            <div className="modal-processing-section">
+              <SofiaLoader size={60} />
+              <div className="modal-processing-text">
+                <p className="modal-processing-title">Creating</p>
+                <p className="modal-processing-step">{processingStep}</p>
+              </div>
+            </div>
+          )}
+
+          {/* Step hint + indicators (bottom) */}
+          {isFormState && step <= 5 && (
+            <p className="onboarding-step-hint">{STEP_HINTS[step - 1]}</p>
+          )}
+          {isFormState && (
+            <div className="onboarding-step-indicators">
+              {[1, 2, 3, 4, 5].map((s) => (
+                <div
+                  key={s}
+                  className={`onboarding-step-dot ${s === step ? "active" : ""} ${s < step ? "completed" : ""}`}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        {!txSuccess && (
+          <div className="modal-actions">
+            {(step === 5 || txError) && (
+              <button
+                className="stake-btn stake-btn-cancel"
+                onClick={handleClose}
+                disabled={txLoading}
+              >
+                {txError ? "Close" : "Skip"}
+              </button>
+            )}
+            {!txError && isFormState && (
+              <button
+                className="modal-btn primary"
+                onClick={handleContinue}
+                disabled={
+                  txLoading ||
+                  !canContinue ||
+                  (step === 5 && breakdown.totalEstimate > userBalance)
+                }
+              >
+                {txLoading
+                  ? "Processing..."
+                  : step === 5
+                    ? "Certify"
+                    : "Continue"}
+              </button>
+            )}
+            {txError && (
+              <button
+                className="modal-btn primary"
+                onClick={handleSubmit}
+                disabled={txLoading}
+              >
+                Retry
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+export default OnboardingClaimModal

--- a/extension/components/styles/OnboardingClaimModal.css
+++ b/extension/components/styles/OnboardingClaimModal.css
@@ -1,0 +1,108 @@
+/* OnboardingClaimModal — Step-by-step onboarding modal */
+
+/* Modal body override — tighten spacing */
+.onboarding-claim-modal .modal-body {
+  padding: var(--spacing-md) var(--spacing-lg);
+  gap: 0;
+}
+
+/* Step indicators */
+.onboarding-step-indicators {
+  display: flex;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) 0 0;
+}
+
+.onboarding-step-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-bg-glass-lighter);
+  transition: var(--transition-normal);
+}
+
+.onboarding-step-dot.active {
+  background: #ffb659;
+  box-shadow: 0 0 8px rgba(255, 182, 89, 0.4);
+  transform: scale(1.25);
+}
+
+.onboarding-step-dot.completed {
+  background: rgba(255, 182, 89, 0.5);
+}
+
+/* Step hint text */
+.onboarding-step-hint {
+  font-family: var(--font-family-primary);
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  text-align: center;
+  color: var(--color-text-secondary);
+  margin: var(--spacing-sm) 0 0;
+  min-height: 22px;
+}
+
+/* Bottom margin for modal actions inside onboarding modal */
+.onboarding-claim-modal .modal-actions {
+  padding: var(--spacing-md) var(--spacing-lg) var(--spacing-lg);
+}
+
+/* Weight amount row spacing inside onboarding */
+.onboarding-claim-modal .weight-modal-amount-row {
+  margin: var(--spacing-md) 0;
+}
+
+/* Section progressive reveal */
+.onboarding-section {
+  opacity: 0;
+  max-height: 0;
+  overflow: hidden;
+  transform: translateY(8px);
+  transition:
+    opacity 0.4s ease,
+    max-height 0.4s ease,
+    transform 0.4s ease;
+  pointer-events: none;
+}
+
+.onboarding-section.visible {
+  opacity: 1;
+  max-height: 500px;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+/* Highlighted step glow */
+.onboarding-section.highlighted {
+  position: relative;
+}
+
+.onboarding-section.highlighted::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 182, 89, 0.2);
+  pointer-events: none;
+  animation: onboarding-pulse 2s ease-in-out infinite;
+}
+
+@keyframes onboarding-pulse {
+  0%,
+  100% {
+    border-color: rgba(255, 182, 89, 0.15);
+  }
+  50% {
+    border-color: rgba(255, 182, 89, 0.35);
+  }
+}
+
+/* Redirect hint on success */
+.onboarding-redirect-hint {
+  font-family: var(--font-family-primary);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-placeholder);
+  margin-top: var(--spacing-sm);
+  font-style: italic;
+}

--- a/extension/hooks/index.ts
+++ b/extension/hooks/index.ts
@@ -54,6 +54,10 @@ export type { TrendingItem, TrendingCategory, TrendingCertifier } from './useTre
 export { usePageDiscovery } from './usePageDiscovery'
 export { useDiscoveryReward } from './useDiscoveryReward'
 
+// Onboarding
+export { useOnboardingClaim } from './useOnboardingClaim'
+export type { UseOnboardingClaimResult } from './useOnboardingClaim'
+
 // UI Hooks
 export { useFavicon } from './useFavicon'
 export { useCredibilityAnalysis, getTotalShares, type CredibilityAnalysis } from './useCredibilityAnalysis'

--- a/extension/hooks/useOnboardingClaim.ts
+++ b/extension/hooks/useOnboardingClaim.ts
@@ -1,0 +1,91 @@
+import { useState, useCallback } from "react"
+import { useIntentionCertify } from "./useIntentionCertify"
+import { useWalletFromStorage } from "./useWalletFromStorage"
+import { createHookLogger } from "~/lib/utils"
+
+const logger = createHookLogger("useOnboardingClaim")
+
+const TOTAL_STEPS = 6
+
+export interface UseOnboardingClaimResult {
+  step: number
+  nextStep: () => void
+  loading: boolean
+  success: boolean
+  error: string | null
+  transactionHash: string | null
+  operationType: "created" | "deposit" | null
+  submitClaim: (weight: bigint) => Promise<void>
+  reset: () => void
+  hasCompletedFirstClaim: () => Promise<boolean>
+  storeFirstTxFlag: () => Promise<void>
+}
+
+export const useOnboardingClaim = (
+  url: string
+): UseOnboardingClaimResult => {
+  const [step, setStep] = useState(1)
+  const { walletAddress } = useWalletFromStorage()
+
+  const {
+    certifyWithCustomPredicate,
+    reset: resetCertify,
+    loading,
+    success,
+    error,
+    transactionHash,
+    operationType
+  } = useIntentionCertify()
+
+  const nextStep = useCallback(() => {
+    setStep((prev) => Math.min(prev + 1, TOTAL_STEPS))
+  }, [])
+
+  const submitClaim = useCallback(
+    async (weight: bigint) => {
+      if (!walletAddress) return
+      logger.info("Submitting first claim", { url, weight: weight.toString() })
+      await certifyWithCustomPredicate(
+        url,
+        "trusts",
+        undefined,
+        "Sofia",
+        weight
+      )
+    },
+    [walletAddress, url, certifyWithCustomPredicate]
+  )
+
+  const storeFirstTxFlag = useCallback(async () => {
+    if (!walletAddress) return
+    const key = `first_claim_done_${walletAddress.toLowerCase()}`
+    await chrome.storage.local.set({ [key]: true })
+    logger.info("First claim flag stored", { wallet: walletAddress })
+  }, [walletAddress])
+
+  const hasCompletedFirstClaim = useCallback(async () => {
+    if (!walletAddress) return false
+    const key = `first_claim_done_${walletAddress.toLowerCase()}`
+    const result = await chrome.storage.local.get(key)
+    return !!result[key]
+  }, [walletAddress])
+
+  const reset = useCallback(() => {
+    setStep(1)
+    resetCertify()
+  }, [resetCertify])
+
+  return {
+    step,
+    nextStep,
+    loading,
+    success,
+    error,
+    transactionHash,
+    operationType,
+    submitClaim,
+    reset,
+    hasCompletedFirstClaim,
+    storeFirstTxFlag
+  }
+}

--- a/extension/sidepanel.tsx
+++ b/extension/sidepanel.tsx
@@ -22,6 +22,7 @@ import UserProfilePage from "./components/pages/UserProfilePage"
 import OnboardingImportPage from "./components/pages/OnboardingImportPage"
 import OnboardingTutorialPage from "./components/pages/OnboardingTutorialPage"
 import OnboardingBookmarkSelectPage from "./components/pages/OnboardingBookmarkSelectPage"
+import OnboardingClaimModal from "./components/modals/OnboardingClaimModal"
 import { IntentionGroupsService } from "./lib/database/indexedDB-methods"
 
 // Configure GraphQL client BEFORE creating QueryClient
@@ -40,7 +41,7 @@ const queryClient = new QueryClient({
 
 
 const SidePanelContent = () => {
-  const { currentPage, navigateTo } = useRouter()
+  const { currentPage, navigateTo, firstClaimData, setFirstClaimData } = useRouter()
 
   // Read wallet from chrome.storage.session (set by tabs/auth.tsx via Privy)
   const { walletAddress, authenticated } = useWalletFromStorage()
@@ -100,6 +101,17 @@ const SidePanelContent = () => {
     <AppLayout>
       {renderCurrentPage()}
       <BottomNavigation />
+      {firstClaimData && (
+        <OnboardingClaimModal
+          isOpen={!!firstClaimData}
+          url={firstClaimData.url}
+          onClose={() => setFirstClaimData(null)}
+          onComplete={() => {
+            setFirstClaimData(null)
+            navigateTo("onboarding-tutorial")
+          }}
+        />
+      )}
     </AppLayout>
   )
 }

--- a/extension/types/messages.ts
+++ b/extension/types/messages.ts
@@ -55,6 +55,8 @@ export type MessageType =
   | 'FORCE_FLUSH_TRACKER'
   // Deep link from share page
   | 'DEEP_LINK_PROFILE'
+  // Onboarding first claim from landing page
+  | 'FIRST_CLAIM'
   // Wallet bridge messages
   | 'WALLET_REQUEST'
   | 'WALLET_EVENT'


### PR DESCRIPTION
## Summary

- Add `FIRST_CLAIM` external message handler so the landing page (`sofia.intuition.box/auth/`) can trigger a "Create your first claim" flow in the extension
- New step-by-step onboarding modal (`OnboardingClaimModal`) that guides the user through their first on-chain certification ("I trust Sofia")
- Deep-link pattern via `chrome.storage.session` (`pending_first_claim`) — same approach as `pending_profile_view`
- First TX flag stored in `chrome.storage.local` to prevent re-triggering

## Flow

```
Landing page
  → chrome.runtime.sendMessage(extensionId, { type: "FIRST_CLAIM", data: { url } })
  → background handler stores pending_first_claim + opens side panel
  → RouterProvider detects pending_first_claim via chrome.storage.onChanged
  → OnboardingClaimModal opens in sidepanel.tsx
  → 5-step progressive reveal (triple card → weight → GS slider → cost → certify)
  → TX success → store flag → redirect to OnboardingTutorialPage
```

## Message contract (for landing page dev)

```typescript
chrome.runtime.sendMessage(extensionId, {
  type: "FIRST_CLAIM",
  data: { url: "https://sofia.intuition.box" }
})
// Response: { success: true } or { success: false, error: "..." }
```

- `extensionId` is passed via query param by the extension when opening the auth page
- Origin `https://sofia.intuition.box` is already whitelisted in `ALLOWED_EXTERNAL_ORIGINS`
- Wallet must be connected before sending (via `WALLET_CONNECTED` message)

## Files created

| File | Description |
|------|-------------|
| `extension/components/modals/OnboardingClaimModal.tsx` | 5-step modal with progressive reveal, weight selection, GS slider, cost breakdown, TX lifecycle |
| `extension/components/styles/OnboardingClaimModal.css` | Step indicators, progressive reveal animations, highlight glow, spacing overrides |
| `extension/hooks/useOnboardingClaim.ts` | Hook: step state, TX via `useIntentionCertify`, first-claim flag in `chrome.storage.local` |

## Files modified

| File | Change |
|------|--------|
| `extension/types/messages.ts` | Add `'FIRST_CLAIM'` to `MessageType` union |
| `extension/background/messageHandlers.ts` | Handle `FIRST_CLAIM` in `onMessageExternal`: store intent + open side panel |
| `extension/components/layout/RouterProvider.tsx` | Detect `pending_first_claim` in `chrome.storage.onChanged`, expose `firstClaimData` / `setFirstClaimData` in context |
| `extension/hooks/index.ts` | Export `useOnboardingClaim` + `UseOnboardingClaimResult` type |
| `extension/sidepanel.tsx` | Render `OnboardingClaimModal` when `firstClaimData` is set |

## Modal behavior

- **Step 1**: Triple card "Sofia · Trusted" (progressive reveal)
- **Step 2**: Weight selection pills (0.01 / 0.5 / 1 / 5 / 10 TRUST) — must select to continue
- **Step 3**: Beta Season Pool slider — must interact to continue
- **Step 4**: Cost breakdown (deposit + fees + total + balance)
- **Step 5**: "Certify" button (disabled if insufficient balance) + "Skip" button
- **Success**: "First Claim Validated" card → auto-redirect to tutorial after 2s
- **Error**: Error message + Retry button
- **Already done**: Modal checks `first_claim_done_{wallet}` flag on mount — closes silently if already completed

## Test plan

- [ ] `pnpm build` compiles without errors
- [ ] From `sofia.intuition.box/auth/`: connect wallet → click "Create your first claim" → side panel opens → modal appears
- [ ] Navigate through all 5 steps — Continue is disabled until required action at steps 2 and 3
- [ ] Skip button only appears at step 5
- [ ] Certify → TX on-chain → success state → redirect to tutorial
- [ ] Re-trigger `FIRST_CLAIM` after completion → modal does not open (flag check)
- [ ] Close overlay click works (when not processing)
