### PR TITLE
Onboarding First Claim Modal (fix)

### DIFF
--- a/extension/background/messageHandlers.ts
+++ b/extension/background/messageHandlers.ts
@@ -128,7 +128,7 @@ export function setupMessageHandlers(): void {
             }
             // Update lastActiveWallet
             await chrome.storage.local.set({ lastActiveWallet: walletAddress })
-            await chrome.storage.session.set({ walletAddress, walletType })
+            await chrome.storage.session.set({ walletAddress, walletType, pending_external_auth: true })
             // Migrate XP from non-prefixed keys to wallet-prefixed keys (one-time)
             await XPServiceClass.migrateToWalletKeys(walletAddress)
             // Migrate unified XP to dual currency (XP + Gold) — one-time, idempotent

--- a/extension/sidepanel.tsx
+++ b/extension/sidepanel.tsx
@@ -50,17 +50,27 @@ const SidePanelContent = () => {
   // Automatic page management based on connection state
   useEffect(() => {
     if (authenticated && walletAddress && currentPage === 'home') {
-      // Check if user has local groups — if not, show onboarding
-      IntentionGroupsService.getAllGroups().then(groups => {
-        if (groups.length === 0) {
-          navigateTo('onboarding-import')
-        } else {
+      // Check if connected from external auth page (landing page)
+      // If so, skip onboarding-import and go to home-connected — wait for FIRST_CLAIM
+      chrome.storage.session.get('pending_external_auth').then(result => {
+        if (result.pending_external_auth) {
+          chrome.storage.session.remove('pending_external_auth')
           navigateTo('home-connected')
+          setOnboardingChecked(true)
+          return
         }
-        setOnboardingChecked(true)
-      }).catch(() => {
-        navigateTo('home-connected')
-        setOnboardingChecked(true)
+        // Internal connection — check if user has local groups
+        IntentionGroupsService.getAllGroups().then(groups => {
+          if (groups.length === 0) {
+            navigateTo('onboarding-import')
+          } else {
+            navigateTo('home-connected')
+          }
+          setOnboardingChecked(true)
+        }).catch(() => {
+          navigateTo('home-connected')
+          setOnboardingChecked(true)
+        })
       })
     } else if (!authenticated && currentPage !== 'home') {
       navigateTo('home')


### PR DESCRIPTION
## Summary

- Add `FIRST_CLAIM` external message handler so the landing page (`sofia.intuition.box/auth/`) can trigger a "Create your first claim" flow in the extension
- New step-by-step onboarding modal (`OnboardingClaimModal`) that guides the user through their first on-chain certification ("I trust Sofia")
- Deep-link pattern via `chrome.storage.session` (`pending_first_claim`) — same approach as `pending_profile_view`
- First TX flag stored in `chrome.storage.local` to prevent re-triggering
- `WALLET_CONNECTED` from external auth no longer triggers onboarding — extension waits for `FIRST_CLAIM`

## Flow

```
Landing page (sofia.intuition.box/auth/)
  1. User connects wallet
     → WALLET_CONNECTED sent → extension stores wallet + pending_external_auth flag
     → side panel skips onboarding-import, goes to home-connected
     → user stays on auth page, sees the CTA

  2. User clicks "Create your first claim"
     → FIRST_CLAIM sent → extension stores pending_first_claim + opens side panel
     → RouterProvider detects pending_first_claim via chrome.storage.onChanged
     → OnboardingClaimModal opens

  3. User completes 5-step flow
     → TX success → store first_claim_done flag → redirect to OnboardingTutorialPage
```

## Message contract (for landing page dev)

Two sequential messages:

```typescript
// 1. Already exists — sent on wallet connection
chrome.runtime.sendMessage(extensionId, {
  type: "WALLET_CONNECTED",
  data: { walletAddress: "0x...", walletType: "privy" }
})

// 2. NEW — sent when user clicks "Create your first claim"
chrome.runtime.sendMessage(extensionId, {
  type: "FIRST_CLAIM",
  data: { url: "https://sofia.intuition.box" }
})
// Response: { success: true } or { success: false, error: "..." }
```

- `extensionId` is passed via query param by the extension when opening the auth page
- Origin `https://sofia.intuition.box` is already whitelisted in `ALLOWED_EXTERNAL_ORIGINS`
- Wallet MUST be connected before sending `FIRST_CLAIM` (via `WALLET_CONNECTED`)
- After sending `FIRST_CLAIM`, landing page can redirect to `https://sofia.intuition.box`

## Files created

| File | Description |
|------|-------------|
| `extension/components/modals/OnboardingClaimModal.tsx` | 5-step modal with progressive reveal, weight selection, GS slider, cost breakdown, TX lifecycle |
| `extension/components/styles/OnboardingClaimModal.css` | Step indicators, progressive reveal animations, highlight glow, spacing overrides |
| `extension/hooks/useOnboardingClaim.ts` | Hook: step state, TX via `useIntentionCertify`, first-claim flag in `chrome.storage.local` |

## Files modified

| File | Change |
|------|--------|
| `extension/types/messages.ts` | Add `'FIRST_CLAIM'` to `MessageType` union |
| `extension/background/messageHandlers.ts` | Handle `FIRST_CLAIM` in `onMessageExternal` (store intent + open side panel). Set `pending_external_auth` flag on `WALLET_CONNECTED` |
| `extension/components/layout/RouterProvider.tsx` | Detect `pending_first_claim` in `chrome.storage.onChanged`, expose `firstClaimData` / `setFirstClaimData` in context |
| `extension/hooks/index.ts` | Export `useOnboardingClaim` + `UseOnboardingClaimResult` type |
| `extension/sidepanel.tsx` | Skip `onboarding-import` when `pending_external_auth` is set. Render `OnboardingClaimModal` when `firstClaimData` is set |

## Key behavior changes

### WALLET_CONNECTED (external)
- **Before**: Extension stores wallet → side panel auto-navigates to `onboarding-import` (bookmark import)
- **After**: Extension stores wallet + `pending_external_auth` flag → side panel goes to `home-connected` and waits

### FIRST_CLAIM (new)
- Stores `pending_first_claim` in `chrome.storage.session`
- Opens side panel via `chrome.sidePanel.open()`
- RouterProvider picks up the intent → sets `firstClaimData` → modal opens

### Internal connection (not from landing page)
- No `pending_external_auth` flag → existing behavior preserved (onboarding-import if no groups)

## Modal behavior

- **Step 1**: Triple card "Sofia · Trusted" (progressive reveal)
- **Step 2**: Weight selection pills (0.01 / 0.5 / 1 / 5 / 10 TRUST) — must select to continue
- **Step 3**: Beta Season Pool slider — must interact to continue
- **Step 4**: Cost breakdown (deposit + fees + total + balance)
- **Step 5**: "Certify" button (disabled if insufficient balance) + "Skip" button
- **Success**: "First Claim Validated" card → auto-redirect to tutorial after 2s
- **Error**: Error message + Retry button
- **Already done**: Modal checks `first_claim_done_{wallet}` flag on mount — closes silently if already completed

## Test plan

- [ ] `pnpm build` compiles without errors
- [ ] From `sofia.intuition.box/auth/`: connect wallet → user stays on auth page (no auto-redirect to onboarding)
- [ ] Click "Create your first claim" → side panel opens → modal appears
- [ ] Navigate through all 5 steps — Continue is disabled until required action at steps 2 and 3
- [ ] Skip button only appears at step 5
- [ ] Certify → TX on-chain → success state → redirect to tutorial
- [ ] Re-trigger `FIRST_CLAIM` after completion → modal does not open (flag check)
- [ ] Internal connection (not from landing page) → onboarding-import still works as before
- [ ] Close overlay click works (when not processing)
