### PR TITLE
feat(realtime): Phase 1.B — SW-level WS subscriptions

### DIFF
--- a/extension/.env.development
+++ b/extension/.env.development
@@ -2,6 +2,7 @@
 PLASMO_PUBLIC_SOFIA_SERVER_URL=http://localhost:3000
 PLASMO_PUBLIC_MASTRA_URL=http://localhost:4111
 PLASMO_PUBLIC_NETWORK=testnet
+PLASMO_PUBLIC_GRAPHQL_WS_URL=wss://testnet.intuition.sh/v1/graphql
 
 # Privy authentication
 PLASMO_PUBLIC_PRIVY_APP_ID=cmj05tjsj03thjs0c3mgxrixm

--- a/extension/.env.exemple
+++ b/extension/.env.exemple
@@ -6,6 +6,12 @@
 # Production: https://sofia-agent.intuition.box
 PLASMO_PUBLIC_SOFIA_SERVER_URL=http://localhost:3000
 
+# Intuition GraphQL WebSocket URL (realtime subscriptions)
+# Testnet: wss://testnet.intuition.sh/v1/graphql
+# Mainnet (default): wss://mainnet.intuition.sh/v1/graphql
+# Leave unset to use the mainnet default baked into the extension.
+PLASMO_PUBLIC_GRAPHQL_WS_URL=wss://mainnet.intuition.sh/v1/graphql
+
 
 PLASMO_PUBLIC_PRIVY_APP_ID= 0000000000000000000000000000
 PLASMO_PUBLIC_PRIVY_CLIENT_ID= 0000000000000000000000000000

--- a/extension/.env.production
+++ b/extension/.env.production
@@ -3,6 +3,7 @@ PLASMO_PUBLIC_SOFIA_SERVER_URL=https://1c7e47af64a3446a360e8fceb253f38991cff023-
 PLASMO_PUBLIC_MASTRA_URL=https://1c7e47af64a3446a360e8fceb253f38991cff023-4111.dstack-pha-prod7.phala.network
 PLASMO_PUBLIC_MCP_URL=https://1c7e47af64a3446a360e8fceb253f38991cff023-3001.dstack-pha-prod7.phala.network
 PLASMO_PUBLIC_NETWORK=mainnet
+PLASMO_PUBLIC_GRAPHQL_WS_URL=wss://mainnet.intuition.sh/v1/graphql
 
 # Privy authentication
 PLASMO_PUBLIC_PRIVY_APP_ID=cmj05tjsj03thjs0c3mgxrixm

--- a/extension/background/index.ts
+++ b/extension/background/index.ts
@@ -1,6 +1,7 @@
 import { setupMessageHandlers } from "./messageHandlers";
 import { MessageBus } from "../lib/services";
 import { initializeThemeIconManager } from "./themeIconManager";
+import { initializeRealtime } from "./realtime";
 import { createServiceLogger } from '../lib/utils/logger'
 import "./oauth/index"; // Initialize OAuth service
 
@@ -34,6 +35,11 @@ async function init(): Promise<void> {
   try {
     // Initialize theme-aware icon system
     await initializeThemeIconManager()
+
+    // Initialize realtime WS subscriptions (Phase 1.B — SW-level).
+    // Reads current wallet from chrome.storage.session and subscribes;
+    // reconnects on wallet change via chrome.storage.onChanged.
+    await initializeRealtime()
 
     // Setup message handlers (has internal guard against duplicates)
     setupMessageHandlers()

--- a/extension/background/realtime.ts
+++ b/extension/background/realtime.ts
@@ -1,0 +1,101 @@
+/**
+ * Service Worker realtime module.
+ *
+ * Instantiates a SubscriptionManager tied to the shared queryClient and
+ * drives WS subscriptions from the wallet address stored in
+ * chrome.storage.session. Wallet connect → manager.connect(wallet).
+ * Wallet disconnect → manager.disconnect(). Wallet switch → reconnect.
+ *
+ * Why SW over offscreen: MV3 keeps the SW alive as long as an active
+ * WebSocket holds a connection open. The extension already owns one
+ * offscreen document (public/offscreen.html, theme detection) and Chrome
+ * caps us at one offscreen per extension. Merging theme + realtime is
+ * doable but invasive (migrate vanilla JS → TS, rewire CSS for theme
+ * detection). Phase 5 can migrate here if we see SW kills under memory
+ * pressure. For Phase 1.B the SW-direct path is sufficient.
+ *
+ * Environment:
+ * - PLASMO_PUBLIC_GRAPHQL_WS_URL — optional override; defaults to mainnet.
+ */
+
+import { persistQueryClient } from "@tanstack/react-query-persist-client"
+import {
+  API_WS_PROD,
+  configureWsClient
+} from "@0xsofia/graphql"
+import {
+  CACHE_MAX_AGE,
+  CACHE_VERSION,
+  persister,
+  queryClient
+} from "../lib/providers/queryClient"
+import { SubscriptionManager } from "../lib/realtime/SubscriptionManager"
+import { createServiceLogger } from "../lib/utils/logger"
+
+const logger = createServiceLogger("Realtime")
+const manager = new SubscriptionManager(queryClient)
+
+let persistStarted = false
+let initialized = false
+
+function ensurePersisted(): void {
+  if (persistStarted) return
+  persistStarted = true
+  // Mirror what PersistQueryClientProvider does in the popup, so SW-side
+  // setQueryData writes land in chrome.storage.local — the popup picks
+  // them up via onChanged and rehydrates its own QueryClient.
+  persistQueryClient({
+    queryClient,
+    persister,
+    maxAge: CACHE_MAX_AGE,
+    buster: CACHE_VERSION
+  })
+}
+
+function isValidWallet(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith("0x")
+}
+
+async function syncWalletFromStorage(): Promise<void> {
+  const result = await chrome.storage.session.get("walletAddress")
+  const wallet = result.walletAddress
+  if (isValidWallet(wallet)) {
+    manager.connect(wallet)
+    logger.info("connected", { wallet: wallet.slice(0, 10) })
+  } else {
+    manager.disconnect()
+  }
+}
+
+export async function initializeRealtime(): Promise<void> {
+  if (initialized) return
+  initialized = true
+
+  const wsUrl = process.env.PLASMO_PUBLIC_GRAPHQL_WS_URL ?? API_WS_PROD
+  configureWsClient({ wsUrl })
+  logger.info("configured", { wsUrl })
+
+  ensurePersisted()
+  await syncWalletFromStorage()
+
+  // React to popup writing/removing the wallet address. Fires even when
+  // the SW was asleep — chrome.storage.onChanged is a wake-up trigger.
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== "session") return
+    if (!("walletAddress" in changes)) return
+    const newValue = changes.walletAddress.newValue
+    if (isValidWallet(newValue)) {
+      manager.connect(newValue)
+      logger.info("wallet switched", { wallet: newValue.slice(0, 10) })
+    } else {
+      manager.disconnect()
+      logger.info("wallet removed, disconnected")
+    }
+  })
+}
+
+/** Exposed for manual cleanup — typically on full logout. */
+export function shutdownRealtime(): void {
+  manager.shutdown()
+  initialized = false
+}

--- a/extension/docs/plan-realtime-extension.md
+++ b/extension/docs/plan-realtime-extension.md
@@ -113,26 +113,36 @@ throwaway messaging code.
    - `derivations.ts`
    - `wsStatus.ts`
 
-3. In the extension app:
+3. In the extension app (shipped in Phase 1.B — SW-direct, not offscreen):
    - Add `PLASMO_PUBLIC_GRAPHQL_WS_URL` env var (default
      `wss://mainnet.intuition.sh/v1/graphql`).
-   - Create the offscreen document (`background/offscreen/realtime.html` +
-     `realtime.ts`). SW spawns it via `chrome.offscreen.createDocument({
-     reasons: ['WORKERS'], justification: 'WebSocket subscription for user
-     positions' })` on wallet-connect, closes on wallet-disconnect.
-   - Offscreen holds the `SubscriptionManager` instance + `setInterval(ping,
-     25000)` keepalive (WS `ConnectionAck`).
-   - Wallet flow: popup writes `sofia-active-wallet` to `chrome.storage.local`
-     → SW listens via `chrome.storage.onChanged` → ensures offscreen doc →
-     offscreen reads the wallet and calls `manager.connect(wallet)`.
-   - Wallet switch: popup rewrites `sofia-active-wallet` → offscreen receives
-     `onChanged` → `manager.disconnect() + manager.connect(newWallet)`.
-   - Security: every `chrome.runtime.onMessage` handler guards
-     `sender.id === chrome.runtime.id`.
+   - Create `extension/background/realtime.ts` that holds the
+     `SubscriptionManager` instance in the service worker directly. MV3
+     keeps the SW alive as long as an open WebSocket is active, so the
+     30s idle shutdown doesn't apply while a user is connected.
+   - Wallet flow: the popup already writes `walletAddress` to
+     `chrome.storage.session` (existing convention). SW listens via
+     `chrome.storage.onChanged` → `manager.connect(wallet)` on write,
+     `manager.disconnect()` on removal.
+   - Wallet switch: onChanged fires with a new value → manager reconnects.
 
-**Acceptance**: open the popup with a wallet connected, check chrome://inspect
-for the offscreen doc, see `[WS positions]` logs with N positions. Switch
-wallet in popup → new subscription kicks in within 1s.
+**Why SW-direct over offscreen document**: the extension already owns
+one offscreen doc (`public/offscreen.html`, theme detection) and Chrome
+caps us at one per extension. Merging theme + realtime is feasible but
+invasive (migrate vanilla JS → TS, rewire CSS for theme detection's
+Canvas trick). Phase 5 can migrate to a unified offscreen if SW kills
+are observed under memory pressure. For Phase 1.B, SW-direct is the
+path of least resistance and meets the acceptance criteria.
+
+**Security** (deferred to Phase 4 messaging): new `chrome.runtime.onMessage`
+handlers guard `sender.id === chrome.runtime.id`. Phase 1.B adds no new
+onMessage handlers (driven by `storage.onChanged`), so no guards needed
+here.
+
+**Acceptance**: open the popup with a wallet connected, inspect the SW in
+`chrome://extensions/ → Inspect views: service worker` — see
+`[WS positions] N positions for 0xabc123…` logs. Switch wallet in popup
+→ new subscription kicks in within 1s.
 
 ### Phase 2 — React Query persister + cross-context bus (1-2 d)
 

--- a/extension/lib/providers/queryClient.ts
+++ b/extension/lib/providers/queryClient.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared QueryClient + persister — instantiated at module load so both
+ * the popup (via queryProvider.tsx) and the offscreen document (via
+ * realtime.ts) consume the same singleton.
+ *
+ * Why the split from queryProvider.tsx: the offscreen runtime has no
+ * React, so we can't import a .tsx that pulls in ReactNode. This file
+ * is React-free — queryProvider.tsx imports from here.
+ *
+ * Cross-context cache flow (Phase 1 + Phase 2):
+ *   offscreen setQueryData → persister writes chrome.storage.local
+ *     → chrome.storage.onChanged fires in the popup
+ *     → popup rehydrates the impacted keys via queryClient.setQueryData
+ */
+
+import { QueryClient } from "@tanstack/react-query"
+import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister"
+import { CACHE_VERSION } from "~/lib/config/cacheVersion"
+
+export const CACHE_MAX_AGE = 24 * 60 * 60 * 1000 // 24h
+export const CACHE_KEY = "sofia-ext-rq-cache"
+export { CACHE_VERSION }
+
+// chrome.storage.local adapter — async, unlike sofia-explorer's sync
+// localStorage. Survives popup close and is readable from SW + offscreen.
+const chromeStorage = {
+  getItem: async (key: string): Promise<string | null> => {
+    const result = await chrome.storage.local.get(key)
+    return (result[key] as string | undefined) ?? null
+  },
+  setItem: async (key: string, value: string): Promise<void> => {
+    await chrome.storage.local.set({ [key]: value })
+  },
+  removeItem: async (key: string): Promise<void> => {
+    await chrome.storage.local.remove(key)
+  }
+}
+
+// BigInt-safe roundtrip. Sofia caches contain vault shares (bigint) which
+// JSON.stringify refuses to serialize — without this tag, the persister
+// would silently throw on every save and leave the cache in-memory only.
+const BIGINT_TAG = "__bigint__"
+
+const replacer = (_key: string, value: unknown): unknown => {
+  if (typeof value === "bigint") return `${BIGINT_TAG}${value.toString()}`
+  return value
+}
+
+const reviver = (_key: string, value: unknown): unknown => {
+  if (typeof value === "string" && value.startsWith(BIGINT_TAG)) {
+    try {
+      return BigInt(value.slice(BIGINT_TAG.length))
+    } catch {
+      return value
+    }
+  }
+  return value
+}
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Long staleTime so rehydrated entries don't all refetch at once on
+      // mount — that burst was causing 429 bursts on sofia-explorer.
+      staleTime: 10 * 60 * 1000,
+      // gcTime must be >= maxAge for the persister to keep entries alive.
+      gcTime: CACHE_MAX_AGE,
+      refetchOnWindowFocus: false,
+      retry: 1,
+      retryDelay: (attempt) => Math.min(2000 * 2 ** attempt, 15_000),
+      throwOnError: false
+    }
+  }
+})
+
+export const persister = createAsyncStoragePersister({
+  storage: chromeStorage,
+  key: CACHE_KEY,
+  serialize: (client) => JSON.stringify(client, replacer),
+  deserialize: (raw) => JSON.parse(raw, reviver)
+})

--- a/extension/lib/providers/queryProvider.tsx
+++ b/extension/lib/providers/queryProvider.tsx
@@ -1,74 +1,13 @@
-import { QueryClient } from "@tanstack/react-query"
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client"
-import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister"
 import type { ReactNode } from "react"
-import { CACHE_VERSION } from "~/lib/config/cacheVersion"
+import {
+  CACHE_MAX_AGE,
+  CACHE_VERSION,
+  persister,
+  queryClient
+} from "./queryClient"
 
-const CACHE_MAX_AGE = 24 * 60 * 60 * 1000 // 24h
-const CACHE_KEY = "sofia-ext-rq-cache"
-
-// chrome.storage.local adapter — async, unlike sofia-explorer's sync
-// localStorage. Survives popup close and is readable from SW + offscreen,
-// which is what Phase 1 (WS) will rely on as a cross-context cache bus.
-const chromeStorage = {
-  getItem: async (key: string): Promise<string | null> => {
-    const result = await chrome.storage.local.get(key)
-    return (result[key] as string | undefined) ?? null
-  },
-  setItem: async (key: string, value: string): Promise<void> => {
-    await chrome.storage.local.set({ [key]: value })
-  },
-  removeItem: async (key: string): Promise<void> => {
-    await chrome.storage.local.remove(key)
-  }
-}
-
-// BigInt-safe roundtrip. Sofia caches contain vault shares (bigint) which
-// JSON.stringify refuses to serialize — without this tag, the persister
-// would silently throw on every save and leave the cache in-memory only,
-// defeating the purpose.
-const BIGINT_TAG = "__bigint__"
-
-const replacer = (_key: string, value: unknown): unknown => {
-  if (typeof value === "bigint") return `${BIGINT_TAG}${value.toString()}`
-  return value
-}
-
-const reviver = (_key: string, value: unknown): unknown => {
-  if (typeof value === "string" && value.startsWith(BIGINT_TAG)) {
-    try {
-      return BigInt(value.slice(BIGINT_TAG.length))
-    } catch {
-      return value
-    }
-  }
-  return value
-}
-
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      // Long staleTime so rehydrated entries don't all refetch at once on
-      // mount — that burst was causing 429 bursts on sofia-explorer.
-      staleTime: 10 * 60 * 1000,
-      // gcTime must be >= maxAge for the persister to keep entries alive.
-      gcTime: CACHE_MAX_AGE,
-      refetchOnWindowFocus: false,
-      // retry:1 avoids amplifying rate-limit storms; retry:3 turns 20
-      // simultaneous mounts into 80 requests in a few seconds.
-      retry: 1,
-      retryDelay: (attempt) => Math.min(2000 * 2 ** attempt, 15_000),
-      throwOnError: false
-    }
-  }
-})
-
-const persister = createAsyncStoragePersister({
-  storage: chromeStorage,
-  key: CACHE_KEY,
-  serialize: (client) => JSON.stringify(client, replacer),
-  deserialize: (raw) => JSON.parse(raw, reviver)
-})
+export { queryClient }
 
 export function QueryProvider({ children }: { children: ReactNode }) {
   return (

--- a/extension/lib/realtime/SubscriptionManager.ts
+++ b/extension/lib/realtime/SubscriptionManager.ts
@@ -1,0 +1,282 @@
+/**
+ * SubscriptionManager — single source of truth for real-time data.
+ *
+ * Opens one WebSocket connection (via the graphql-ws client in
+ * @0xsofia/graphql) and subscribes to wallet-scoped queries. Each delta
+ * is pushed into the React Query cache via setQueryData(), so components
+ * consuming those keys re-render without fetching.
+ *
+ * Phase 1.B scope:
+ * - Lifecycle: connect(wallet), disconnect(), shutdown()
+ * - Status tracking via wsStatus (feeds Phase 5 offline badge)
+ * - Logs payloads to prove the WS works — cache writes go through
+ *   stub derivations (Phase 3 fills them in)
+ *
+ * Phase 5 will add:
+ * - HTTP fallback after 30s offline grace period (needs a
+ *   GetUserPositions HTTP query added to @0xsofia/graphql first)
+ */
+
+import { print, type DocumentNode } from "graphql"
+import type { QueryClient } from "@tanstack/react-query"
+import {
+  getWsClient,
+  disposeWsClient,
+  WatchUserPositionsDocument,
+  WatchUserTrackedPositionsDocument,
+  type WatchUserPositionsSubscription,
+  type WatchUserPositionsSubscriptionVariables,
+  type WatchUserTrackedPositionsSubscription,
+  type WatchUserTrackedPositionsSubscriptionVariables
+} from "@0xsofia/graphql"
+import {
+  derivePositionsByTopic,
+  derivePositionsByCategory,
+  derivePositionsByPlatform,
+  deriveVerifiedPlatforms,
+  deriveUserProfile,
+  deriveUserStats,
+  realtimeKeys
+} from "./derivations"
+import {
+  markConnecting,
+  markConnected,
+  markOffline,
+  markError
+} from "./wsStatus"
+
+/**
+ * Atom term_ids to subscribe to via WatchUserTrackedPositions (in addition
+ * to the top-500 positions sub). Stays empty in Phase 1.B — Phase 3 will
+ * add Sofia-specific termIds (predicate atoms, quest atoms, etc.) once
+ * the relevant atom config is defined. With an empty list, the tracked
+ * subscription is effectively a no-op (Hasura filters with _in: [] → no
+ * rows), saving bandwidth.
+ */
+const TRACKED_TERM_IDS: string[] = []
+
+const toQueryString = (doc: unknown): string => {
+  if (typeof doc === "string") return doc
+  return print(doc as DocumentNode)
+}
+
+type Unsubscribe = () => void
+
+export class SubscriptionManager {
+  private queryClient: QueryClient
+  private walletAddress: string | null = null
+  private subscriptions = new Map<string, Unsubscribe>()
+  private statusListenerUnsubs: Array<() => void> = []
+
+  constructor(queryClient: QueryClient) {
+    this.queryClient = queryClient
+  }
+
+  connect(walletAddress: string) {
+    const normalized = walletAddress.toLowerCase()
+    if (this.walletAddress === normalized) return
+    this.disconnect()
+    this.walletAddress = normalized
+    this.attachStatusListeners()
+    this.subscribePositions()
+    if (TRACKED_TERM_IDS.length > 0) {
+      this.subscribeTrackedPositions()
+    }
+  }
+
+  disconnect() {
+    for (const unsub of this.subscriptions.values()) {
+      try {
+        unsub()
+      } catch {
+        /* ignore */
+      }
+    }
+    this.subscriptions.clear()
+    this.detachStatusListeners()
+    this.walletAddress = null
+  }
+
+  /** Dispose the shared WS client. Use on full logout or offscreen unmount. */
+  shutdown() {
+    this.disconnect()
+    disposeWsClient()
+  }
+
+  // ── Status listeners ──────────────────────────────────────────────────────
+
+  private attachStatusListeners() {
+    const client = getWsClient()
+    markConnecting()
+
+    this.statusListenerUnsubs.push(
+      client.on("connecting", () => markConnecting()),
+      client.on("connected", () => markConnected()),
+      client.on("closed", (ev) => {
+        const reason =
+          typeof ev === "object" && ev && "reason" in ev
+            ? String((ev as { reason?: unknown }).reason ?? "")
+            : undefined
+        markOffline(reason)
+      }),
+      client.on("error", (err) => {
+        const reason =
+          err instanceof Error ? err.message : String(err ?? "unknown")
+        markError(reason)
+      })
+    )
+  }
+
+  private detachStatusListeners() {
+    for (const unsub of this.statusListenerUnsubs) {
+      try {
+        unsub()
+      } catch {
+        /* ignore */
+      }
+    }
+    this.statusListenerUnsubs = []
+  }
+
+  // ── Subscriptions ─────────────────────────────────────────────────────────
+
+  private subscribePositions() {
+    if (!this.walletAddress) return
+
+    const variables: WatchUserPositionsSubscriptionVariables = {
+      accountId: this.walletAddress
+    }
+
+    const unsub = getWsClient().subscribe<WatchUserPositionsSubscription>(
+      {
+        query: toQueryString(WatchUserPositionsDocument),
+        variables
+      },
+      {
+        next: ({ data }) => {
+          if (!data) return
+          this.onPositionsUpdate(data)
+        },
+        error: (err) => {
+          console.error("[WS positions] error", err)
+        },
+        complete: () => {
+          console.log("[WS positions] complete")
+        }
+      }
+    )
+
+    this.subscriptions.set("positions", unsub)
+  }
+
+  /**
+   * Narrower subscription filtered server-side by term_id. Used for
+   * positions that would otherwise be truncated by Hasura's 500-row cap
+   * on the main positions sub — ensures low-share positions on tracked
+   * atoms always arrive.
+   *
+   * Phase 1.B: TRACKED_TERM_IDS is empty so this is never called. Phase 3
+   * will wire it to Sofia's critical atom set.
+   */
+  private subscribeTrackedPositions() {
+    if (!this.walletAddress) return
+
+    const variables: WatchUserTrackedPositionsSubscriptionVariables = {
+      accountId: this.walletAddress,
+      termIds: TRACKED_TERM_IDS
+    }
+
+    const unsub =
+      getWsClient().subscribe<WatchUserTrackedPositionsSubscription>(
+        {
+          query: toQueryString(WatchUserTrackedPositionsDocument),
+          variables
+        },
+        {
+          next: ({ data }) => {
+            if (!data) return
+            this.onTrackedPositionsUpdate(data)
+          },
+          error: (err) => {
+            console.error("[WS tracked] error", err)
+          },
+          complete: () => {
+            console.log("[WS tracked] complete")
+          }
+        }
+      )
+
+    this.subscriptions.set("tracked-positions", unsub)
+  }
+
+  // ── Cache writers (Phase 1.B: log-only; Phase 3 activates derivations) ────
+
+  private onPositionsUpdate(data: WatchUserPositionsSubscription) {
+    const positions = data.positions ?? []
+    const wallet = this.walletAddress
+    if (!wallet) return
+
+    const qc = this.queryClient
+    try {
+      qc.setQueryData(realtimeKeys.positions(wallet), positions)
+      qc.setQueryData(
+        realtimeKeys.verifiedPlatforms(wallet),
+        deriveVerifiedPlatforms(positions)
+      )
+      qc.setQueryData(
+        realtimeKeys.userProfileDerived(wallet),
+        deriveUserProfile(positions)
+      )
+      qc.setQueryData(
+        realtimeKeys.userStats(wallet),
+        deriveUserStats(positions)
+      )
+    } catch (err) {
+      console.error("[WS positions] derivation/setQueryData failed", err)
+    }
+
+    console.log(
+      `[WS positions] ${positions.length} positions for ${wallet.slice(0, 8)}…`
+    )
+  }
+
+  private onTrackedPositionsUpdate(
+    data: WatchUserTrackedPositionsSubscription
+  ) {
+    const positions = data.positions ?? []
+    const wallet = this.walletAddress
+    if (!wallet) return
+
+    const qc = this.queryClient
+    try {
+      qc.setQueryData(
+        realtimeKeys.topicPositionsMap(wallet),
+        derivePositionsByTopic(
+          positions as unknown as Parameters<typeof derivePositionsByTopic>[0]
+        )
+      )
+      qc.setQueryData(
+        realtimeKeys.categoryPositionsMap(wallet),
+        derivePositionsByCategory(
+          positions as unknown as Parameters<
+            typeof derivePositionsByCategory
+          >[0]
+        )
+      )
+      qc.setQueryData(
+        realtimeKeys.platformPositionsMap(wallet),
+        derivePositionsByPlatform(
+          positions as unknown as Parameters<
+            typeof derivePositionsByPlatform
+          >[0]
+        )
+      )
+    } catch (err) {
+      console.error("[WS tracked] derivation/setQueryData failed", err)
+    }
+
+    console.log(
+      `[WS tracked] ${positions.length} tracked positions for ${wallet.slice(0, 8)}…`
+    )
+  }
+}

--- a/extension/lib/realtime/derivations.ts
+++ b/extension/lib/realtime/derivations.ts
@@ -1,0 +1,155 @@
+/**
+ * Derivations — pure functions that convert raw WS subscription payloads
+ * into the shapes consumed by hooks (useTopicPositions, useUserProfile...).
+ *
+ * Phase 1.B stub: only the query key builders (realtimeKeys) and the
+ * Position type are live. The actual derivation functions return empty
+ * placeholders so SubscriptionManager can call them without crashing.
+ *
+ * Phase 3 will fill in the real logic once we've decided which Sofia-
+ * specific atom IDs to map (predicates, quest atoms, topics if any).
+ * The Explorer version hardcodes TOPIC_ATOM_IDS/CATEGORY_ATOM_IDS/
+ * PLATFORM_ATOM_IDS — Sofia's equivalent still needs to be defined.
+ */
+
+import type { QueryClient } from "@tanstack/react-query"
+import type { WatchUserPositionsSubscription } from "@0xsofia/graphql"
+
+export type Position = NonNullable<
+  WatchUserPositionsSubscription["positions"]
+>[number]
+
+// ── Query key builders (single source of truth) ─────────────────────────────
+
+export const realtimeKeys = {
+  positions: (wallet: string) => ["positions", wallet] as const,
+  topicPositionsMap: (wallet: string) =>
+    ["topic-positions-map", wallet] as const,
+  categoryPositionsMap: (wallet: string) =>
+    ["category-positions-map", wallet] as const,
+  platformPositionsMap: (wallet: string) =>
+    ["platform-positions-map", wallet] as const,
+  verifiedPlatforms: (wallet: string) =>
+    ["verified-platforms", wallet] as const,
+  userProfileDerived: (wallet: string) =>
+    ["user-profile-derived", wallet] as const,
+  userStats: (wallet: string) => ["user-stats", wallet] as const
+}
+
+// ── BigInt helpers (stable cache shape) ─────────────────────────────────────
+//
+// Shares stored as decimal strings in the cache — JSON.stringify throws on
+// BigInt, which would break the React Query persister (Phase 2).
+
+function toBigInt(v: unknown): bigint {
+  if (typeof v === "bigint") return v
+  if (typeof v === "number") return BigInt(Math.trunc(v))
+  if (typeof v === "string" && v.length > 0) {
+    try {
+      return BigInt(v)
+    } catch {
+      return 0n
+    }
+  }
+  return 0n
+}
+
+export function sharesToBigInt(v: unknown): bigint {
+  return toBigInt(v)
+}
+
+// ── Derivation stubs (Phase 3 implements these) ─────────────────────────────
+
+export function derivePositionsByTopic(
+  _positions: Position[]
+): Record<string, string> {
+  return {}
+}
+
+export function derivePositionsByCategory(
+  _positions: Position[]
+): Record<string, string> {
+  return {}
+}
+
+export function derivePositionsByPlatform(
+  _positions: Position[]
+): Record<string, string> {
+  return {}
+}
+
+export function deriveVerifiedPlatforms(_positions: Position[]): string[] {
+  return []
+}
+
+export interface UserPositionView {
+  termId: string
+  shares: string
+  currentSharePrice: string
+  isTriple: boolean
+  predicateLabel?: string
+  objectLabel?: string
+  objectUrl?: string
+  tripleSubjectId?: string
+  tripleObjectId?: string
+  atomLabel?: string
+  atomUrl?: string
+}
+
+export interface UserStats {
+  totalPositions: number
+  totalAtomPositions: number
+  totalTriplePositions: number
+  totalStaked: number
+  verifiedPlatforms: string[]
+}
+
+export interface UserProfileDerived {
+  positions: UserPositionView[]
+  totalPositions: number
+  totalAtomPositions: number
+  totalStaked: number
+  verifiedPlatforms: string[]
+}
+
+export function deriveUserProfile(
+  _positions: Position[]
+): UserProfileDerived {
+  return {
+    positions: [],
+    totalPositions: 0,
+    totalAtomPositions: 0,
+    totalStaked: 0,
+    verifiedPlatforms: []
+  }
+}
+
+export function deriveUserStats(_positions: Position[]): UserStats {
+  return {
+    totalPositions: 0,
+    totalAtomPositions: 0,
+    totalTriplePositions: 0,
+    totalStaked: 0,
+    verifiedPlatforms: []
+  }
+}
+
+// ── Optimistic updates (Phase 4 wires these to deposit/redeem flows) ─────────
+
+export function applyOptimisticPosition(
+  _qc: QueryClient,
+  _walletAddress: string,
+  _termId: string,
+  _delta: bigint
+): void {
+  // Phase 4 implementation. Stub keeps the SubscriptionManager and future
+  // deposit hooks compiling without needing this yet.
+}
+
+export function clearOptimisticPosition(
+  _qc: QueryClient,
+  _walletAddress: string,
+  _termId: string
+): void {
+  // Phase 4 implementation.
+}

--- a/extension/lib/realtime/wsStatus.ts
+++ b/extension/lib/realtime/wsStatus.ts
@@ -1,0 +1,94 @@
+/**
+ * wsStatus — tiny external store exposing the health of the realtime
+ * WebSocket connection. Consumed by the offline badge (Phase 5) and by
+ * the SubscriptionManager's HTTP fallback (Phase 5).
+ *
+ * Uses the useSyncExternalStore pattern — no Zustand dep needed.
+ *
+ * Phase 1.B note: the store lives in the offscreen document. The popup
+ * reads the current status via chrome.storage.local (writer: offscreen;
+ * reader: popup via onChanged). This file is the offscreen-side API.
+ */
+
+export type WsConnectionStatus =
+  | "idle" // nothing mounted yet
+  | "connecting" // first connection attempt
+  | "connected" // happy path
+  | "offline" // closed unexpectedly, graphql-ws is retrying
+  | "error" // terminal error surfaced by graphql-ws
+
+export interface WsStatusSnapshot {
+  status: WsConnectionStatus
+  /** Unix ms of the last 'connected' event (or 0) */
+  lastConnectedAt: number
+  /** Unix ms of the last 'closed'/'error' event (or 0) */
+  lastDisconnectedAt: number
+  /** Cumulative reconnect attempts within the current session */
+  reconnectAttempts: number
+  /** Last error message surfaced by graphql-ws */
+  lastError: string | null
+}
+
+const INITIAL: WsStatusSnapshot = {
+  status: "idle",
+  lastConnectedAt: 0,
+  lastDisconnectedAt: 0,
+  reconnectAttempts: 0,
+  lastError: null
+}
+
+let snapshot: WsStatusSnapshot = INITIAL
+const listeners = new Set<() => void>()
+
+function emit() {
+  for (const l of listeners) l()
+}
+
+export function getWsStatus(): WsStatusSnapshot {
+  return snapshot
+}
+
+export function subscribeWsStatus(cb: () => void): () => void {
+  listeners.add(cb)
+  return () => {
+    listeners.delete(cb)
+  }
+}
+
+// ── Writers called by SubscriptionManager ───────────────────────────────────
+
+export function markConnecting() {
+  snapshot = { ...snapshot, status: "connecting" }
+  emit()
+}
+
+export function markConnected() {
+  snapshot = {
+    ...snapshot,
+    status: "connected",
+    lastConnectedAt: Date.now(),
+    lastError: null
+  }
+  emit()
+}
+
+export function markOffline(reason?: string) {
+  snapshot = {
+    ...snapshot,
+    status: "offline",
+    lastDisconnectedAt: Date.now(),
+    reconnectAttempts: snapshot.reconnectAttempts + 1,
+    lastError: reason ?? snapshot.lastError
+  }
+  emit()
+}
+
+export function markError(reason: string) {
+  snapshot = {
+    ...snapshot,
+    status: "error",
+    lastDisconnectedAt: Date.now(),
+    lastError: reason
+  }
+  emit()
+}


### PR DESCRIPTION
## Summary

Phase 1.B of the realtime refactor plan. Wires Phase 1.A's WS infrastructure into the service worker so user positions push live into the React Query cache.

**Validated locally**: \`[WS positions] 100 positions for 0xc634…\` appears in the SW console within 2s of wallet connect.

## Key decision: SW-direct over offscreen document

Extension already owns one offscreen doc (theme detection, vanilla JS in \`public/\`) and Chrome caps us at one per extension. Merging theme + realtime is invasive. MV3 keeps the SW alive as long as an active WebSocket holds a connection open, so SW-direct is sufficient. Phase 5 can migrate to a unified offscreen if SW kills become a problem under memory pressure.

## Changes

- \`lib/realtime/wsStatus.ts\` — external store for WS health (feeds Phase 5 offline badge)
- \`lib/realtime/derivations.ts\` — query key builders live, derivation functions stubbed (Phase 3)
- \`lib/realtime/SubscriptionManager.ts\` — lifecycle + status tracking + log-only cache writes
- \`lib/providers/queryClient.ts\` — extracted from queryProvider.tsx so SW can import without React
- \`background/realtime.ts\` — instantiates manager, drives it from \`storage.session.walletAddress\` via \`onChanged\`
- \`background/index.ts\` — calls \`initializeRealtime()\` in existing init flow
- \`.env.*\` — documents \`PLASMO_PUBLIC_GRAPHQL_WS_URL\` per environment
- \`docs/plan-realtime-extension.md\` — updated to reflect SW-direct decision

## Test plan

- [x] SW devtools console shows \`[WS positions] N positions\` on wallet connect
- [x] Wallet switch reconnects WS within 1s
- [x] Theme detection still works (offscreen untouched)
- [x] No SW kill observed over a 10min session

## Next

Phase 3: swap stub derivations for real ones + migrate hook consumers to read from WS-backed cache keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)