### PR TITLE
feat(realtime): Phase 3.A — Sofia derivations + TRACKED_TERM_IDS

### DIFF
--- a/extension/docs/plan-realtime-extension.md
+++ b/extension/docs/plan-realtime-extension.md
@@ -175,24 +175,64 @@ cross-context propagation bus.
 from cache, no loading spinner. Bump `CACHE_VERSION` to `"v2"` and reload →
 cache wiped, fresh fetch.
 
-### Phase 3 — Derivations + cache writes (1 d)
+### Phase 3 — Derivations + hook migrations
 
-Port `src/lib/realtime/derivations.ts` from Explorer. Wire
-`onPositionsUpdate` + `onTrackedPositionsUpdate` in the offscreen to write:
+Split into two sub-PRs to keep reviewable chunks:
 
-- `['positions', wallet]`
-- `['verified-platforms', wallet]`
-- `['user-profile-derived', wallet]`
-- `['user-stats', wallet]`
-- `['topic-positions-map', wallet]` (from tracked subscription)
-- `['category-positions-map', wallet]`
-- `['platform-positions-map', wallet]`
+#### Phase 3.A — Sofia-specific derivations (shipped)
+
+Replaces the Phase 1.B stubs with real derivation logic adapted to
+Sofia's atom set (no "topics/categories/platforms" à la Explorer — Sofia
+models things differently).
+
+`onPositionsUpdate` now writes 8 cache keys per WS push:
+
+- `['positions', wallet]` — raw payload
+- `['user-profile-derived', wallet]` — full profile view
+- `['user-stats', wallet]` — aggregate counts / staked total
+- `['trust-circle', wallet]` — `{accountTermId, accountLabel, shares, tripleTermId}[]` from predicate TRUSTS
+- `['following', wallet]` — same shape from predicate FOLLOW (curve_id=1)
+- `['daily-streak', wallet]` — `{certifiedToday, votedToday}` booleans from DAILY_CERTIFICATION/VOTE atoms
+- `['verified-oauth-platforms', wallet]` — set of platforms from MEMBER_OF/OWNER_OF/TOP_ARTIST/TOP_TRACK/AM predicates
+- `['intention-groups', wallet]` — VISITS_FOR_* positions grouped by URL/domain
+- `['global-stake-position', wallet]` — position on Beta season pool atom
+- `['verified-platforms', wallet]` — legacy alias for OAuth platforms
+
+`TRACKED_TERM_IDS` now contains:
+- `DAILY_CERTIFICATION_ATOM_ID`
+- `DAILY_VOTE_ATOM_ID`
+- `GLOBAL_STAKE.TERM_ID`
+
+This guarantees these positions arrive regardless of the user's total
+position count (1-TRUST daily stakes would otherwise drop below the
+top-500 cap for power users).
 
 All keys scoped by `wallet` for multi-wallet correctness.
 
-Port hook migrations from Explorer commits tagged `Phase 3`: `useTopicPositions`,
-`useUserProfile`, etc. Grep matching extension hooks and apply the same
-`staleTime: 10min, gcTime: 24h, refetchOnWindowFocus: false`.
+**Acceptance**: SW console shows `[WS tracked] N positions` on connect
+(N ∈ [0..3] depending on user's quest activity). Inspect cache in popup
+devtools: `queryClient.getQueryData(['trust-circle', wallet])` returns
+the expected trust list.
+
+#### Phase 3.B — Hook migrations (not started)
+
+Migrate 5 candidate hooks to read from the WS-backed cache keys with
+`staleTime: Infinity, enabled: !!wallet`. Drop their HTTP fetchers.
+
+Candidates from the Phase 3 audit:
+- `useTrustCircle` → `['trust-circle', wallet]`
+- `useFollowing` → `['following', wallet]`
+- `useFollowers` → requires dynamic My Account atom tracking (deferred)
+- `useUserSignals` → partial migration (top-100 positions only)
+- `useAccountStats` → `['user-stats', wallet]`
+
+Plus `useQuestSystem` gets a light trigger-based refetch: WS sees a
+position on DAILY_* → invalidate the HTTP streak count query.
+
+Blockers that stay HTTP:
+- `useUserDiscoveryScore` (cross-user, different wallet)
+- `useUserCertifications` singleton (>500 possible, refactor invasive)
+- `useTrendingCertifications` (cross-user firehose)
 
 ### Phase 4 — Optimistic updates (1 d)
 

--- a/extension/lib/realtime/SubscriptionManager.ts
+++ b/extension/lib/realtime/SubscriptionManager.ts
@@ -46,6 +46,11 @@ import {
   realtimeKeys
 } from "./derivations"
 import {
+  DAILY_CERTIFICATION_ATOM_ID,
+  DAILY_VOTE_ATOM_ID,
+  GLOBAL_STAKE
+} from "~/lib/config/chainConfig"
+import {
   markConnecting,
   markConnected,
   markOffline,
@@ -54,13 +59,25 @@ import {
 
 /**
  * Atom term_ids to subscribe to via WatchUserTrackedPositions (in addition
- * to the top-500 positions sub). Stays empty in Phase 1.B — Phase 3 will
- * add Sofia-specific termIds (predicate atoms, quest atoms, etc.) once
- * the relevant atom config is defined. With an empty list, the tracked
- * subscription is effectively a no-op (Hasura filters with _in: [] → no
- * rows), saving bandwidth.
+ * to the top-500 positions sub). These are atoms where the user's position
+ * matters for live UI but might otherwise be missed if the user has >500
+ * positions and this one sits below the cap (1 TRUST stake on a daily atom
+ * is trivially buried under certification triples with larger shares).
+ *
+ * Contents:
+ * - DAILY_CERTIFICATION_ATOM_ID → powers deriveDailyStreak.certifiedToday
+ * - DAILY_VOTE_ATOM_ID → powers deriveDailyStreak.votedToday
+ * - GLOBAL_STAKE.TERM_ID → powers deriveGlobalStakePosition (Beta pool)
+ *
+ * Future candidates (require dynamic resolution, not hardcoded):
+ * - The user's Account atom term_id → drives followers count (requires an
+ *   initial HTTP fetch via findAccountAtom(walletAddress) at connect time)
  */
-const TRACKED_TERM_IDS: string[] = []
+const TRACKED_TERM_IDS: string[] = [
+  DAILY_CERTIFICATION_ATOM_ID,
+  DAILY_VOTE_ATOM_ID,
+  GLOBAL_STAKE.TERM_ID
+]
 
 const toQueryString = (doc: unknown): string => {
   if (typeof doc === "string") return doc

--- a/extension/lib/realtime/SubscriptionManager.ts
+++ b/extension/lib/realtime/SubscriptionManager.ts
@@ -36,6 +36,13 @@ import {
   deriveVerifiedPlatforms,
   deriveUserProfile,
   deriveUserStats,
+  // Sofia-specific (Phase 3.A)
+  deriveTrustCircle,
+  deriveFollowing,
+  deriveDailyStreak,
+  deriveVerifiedOAuthPlatforms,
+  deriveIntentionGroups,
+  deriveGlobalStakePosition,
   realtimeKeys
 } from "./derivations"
 import {
@@ -209,7 +216,7 @@ export class SubscriptionManager {
     this.subscriptions.set("tracked-positions", unsub)
   }
 
-  // ── Cache writers (Phase 1.B: log-only; Phase 3 activates derivations) ────
+  // ── Cache writers (Phase 3.A: real derivations wired) ────────────────────
 
   private onPositionsUpdate(data: WatchUserPositionsSubscription) {
     const positions = data.positions ?? []
@@ -218,11 +225,38 @@ export class SubscriptionManager {
 
     const qc = this.queryClient
     try {
+      // Raw payload — consumers that want the full list read this key.
       qc.setQueryData(realtimeKeys.positions(wallet), positions)
+
+      // Sofia-specific derivations (Phase 3.A) — each one filters positions
+      // by predicate / atom term_id and produces the shape the matching
+      // hook consumes. Phase 3.B migrates those hooks to read from here.
       qc.setQueryData(
-        realtimeKeys.verifiedPlatforms(wallet),
-        deriveVerifiedPlatforms(positions)
+        realtimeKeys.trustCircle(wallet),
+        deriveTrustCircle(positions)
       )
+      qc.setQueryData(
+        realtimeKeys.following(wallet),
+        deriveFollowing(positions)
+      )
+      qc.setQueryData(
+        realtimeKeys.dailyStreak(wallet),
+        deriveDailyStreak(positions)
+      )
+      qc.setQueryData(
+        realtimeKeys.verifiedOAuthPlatforms(wallet),
+        deriveVerifiedOAuthPlatforms(positions)
+      )
+      qc.setQueryData(
+        realtimeKeys.intentionGroups(wallet),
+        deriveIntentionGroups(positions)
+      )
+      qc.setQueryData(
+        realtimeKeys.globalStakePosition(wallet),
+        deriveGlobalStakePosition(positions)
+      )
+
+      // Aggregate views — consumed by profile UI.
       qc.setQueryData(
         realtimeKeys.userProfileDerived(wallet),
         deriveUserProfile(positions)
@@ -230,6 +264,12 @@ export class SubscriptionManager {
       qc.setQueryData(
         realtimeKeys.userStats(wallet),
         deriveUserStats(positions)
+      )
+
+      // Legacy alias — Sofia's "verified platforms" === OAuth platforms.
+      qc.setQueryData(
+        realtimeKeys.verifiedPlatforms(wallet),
+        deriveVerifiedPlatforms(positions)
       )
     } catch (err) {
       console.error("[WS positions] derivation/setQueryData failed", err)

--- a/extension/lib/realtime/derivations.ts
+++ b/extension/lib/realtime/derivations.ts
@@ -20,9 +20,33 @@ export type Position = NonNullable<
 >[number]
 
 // ── Query key builders (single source of truth) ─────────────────────────────
+//
+// Canonical keys written by SubscriptionManager.onPositionsUpdate (top-500
+// user positions) and onTrackedPositionsUpdate (targeted atom subscriptions).
+// Hook consumers (Phase 3.B) read from these keys with staleTime:Infinity
+// instead of firing HTTP queries.
 
 export const realtimeKeys = {
+  // Core
   positions: (wallet: string) => ["positions", wallet] as const,
+  userProfileDerived: (wallet: string) =>
+    ["user-profile-derived", wallet] as const,
+  userStats: (wallet: string) => ["user-stats", wallet] as const,
+
+  // Sofia-specific derivations (Phase 3.A)
+  trustCircle: (wallet: string) => ["trust-circle", wallet] as const,
+  following: (wallet: string) => ["following", wallet] as const,
+  followers: (wallet: string) => ["followers", wallet] as const,
+  dailyStreak: (wallet: string) => ["daily-streak", wallet] as const,
+  verifiedOAuthPlatforms: (wallet: string) =>
+    ["verified-oauth-platforms", wallet] as const,
+  intentionGroups: (wallet: string) => ["intention-groups", wallet] as const,
+  globalStakePosition: (wallet: string) =>
+    ["global-stake-position", wallet] as const,
+
+  // Legacy Explorer keys — kept for SubscriptionManager compat. Sofia doesn't
+  // map topics/categories/platforms the same way; may be removed in cleanup
+  // once we're sure no consumer references them.
   topicPositionsMap: (wallet: string) =>
     ["topic-positions-map", wallet] as const,
   categoryPositionsMap: (wallet: string) =>
@@ -30,10 +54,7 @@ export const realtimeKeys = {
   platformPositionsMap: (wallet: string) =>
     ["platform-positions-map", wallet] as const,
   verifiedPlatforms: (wallet: string) =>
-    ["verified-platforms", wallet] as const,
-  userProfileDerived: (wallet: string) =>
-    ["user-profile-derived", wallet] as const,
-  userStats: (wallet: string) => ["user-stats", wallet] as const
+    ["verified-platforms", wallet] as const
 }
 
 // ── BigInt helpers (stable cache shape) ─────────────────────────────────────

--- a/extension/lib/realtime/derivations.ts
+++ b/extension/lib/realtime/derivations.ts
@@ -1,19 +1,24 @@
 /**
  * Derivations — pure functions that convert raw WS subscription payloads
- * into the shapes consumed by hooks (useTopicPositions, useUserProfile...).
+ * into the shapes consumed by hooks (useTrustCircle, useFollowing, etc.).
  *
- * Phase 1.B stub: only the query key builders (realtimeKeys) and the
- * Position type are live. The actual derivation functions return empty
- * placeholders so SubscriptionManager can call them without crashing.
+ * SubscriptionManager.onPositionsUpdate pipes WatchUserPositions payloads
+ * through each derivation and writes the result under a canonical query
+ * key. Hook consumers (Phase 3.B) read from those keys with
+ * staleTime:Infinity instead of firing HTTP queries.
  *
- * Phase 3 will fill in the real logic once we've decided which Sofia-
- * specific atom IDs to map (predicates, quest atoms, topics if any).
- * The Explorer version hardcodes TOPIC_ATOM_IDS/CATEGORY_ATOM_IDS/
- * PLATFORM_ATOM_IDS — Sofia's equivalent still needs to be defined.
+ * All derivations are pure — given the same positions array they always
+ * return the same output. Makes them trivially testable and cacheable.
  */
 
 import type { QueryClient } from "@tanstack/react-query"
 import type { WatchUserPositionsSubscription } from "@0xsofia/graphql"
+import {
+  DAILY_CERTIFICATION_ATOM_ID,
+  DAILY_VOTE_ATOM_ID,
+  GLOBAL_STAKE,
+  PREDICATE_IDS
+} from "~/lib/config/chainConfig"
 
 export type Position = NonNullable<
   WatchUserPositionsSubscription["positions"]
@@ -79,29 +84,235 @@ export function sharesToBigInt(v: unknown): bigint {
   return toBigInt(v)
 }
 
-// ── Derivation stubs (Phase 3 implements these) ─────────────────────────────
-
-export function derivePositionsByTopic(
-  _positions: Position[]
-): Record<string, string> {
-  return {}
+function addShares(a: string | undefined, b: unknown): string {
+  return (toBigInt(a) + toBigInt(b)).toString()
 }
 
-export function derivePositionsByCategory(
-  _positions: Position[]
-): Record<string, string> {
-  return {}
+// ── Predicate filter helpers ────────────────────────────────────────────────
+
+function getTriplePredicateId(p: Position): string | undefined {
+  return p.vault?.term?.triple?.predicate?.term_id ?? undefined
 }
 
-export function derivePositionsByPlatform(
-  _positions: Position[]
-): Record<string, string> {
-  return {}
+function getTriplePredicateLabel(p: Position): string | undefined {
+  return p.vault?.term?.triple?.predicate?.label ?? undefined
 }
 
-export function deriveVerifiedPlatforms(_positions: Position[]): string[] {
-  return []
+function hasPredicate(p: Position, predicateTermId: string): boolean {
+  return getTriplePredicateId(p) === predicateTermId
 }
+
+const OAUTH_PREDICATE_IDS = new Set<string>([
+  PREDICATE_IDS.MEMBER_OF,
+  PREDICATE_IDS.OWNER_OF,
+  PREDICATE_IDS.TOP_ARTIST,
+  PREDICATE_IDS.TOP_TRACK,
+  PREDICATE_IDS.AM
+])
+
+const INTENTION_PREDICATE_IDS = new Set<string>([
+  PREDICATE_IDS.VISITS_FOR_WORK,
+  PREDICATE_IDS.VISITS_FOR_LEARNING,
+  PREDICATE_IDS.VISITS_FOR_FUN,
+  PREDICATE_IDS.VISITS_FOR_INSPIRATION,
+  PREDICATE_IDS.VISITS_FOR_BUYING,
+  PREDICATE_IDS.VISITS_FOR_MUSIC
+])
+
+function extractDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "")
+  } catch {
+    return url
+  }
+}
+
+// ── Trust circle ────────────────────────────────────────────────────────────
+
+export interface TrustCircleEntry {
+  tripleTermId: string
+  accountTermId: string
+  accountLabel: string
+  shares: string
+}
+
+/**
+ * Accounts the user trusts (has shares > 0 on a `trusts` triple). Multiple
+ * positions per triple (one per curve) are aggregated into a single entry.
+ */
+export function deriveTrustCircle(positions: Position[]): TrustCircleEntry[] {
+  const byTriple = new Map<string, TrustCircleEntry>()
+  for (const p of positions) {
+    if (!hasPredicate(p, PREDICATE_IDS.TRUSTS)) continue
+    const triple = p.vault?.term?.triple
+    if (!triple?.term_id || !triple.object?.term_id) continue
+    const existing = byTriple.get(triple.term_id)
+    if (existing) {
+      existing.shares = addShares(existing.shares, p.shares)
+    } else {
+      byTriple.set(triple.term_id, {
+        tripleTermId: triple.term_id,
+        accountTermId: triple.object.term_id,
+        accountLabel: triple.object.label ?? "",
+        shares: String(p.shares ?? "0")
+      })
+    }
+  }
+  return Array.from(byTriple.values())
+}
+
+// ── Following ───────────────────────────────────────────────────────────────
+
+export interface FollowingEntry {
+  tripleTermId: string
+  accountTermId: string
+  accountLabel: string
+  shares: string
+}
+
+/**
+ * Accounts the user follows. Follow positions are scoped to curve_id=1
+ * (linear curve) to match the convention used elsewhere in the app.
+ */
+export function deriveFollowing(positions: Position[]): FollowingEntry[] {
+  const byTriple = new Map<string, FollowingEntry>()
+  for (const p of positions) {
+    if (!hasPredicate(p, PREDICATE_IDS.FOLLOW)) continue
+    if (String(p.curve_id) !== "1") continue
+    const triple = p.vault?.term?.triple
+    if (!triple?.term_id || !triple.object?.term_id) continue
+    const existing = byTriple.get(triple.term_id)
+    if (existing) {
+      existing.shares = addShares(existing.shares, p.shares)
+    } else {
+      byTriple.set(triple.term_id, {
+        tripleTermId: triple.term_id,
+        accountTermId: triple.object.term_id,
+        accountLabel: triple.object.label ?? "",
+        shares: String(p.shares ?? "0")
+      })
+    }
+  }
+  return Array.from(byTriple.values())
+}
+
+// ── Daily streak status ─────────────────────────────────────────────────────
+
+export interface DailyStreakStatus {
+  /** True if the user currently has shares > 0 on the daily-certification atom. */
+  certifiedToday: boolean
+  /** True if the user currently has shares > 0 on the daily-vote atom. */
+  votedToday: boolean
+  certificationShares: string
+  voteShares: string
+}
+
+/**
+ * Phase 3.A scope: live quest completion status (boolean "did I do it today?").
+ * The full streak count (consecutive days) stays HTTP for now — it's computed
+ * from deposits history, which isn't part of the positions subscription.
+ *
+ * Requires DAILY_CERTIFICATION_ATOM_ID and DAILY_VOTE_ATOM_ID to be in
+ * TRACKED_TERM_IDS so low-share positions (1 TRUST minimum) aren't dropped
+ * by Hasura's top-500 cap.
+ */
+export function deriveDailyStreak(positions: Position[]): DailyStreakStatus {
+  const cert = positions.find((p) => p.term_id === DAILY_CERTIFICATION_ATOM_ID)
+  const vote = positions.find((p) => p.term_id === DAILY_VOTE_ATOM_ID)
+  return {
+    certifiedToday: !!cert && sharesToBigInt(cert.shares) > 0n,
+    votedToday: !!vote && sharesToBigInt(vote.shares) > 0n,
+    certificationShares: String(cert?.shares ?? "0"),
+    voteShares: String(vote?.shares ?? "0")
+  }
+}
+
+// ── Verified OAuth platforms ────────────────────────────────────────────────
+
+/**
+ * OAuth platforms the user has verified, derived from triples whose predicate
+ * is one of MEMBER_OF / OWNER_OF / TOP_ARTIST / TOP_TRACK / AM.
+ * Returns lowercased predicate labels ("member_of", "top_artist", ...).
+ */
+export function deriveVerifiedOAuthPlatforms(positions: Position[]): string[] {
+  const set = new Set<string>()
+  for (const p of positions) {
+    const predicateId = getTriplePredicateId(p)
+    if (!predicateId || !OAUTH_PREDICATE_IDS.has(predicateId)) continue
+    const label = getTriplePredicateLabel(p)
+    if (label) set.add(label.toLowerCase())
+  }
+  return [...set]
+}
+
+// ── Intention groups (by URL) ───────────────────────────────────────────────
+
+export interface IntentionGroupEntry {
+  url: string
+  domain: string
+  intentions: string[]
+  totalShares: string
+}
+
+/**
+ * Groups user's intention certifications by the target URL. Each entry
+ * lists the intention predicates that apply ("visits for work", etc.)
+ * plus the total shares across all those positions. What
+ * useOnChainIntentionGroups consumes to render the Echoes list.
+ */
+export function deriveIntentionGroups(
+  positions: Position[]
+): IntentionGroupEntry[] {
+  const byUrl = new Map<string, IntentionGroupEntry>()
+  for (const p of positions) {
+    const predicateId = getTriplePredicateId(p)
+    if (!predicateId || !INTENTION_PREDICATE_IDS.has(predicateId)) continue
+    const object = p.vault?.term?.triple?.object
+    const url = object?.value?.thing?.url ?? object?.label
+    if (!url) continue
+    const domain = extractDomain(url)
+    const predicateLabel = getTriplePredicateLabel(p) ?? "unknown"
+    const existing = byUrl.get(url)
+    if (existing) {
+      if (!existing.intentions.includes(predicateLabel)) {
+        existing.intentions.push(predicateLabel)
+      }
+      existing.totalShares = addShares(existing.totalShares, p.shares)
+    } else {
+      byUrl.set(url, {
+        url,
+        domain,
+        intentions: [predicateLabel],
+        totalShares: String(p.shares ?? "0")
+      })
+    }
+  }
+  return Array.from(byUrl.values())
+}
+
+// ── Global stake position ───────────────────────────────────────────────────
+
+export interface GlobalStakePositionView {
+  shares: string
+  hasPosition: boolean
+}
+
+/**
+ * User's position on the Beta season global stake atom. The GLOBAL_STAKE.TERM_ID
+ * must be in TRACKED_TERM_IDS so we receive updates regardless of whether
+ * this position is in the user's top-500 by shares.
+ */
+export function deriveGlobalStakePosition(
+  positions: Position[]
+): GlobalStakePositionView {
+  const p = positions.find((pos) => pos.term_id === GLOBAL_STAKE.TERM_ID)
+  return {
+    shares: String(p?.shares ?? "0"),
+    hasPosition: !!p && sharesToBigInt(p.shares) > 0n
+  }
+}
+
+// ── User profile / stats (real implementations) ─────────────────────────────
 
 export interface UserPositionView {
   termId: string
@@ -133,26 +344,88 @@ export interface UserProfileDerived {
   verifiedPlatforms: string[]
 }
 
-export function deriveUserProfile(
-  _positions: Position[]
-): UserProfileDerived {
+export function deriveUserStats(positions: Position[]): UserStats {
+  const tripleCount = positions.filter((p) => p.vault?.term?.triple).length
+  const atomCount = positions.length - tripleCount
+  const totalStaked =
+    Math.round(
+      positions.reduce((sum, p) => {
+        const shares = parseFloat(String(p.shares ?? "0")) || 0
+        const price =
+          parseFloat(String(p.vault?.current_share_price ?? "0")) || 0
+        return sum + (shares * price) / 1e18
+      }, 0) * 100
+    ) / 100
   return {
-    positions: [],
-    totalPositions: 0,
-    totalAtomPositions: 0,
-    totalStaked: 0,
-    verifiedPlatforms: []
+    totalPositions: positions.length,
+    totalAtomPositions: atomCount,
+    totalTriplePositions: tripleCount,
+    totalStaked,
+    verifiedPlatforms: deriveVerifiedOAuthPlatforms(positions)
   }
 }
 
-export function deriveUserStats(_positions: Position[]): UserStats {
+export function deriveUserProfile(
+  positions: Position[]
+): UserProfileDerived {
+  const views: UserPositionView[] = positions.map((p) => {
+    const atom = p.vault?.term?.atom
+    const triple = p.vault?.term?.triple
+    return {
+      termId: atom?.term_id ?? triple?.term_id ?? p.term_id,
+      shares: String(p.shares ?? "0"),
+      currentSharePrice: String(p.vault?.current_share_price ?? "0"),
+      isTriple: !!triple,
+      predicateLabel: triple?.predicate?.label ?? undefined,
+      objectLabel: triple?.object?.label ?? atom?.label ?? undefined,
+      objectUrl:
+        triple?.object?.value?.thing?.url ??
+        atom?.value?.thing?.url ??
+        undefined,
+      tripleSubjectId: triple?.subject?.term_id,
+      tripleObjectId: triple?.object?.term_id,
+      atomLabel: atom?.label ?? undefined,
+      atomUrl: atom?.value?.thing?.url ?? undefined
+    }
+  })
+
+  const stats = deriveUserStats(positions)
   return {
-    totalPositions: 0,
-    totalAtomPositions: 0,
-    totalTriplePositions: 0,
-    totalStaked: 0,
-    verifiedPlatforms: []
+    positions: views,
+    totalPositions: stats.totalPositions,
+    totalAtomPositions: stats.totalAtomPositions,
+    totalStaked: stats.totalStaked,
+    verifiedPlatforms: stats.verifiedPlatforms
   }
+}
+
+// ── Explorer-legacy stubs (kept for SubscriptionManager compat) ─────────────
+// Sofia doesn't model topics/categories/platforms the same way. These stubs
+// let the manager's onTrackedPositionsUpdate still write to these keys
+// without breaking anything — returns are empty, consumers would see nothing.
+// Candidate for removal once we're confident no consumer references them.
+
+export function derivePositionsByTopic(
+  _positions: Position[]
+): Record<string, string> {
+  return {}
+}
+
+export function derivePositionsByCategory(
+  _positions: Position[]
+): Record<string, string> {
+  return {}
+}
+
+export function derivePositionsByPlatform(
+  _positions: Position[]
+): Record<string, string> {
+  return {}
+}
+
+export function deriveVerifiedPlatforms(positions: Position[]): string[] {
+  // Alias to the OAuth version — Sofia's "verified platforms" concept IS OAuth.
+  return deriveVerifiedOAuthPlatforms(positions)
 }
 
 // ── Optimistic updates (Phase 4 wires these to deposit/redeem flows) ─────────
@@ -163,8 +436,7 @@ export function applyOptimisticPosition(
   _termId: string,
   _delta: bigint
 ): void {
-  // Phase 4 implementation. Stub keeps the SubscriptionManager and future
-  // deposit hooks compiling without needing this yet.
+  // Phase 4 implementation.
 }
 
 export function clearOptimisticPosition(


### PR DESCRIPTION
## Summary

Phase 3.A of the realtime refactor plan. Replaces Phase 1.B's derivation stubs with real Sofia-specific logic and populates \`TRACKED_TERM_IDS\` with the quest + global-stake atoms.

**Dependent on #phase-1B** — base is \`feature/phase1b-offscreen-ws\`. Rebase to dev after Phase 1.B merges.

## Changes

- 7 Sofia-specific cache keys: \`trustCircle\`, \`following\`, \`followers\`, \`dailyStreak\`, \`verifiedOAuthPlatforms\`, \`intentionGroups\`, \`globalStakePosition\`
- Real derivation functions filtering positions by predicate term_id (from \`chainConfig.PREDICATE_IDS\`)
- \`TRACKED_TERM_IDS = [DAILY_CERTIFICATION, DAILY_VOTE, GLOBAL_STAKE.TERM_ID]\` — these 1-TRUST positions would otherwise be buried under the 500-row Hasura cap for power users
- Plan doc updated with Phase 3.A / 3.B split

## Test plan

- [ ] SW console shows \`[WS tracked] N positions\` on wallet connect
- [ ] \`queryClient.getQueryData(['trust-circle', wallet])\` returns expected accounts
- [ ] \`['daily-streak', wallet]\` reflects certified/voted today correctly
- [ ] \`['intention-groups', wallet]\` lists VISITS_FOR_* certs grouped by URL

## Next

Phase 3.B: migrate 5 hooks to read from these keys with \`staleTime: Infinity\`. Drop their HTTP fetchers. useQuestSystem gets a trigger-based refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)