### PR TITLE
feat(realtime): live quest streak trigger via WS daily-streak

### DIFF
--- a/extension/hooks/useOnChainStreak.ts
+++ b/extension/hooks/useOnChainStreak.ts
@@ -20,6 +20,9 @@ export interface OnChainStreakResult {
   streak: number
   activityDates: string[]
   loading: boolean
+  /** Force a refetch — used by useQuestSystem to refresh the streak count
+   *  when the WS pushes a new daily-streak position (cert/vote today). */
+  refetch: () => Promise<void>
 }
 
 export const useOnChainStreak = (
@@ -72,5 +75,5 @@ export const useOnChainStreak = (
     fetchStreak()
   }, [fetchStreak])
 
-  return { streak, activityDates, loading }
+  return { streak, activityDates, loading, refetch: fetchStreak }
 }

--- a/extension/hooks/useQuestSystem.ts
+++ b/extension/hooks/useQuestSystem.ts
@@ -13,6 +13,7 @@
  */
 
 import { useState, useEffect, useMemo, useRef } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { useWalletFromStorage } from './useWalletFromStorage'
 import { useBookmarks } from './useBookmarks'
 import { useDiscoveryScore } from './useDiscoveryScore'
@@ -22,6 +23,8 @@ import { QuestBadgeService, QuestProgressService } from '../lib/services'
 import { DAILY_CERTIFICATION_ATOM_ID, DAILY_VOTE_ATOM_ID } from '../lib/config/chainConfig'
 import { computeQuestStatuses, calculateLevelFromXP, calculateXPForNextLevel, getClaimId, getWalletKey } from '../lib/utils'
 import { createHookLogger } from '../lib/utils/logger'
+import { realtimeKeys } from '../lib/realtime/derivations'
+import type { DailyStreakStatus } from '../lib/realtime/derivations'
 import { QUEST_DEFINITIONS } from '../types/questTypes'
 import type { Quest, UserProgress, QuestSystemResult } from '../types/questTypes'
 
@@ -55,6 +58,39 @@ export const useQuestSystem = (targetWalletAddress?: string): QuestSystemResult 
   // On-chain streak data (same source as LeaderboardTab)
   const certStreak = useOnChainStreak(DAILY_CERTIFICATION_ATOM_ID, walletAddress)
   const voteStreak = useOnChainStreak(DAILY_VOTE_ATOM_ID, walletAddress)
+
+  // Live WS trigger: when the SubscriptionManager pushes a new position on
+  // the daily-cert or daily-vote atoms (user just certified / voted), the
+  // ['daily-streak', wallet] cache key updates. The streak *count* itself
+  // comes from deposits history (GetProxyDepositDays) — not positions — so
+  // we can't derive it from the WS payload. Instead we use the WS update
+  // as a signal to re-fetch the HTTP streak without polling.
+  const walletLowerForStreak = walletAddress?.toLowerCase()
+  const { data: dailyStreakStatus } = useQuery<DailyStreakStatus | undefined>({
+    queryKey: walletLowerForStreak
+      ? realtimeKeys.dailyStreak(walletLowerForStreak)
+      : ['daily-streak', 'none'],
+    queryFn: () => Promise.resolve(undefined),
+    enabled: !!walletLowerForStreak,
+    staleTime: Infinity,
+    gcTime: Infinity
+  })
+
+  const lastStreakFingerprintRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!dailyStreakStatus || !walletAddress) return
+    // Fingerprint the WS payload — only refetch when it actually changed.
+    // certifiedToday/votedToday are the fields that flip when user acts.
+    const fingerprint = `${dailyStreakStatus.certifiedToday}|${dailyStreakStatus.votedToday}|${dailyStreakStatus.certificationShares}|${dailyStreakStatus.voteShares}`
+    if (lastStreakFingerprintRef.current === fingerprint) return
+    // Skip the very first observation — the streaks already fetched on mount.
+    if (lastStreakFingerprintRef.current !== null) {
+      logger.debug('WS daily-streak changed → refetching streak counts')
+      certStreak.refetch().catch(() => {})
+      voteStreak.refetch().catch(() => {})
+    }
+    lastStreakFingerprintRef.current = fingerprint
+  }, [dailyStreakStatus, walletAddress, certStreak, voteStreak])
 
   // React state
   const [userProgress, setUserProgress] = useState<UserProgress>({


### PR DESCRIPTION
## Summary

Cherry-picked from the abandoned Phase 3.B — the one piece that actually worked. \`useQuestSystem\` observes the \`['daily-streak', wallet]\` cache key populated by SubscriptionManager, fingerprints the payload, and refetches \`useOnChainStreak\` when the user certifies or votes. Streak count updates within ~1s of the TX confirming, no polling.

The rest of Phase 3.B (useTrustCircle + useFollowing WS migrations) was abandoned because the derivations didn't handle Sofia's business rules correctly.

## Changes

- \`extension/hooks/useOnChainStreak.ts\` — expose \`refetch\` in the return value (additive, non-breaking)
- \`extension/hooks/useQuestSystem.ts\` — observe daily-streak cache key, fingerprint payload, refetch streak counts on change

## Test plan

- [ ] Certify a URL → streak count refreshes within ~1s
- [ ] Vote on a cert → same
- [ ] No regression on trust circle / following / followers (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)