### PR TITLE
feat(realtime): Phase 4 — optimistic updates (daily quest + claim vote)

### DIFF
--- a/extension/docs/plan-realtime-extension.md
+++ b/extension/docs/plan-realtime-extension.md
@@ -234,25 +234,44 @@ Blockers that stay HTTP:
 - `useUserCertifications` singleton (>500 possible, refactor invasive)
 - `useTrendingCertifications` (cross-user firehose)
 
-### Phase 4 — Optimistic updates (1 d)
+### Phase 4 — Optimistic updates (shipped as "mini")
 
-Port `applyOptimisticPosition` / `clearOptimisticPosition` from
-`sofia-explorer/src/lib/realtime/derivations.ts`.
+Scoped down to the two flows where an optimistic flip is genuinely
+visible (the rest would need Phase 3.B v2 consumers to matter).
 
-**Transport: direct `chrome.runtime.sendMessage` popup → offscreen** (NOT via
-persister — storage latency of 5-50ms breaks the "instant UI" feel).
+**Shipped**:
+- `applyOptimisticDailyStreak(qc, wallet, kind)` in `derivations.ts` —
+  flips `['daily-streak', wallet]` cache key, returns a rollback closure
+  that restores the exact pre-apply snapshot (not a blind set-to-false,
+  which would be wrong if the user already acted earlier today).
+- `clearOptimisticDailyStreak(qc, wallet)` helper for explicit removal.
+- `useQuestSystem.claimQuestXP` wires the cache flip AND a parallel
+  `setUserProgress` update so the quest icon turns green in 0ms
+  regardless of whether the consumer reads from the WS cache or from
+  local `userProgress` state. Rollback on throw or success:false;
+  TripleExists treated as success.
+- `useDebateClaims.handleStakeSubmit` (Resonance support/oppose claim)
+  — `setLocalVotes` moved from the `result.success` branch to BEFORE
+  the `await depositWithPool`, so the green support/oppose arrow
+  appears the moment the user confirms the stake modal. Previous vote
+  captured for precise rollback.
 
-Flow:
-1. User clicks "Deposit 10 TRUST" in popup
-2. Popup applies optimistic on **its own** `QueryClient` → UI updates in 0ms
-3. Popup fires `{ type: 'OPTIMISTIC_POSITION', payload }` to offscreen
-4. Offscreen applies same optimistic on its `QueryClient` (persister → storage
-   → popup rehydrate is idempotent, no-op in practice)
-5. TX broadcasts on-chain, WS subscription receives the event, overwrites optimistic
-6. TX failure → popup sends `{ type: 'CLEAR_OPTIMISTIC' }` → rollback
+**Transport**: direct setState — no offscreen messaging needed since we
+run SW-direct, not offscreen. The popup's QueryClient is the one the
+UI reads, so mutating it directly is enough. The SW's QueryClient
+catches up via chrome.storage.onChanged when the WS push arrives.
 
-Hook into the extension's deposit/redeem flows (grep `executeSingleDeposit`
-or similar).
+**Deferred to Phase 3.B v2**:
+- Generic `applyOptimisticPosition(qc, wallet, termId, delta)` that
+  routes by termId type (topic / category / platform / triple). Needs
+  per-termId metadata Sofia doesn't cleanly expose yet — ship alongside
+  the hook migration attempts for trust / follow / intentions.
+
+**Flows still not optimistic**:
+- Cart submit (batch certifications, intentions, trust/distrust) — the
+  ModalWeight UI already shows a processing/success state, optimistic
+  would just duplicate that
+- Regular deposit / redeem — no WS-fed consumer to benefit yet
 
 ### Phase 5 — Offline badge + HTTP fallback (1 d)
 

--- a/extension/hooks/useDebateClaims.ts
+++ b/extension/hooks/useDebateClaims.ts
@@ -440,6 +440,24 @@ export const useDebateClaims = (): UseDebateClaimsResult => {
       if (!selectedClaim || !selectedVaultId) return
       const weight = customWeights?.[0] || BigInt(Math.floor(0.5 * 1e18))
 
+      // Optimistic: flip the local vote marker immediately so the green
+      // support/oppose arrow appears on the ClaimCard in 0ms. Rolled back
+      // below if the deposit throws or returns success:false.
+      const voteType: "support" | "oppose" =
+        selectedVaultId === selectedClaim.termId ? "support" : "oppose"
+      const claimId = selectedClaim.id
+      const previousVote = localVotes.get(claimId)
+      setLocalVotes((prev) => new Map(prev).set(claimId, voteType))
+
+      const rollbackOptimistic = () => {
+        setLocalVotes((prev) => {
+          const next = new Map(prev)
+          if (previousVote === undefined) next.delete(claimId)
+          else next.set(claimId, previousVote)
+          return next
+        })
+      }
+
       try {
         setIsProcessing(true)
         setTransactionError(undefined)
@@ -449,16 +467,6 @@ export const useDebateClaims = (): UseDebateClaimsResult => {
         if (result.success) {
           setTransactionHash(result.txHash)
           setTransactionSuccess(true)
-          // Track local vote state
-          const voteType =
-            selectedVaultId === selectedClaim.termId ? "support" : "oppose"
-          setLocalVotes(
-            (prev) =>
-              new Map(prev).set(
-                selectedClaim.id,
-                voteType as "support" | "oppose"
-              )
-          )
           // Quest/Gold tracking (non-critical)
           try {
             await questTrackingService.recordVoteActivity()
@@ -471,9 +479,11 @@ export const useDebateClaims = (): UseDebateClaimsResult => {
             // Swallow non-critical error
           }
         } else {
+          rollbackOptimistic()
           setTransactionError(result.error || "Transaction failed")
         }
       } catch (error) {
+        rollbackOptimistic()
         setTransactionError(
           error instanceof Error ? error.message : "Transaction failed"
         )
@@ -481,7 +491,14 @@ export const useDebateClaims = (): UseDebateClaimsResult => {
         setIsProcessing(false)
       }
     },
-    [selectedClaim, selectedVaultId, selectedCurve, depositWithPool, address]
+    [
+      selectedClaim,
+      selectedVaultId,
+      selectedCurve,
+      depositWithPool,
+      address,
+      localVotes
+    ]
   )
 
   // ── List expand/collapse + lazy fetch entries ───────────────────

--- a/extension/hooks/useQuestSystem.ts
+++ b/extension/hooks/useQuestSystem.ts
@@ -13,7 +13,7 @@
  */
 
 import { useState, useEffect, useMemo, useRef } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useWalletFromStorage } from './useWalletFromStorage'
 import { useBookmarks } from './useBookmarks'
 import { useDiscoveryScore } from './useDiscoveryScore'
@@ -23,7 +23,10 @@ import { QuestBadgeService, QuestProgressService } from '../lib/services'
 import { DAILY_CERTIFICATION_ATOM_ID, DAILY_VOTE_ATOM_ID } from '../lib/config/chainConfig'
 import { computeQuestStatuses, calculateLevelFromXP, calculateXPForNextLevel, getClaimId, getWalletKey } from '../lib/utils'
 import { createHookLogger } from '../lib/utils/logger'
-import { realtimeKeys } from '../lib/realtime/derivations'
+import {
+  applyOptimisticDailyStreak,
+  realtimeKeys
+} from '../lib/realtime/derivations'
 import type { DailyStreakStatus } from '../lib/realtime/derivations'
 import { QUEST_DEFINITIONS } from '../types/questTypes'
 import type { Quest, UserProgress, QuestSystemResult } from '../types/questTypes'
@@ -54,6 +57,8 @@ export const useQuestSystem = (targetWalletAddress?: string): QuestSystemResult 
   const { stats: discoveryStats } = isReadOnlyMode
     ? { stats: undefined }
     : discoveryData
+
+  const queryClient = useQueryClient()
 
   // On-chain streak data (same source as LeaderboardTab)
   const certStreak = useOnChainStreak(DAILY_CERTIFICATION_ATOM_ID, walletAddress)
@@ -321,6 +326,18 @@ export const useQuestSystem = (targetWalletAddress?: string): QuestSystemResult 
     setClaimingQuestId(questId)
     setError(null)
 
+    // Optimistic daily-streak flip: quest icon + streak panel reflect the
+    // new activity in 0ms, well before the on-chain TX confirms (3-5s).
+    // The WS SubscriptionManager will overwrite with the authoritative
+    // value as soon as the deposit lands, so the optimistic is effectively
+    // a no-op refresh on success.
+    const optimisticRollback =
+      questId === 'daily-certification'
+        ? applyOptimisticDailyStreak(queryClient, walletAddress, 'cert')
+        : questId === 'daily-vote'
+          ? applyOptimisticDailyStreak(queryClient, walletAddress, 'vote')
+          : null
+
     try {
       logger.info('Creating on-chain badge for quest', { title: quest.title })
 
@@ -343,6 +360,9 @@ export const useQuestSystem = (targetWalletAddress?: string): QuestSystemResult 
         setClaimedQuestIds(newClaimed)
         await QuestBadgeService.saveClaimedQuestIds(walletAddress, newClaimed)
         logger.info('Claimed XP for quest', { claimId })
+      } else if (optimisticRollback) {
+        // Non-throwing failure (service returned success:false) — undo the flip.
+        optimisticRollback()
       }
 
       return result
@@ -356,12 +376,18 @@ export const useQuestSystem = (targetWalletAddress?: string): QuestSystemResult 
         errorMessage.includes('Triple creation failed')
 
       if (isTripleExistsError) {
+        // Badge already claimed on-chain — the optimistic state matches
+        // reality, leave it in place.
         logger.info('Badge already exists on-chain, marking as claimed')
         const newClaimed = new Set(claimedQuestIds)
         newClaimed.add(claimId)
         setClaimedQuestIds(newClaimed)
         await QuestBadgeService.saveClaimedQuestIds(walletAddress, newClaimed)
         return { success: true, error: 'Badge already claimed on-chain' }
+      }
+
+      if (optimisticRollback) {
+        optimisticRollback()
       }
 
       setError(errorMessage)

--- a/extension/hooks/useQuestSystem.ts
+++ b/extension/hooks/useQuestSystem.ts
@@ -326,17 +326,51 @@ export const useQuestSystem = (targetWalletAddress?: string): QuestSystemResult 
     setClaimingQuestId(questId)
     setError(null)
 
-    // Optimistic daily-streak flip: quest icon + streak panel reflect the
-    // new activity in 0ms, well before the on-chain TX confirms (3-5s).
-    // The WS SubscriptionManager will overwrite with the authoritative
-    // value as soon as the deposit lands, so the optimistic is effectively
-    // a no-op refresh on success.
+    // Optimistic daily-streak flip: both the WS-backed cache key AND the
+    // local userProgress state get flipped together, so the quest icon
+    // and streak panel reflect the new activity in 0ms regardless of
+    // which source the UI reads from. The WS will overwrite the cache
+    // once the TX confirms; QuestProgressService will reconcile
+    // userProgress on the next refresh cycle.
+    const isDailyCert = questId === 'daily-certification'
+    const isDailyVote = questId === 'daily-vote'
+    const cacheRollback = isDailyCert
+      ? applyOptimisticDailyStreak(queryClient, walletAddress, 'cert')
+      : isDailyVote
+        ? applyOptimisticDailyStreak(queryClient, walletAddress, 'vote')
+        : null
+
+    let progressRollback: (() => void) | null = null
+    if (isDailyCert || isDailyVote) {
+      const today = new Date().toISOString().split('T')[0]
+      const snapshot = userProgress
+      progressRollback = () => setUserProgress(snapshot)
+      const datesKey = isDailyCert ? 'certActivityDates' : 'voteActivityDates'
+      const existing = snapshot[datesKey]
+      const nextDates = existing.includes(today)
+        ? existing
+        : [...existing, today].sort()
+      setUserProgress({
+        ...snapshot,
+        ...(isDailyCert
+          ? {
+              hasCertificationToday: true,
+              certActivityDates: nextDates
+            }
+          : {
+              hasVotedToday: true,
+              voteActivityDates: nextDates
+            })
+      })
+    }
+
     const optimisticRollback =
-      questId === 'daily-certification'
-        ? applyOptimisticDailyStreak(queryClient, walletAddress, 'cert')
-        : questId === 'daily-vote'
-          ? applyOptimisticDailyStreak(queryClient, walletAddress, 'vote')
-          : null
+      cacheRollback || progressRollback
+        ? () => {
+            cacheRollback?.()
+            progressRollback?.()
+          }
+        : null
 
     try {
       logger.info('Creating on-chain badge for quest', { title: quest.title })

--- a/extension/lib/realtime/derivations.ts
+++ b/extension/lib/realtime/derivations.ts
@@ -15,7 +15,9 @@ import type { QueryClient } from "@tanstack/react-query"
 import type { WatchUserPositionsSubscription } from "@0xsofia/graphql"
 import {
   DAILY_CERTIFICATION_ATOM_ID,
+  DAILY_STREAK_STAKE,
   DAILY_VOTE_ATOM_ID,
+  DAILY_VOTE_STAKE,
   GLOBAL_STAKE,
   PREDICATE_IDS
 } from "~/lib/config/chainConfig"
@@ -428,7 +430,88 @@ export function deriveVerifiedPlatforms(positions: Position[]): string[] {
   return deriveVerifiedOAuthPlatforms(positions)
 }
 
-// ── Optimistic updates (Phase 4 wires these to deposit/redeem flows) ─────────
+// ── Optimistic updates ──────────────────────────────────────────────────────
+//
+// Applied client-side right after the user clicks an action, so the UI
+// reflects the change in 0ms instead of waiting the 3-5s indexer lag
+// before the WS pushes the real state. When the WS eventually arrives,
+// it overwrites the same query key with the authoritative value (in
+// practice identical to the optimistic one for daily streak, so it's
+// effectively a no-op refresh).
+
+export type DailyStreakKind = "cert" | "vote"
+
+/**
+ * Flip the daily-streak cache key to reflect a fresh cert/vote deposit.
+ * Returns a rollback function that restores the previous snapshot — call
+ * it from the transaction's catch block if the TX fails or the user
+ * cancels.
+ *
+ * Usage:
+ *   const rollback = applyOptimisticDailyStreak(qc, wallet, "cert")
+ *   try { await claimTx() } catch (err) { rollback(); throw err }
+ */
+export function applyOptimisticDailyStreak(
+  qc: QueryClient,
+  walletAddress: string,
+  kind: DailyStreakKind
+): () => void {
+  const wallet = walletAddress.toLowerCase()
+  const key = realtimeKeys.dailyStreak(wallet)
+  const previous = qc.getQueryData<DailyStreakStatus>(key)
+
+  // Use the chainConfig stake constants as the optimistic share amount.
+  // When the WS overwrites this shortly after, the real value will be
+  // equivalent (same stake, same atom) — effectively a no-op refresh.
+  const baseline: DailyStreakStatus = previous ?? {
+    certifiedToday: false,
+    votedToday: false,
+    certificationShares: "0",
+    voteShares: "0"
+  }
+
+  const next: DailyStreakStatus = {
+    ...baseline,
+    ...(kind === "cert"
+      ? {
+          certifiedToday: true,
+          certificationShares: DAILY_STREAK_STAKE.toString()
+        }
+      : {
+          votedToday: true,
+          voteShares: DAILY_VOTE_STAKE.toString()
+        })
+  }
+
+  qc.setQueryData<DailyStreakStatus>(key, next)
+
+  return () => {
+    // Restore the exact snapshot we had before the optimistic apply.
+    // If previous was undefined (first action of the session), remove
+    // the entry so consumers fall back to their own defaults.
+    if (previous === undefined) {
+      qc.removeQueries({ queryKey: key, exact: true })
+    } else {
+      qc.setQueryData<DailyStreakStatus>(key, previous)
+    }
+  }
+}
+
+/**
+ * Explicit clear without the rollback-closure dance. Prefer the rollback
+ * returned by applyOptimisticDailyStreak — it restores the previous
+ * snapshot instead of forcing certifiedToday/votedToday back to false
+ * (which would be wrong if the user had already acted earlier today).
+ */
+export function clearOptimisticDailyStreak(
+  qc: QueryClient,
+  walletAddress: string
+): void {
+  const wallet = walletAddress.toLowerCase()
+  qc.removeQueries({ queryKey: realtimeKeys.dailyStreak(wallet), exact: true })
+}
+
+// ── Legacy placeholders (Phase 3.B v2 can fill these in) ────────────────────
 
 export function applyOptimisticPosition(
   _qc: QueryClient,
@@ -436,7 +519,9 @@ export function applyOptimisticPosition(
   _termId: string,
   _delta: bigint
 ): void {
-  // Phase 4 implementation.
+  // Generic variant deferred — requires per-termId routing (topic /
+  // category / platform / triple) that Sofia's atom model doesn't neatly
+  // cover. Phase 3.B v2 should implement alongside the hook migrations.
 }
 
 export function clearOptimisticPosition(
@@ -444,5 +529,5 @@ export function clearOptimisticPosition(
   _walletAddress: string,
   _termId: string
 ): void {
-  // Phase 4 implementation.
+  // Same as above.
 }


### PR DESCRIPTION
## Summary

Phase 4 mini extended. Three UX flows now reflect user action in 0ms instead of waiting 3-5s for the TX to confirm.

## Changes

**Daily quest claim** (useQuestSystem)
- \`applyOptimisticDailyStreak(qc, wallet, kind)\` in derivations — flips WS-backed cache key, returns rollback closure
- \`claimQuestXP\` flips both the cache AND local userProgress state (cert/voteActivityDates + hasCertification/VotedToday) so the icon turns green in 0ms regardless of which source the UI reads
- Rollback on throw or success:false; TripleExists treated as success (badge already on-chain)

**Resonance claim vote** (useDebateClaims)
- setLocalVotes moved from \`result.success\` branch to BEFORE \`await depositWithPool\`
- Previous vote captured for precise rollback (including undefined → delete)
- Green support/oppose arrow appears on ClaimCard in 0ms

## Test plan

- [ ] Click Claim on Daily Certification → icon + streak flip in 0ms
- [ ] Click Claim on Daily Vote → same
- [ ] Click Support on a Resonance claim → green arrow 0ms
- [ ] Click Oppose → red arrow 0ms
- [ ] TX fails (kill network before confirm) → state rolls back
- [ ] Non-daily quests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)