### PR TITLE
feat(realtime): Phase 5 — WS offline badge

### DIFF
--- a/extension/background/realtime.ts
+++ b/extension/background/realtime.ts
@@ -30,7 +30,17 @@ import {
   queryClient
 } from "../lib/providers/queryClient"
 import { SubscriptionManager } from "../lib/realtime/SubscriptionManager"
+import {
+  getWsStatus,
+  subscribeWsStatus,
+  type WsStatusSnapshot
+} from "../lib/realtime/wsStatus"
 import { createServiceLogger } from "../lib/utils/logger"
+
+/** chrome.storage.local key holding the current WS status snapshot.
+ *  Popup subscribes to changes via chrome.storage.onChanged to render
+ *  the offline badge. */
+const WS_STATUS_STORAGE_KEY = "sofia-ws-status"
 
 const logger = createServiceLogger("Realtime")
 const manager = new SubscriptionManager(queryClient)
@@ -67,6 +77,14 @@ async function syncWalletFromStorage(): Promise<void> {
   }
 }
 
+async function persistWsStatus(snapshot: WsStatusSnapshot): Promise<void> {
+  try {
+    await chrome.storage.local.set({ [WS_STATUS_STORAGE_KEY]: snapshot })
+  } catch (err) {
+    logger.warn("failed to persist ws status", err)
+  }
+}
+
 export async function initializeRealtime(): Promise<void> {
   if (initialized) return
   initialized = true
@@ -74,6 +92,15 @@ export async function initializeRealtime(): Promise<void> {
   const wsUrl = process.env.PLASMO_PUBLIC_GRAPHQL_WS_URL ?? API_WS_PROD
   configureWsClient({ wsUrl })
   logger.info("configured", { wsUrl })
+
+  // Mirror the in-memory wsStatus store into chrome.storage.local on
+  // every change. Popup reads via onChanged to render the offline badge.
+  // Write the initial snapshot once so the popup has something to hydrate
+  // from even if it mounts before the first status transition.
+  void persistWsStatus(getWsStatus())
+  subscribeWsStatus(() => {
+    void persistWsStatus(getWsStatus())
+  })
 
   ensurePersisted()
   await syncWalletFromStorage()

--- a/extension/components/layout/AppLayout.tsx
+++ b/extension/components/layout/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { useWalletFromStorage } from '../../hooks'
 import Background from './background'
+import WsStatusBadge from '../ui/WsStatusBadge'
 import { useRouter } from './RouterProvider'
 import '../styles/Global.css'
 import '../styles/AppLayout.css'
@@ -25,6 +26,7 @@ const AppLayout = ({ children }: AppLayoutProps) => {
       <div className="app-content">
         {children}
       </div>
+      <WsStatusBadge />
     </div>
   )
 }

--- a/extension/components/styles/WsStatusBadge.css
+++ b/extension/components/styles/WsStatusBadge.css
@@ -1,0 +1,61 @@
+.ws-status-badge {
+  position: fixed;
+  top: 8px;
+  right: 8px;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  pointer-events: auto;
+  user-select: none;
+  transition: opacity 0.2s ease;
+}
+
+.ws-status-badge__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: ws-status-pulse 1.4s ease-in-out infinite;
+}
+
+.ws-status-badge__label {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.ws-status-badge--connecting {
+  background: rgba(230, 160, 50, 0.14);
+  border-color: rgba(230, 160, 50, 0.35);
+}
+
+.ws-status-badge--connecting .ws-status-badge__dot {
+  background: rgb(230, 160, 50);
+  box-shadow: 0 0 6px rgba(230, 160, 50, 0.7);
+}
+
+.ws-status-badge--offline {
+  background: rgba(220, 80, 80, 0.14);
+  border-color: rgba(220, 80, 80, 0.35);
+}
+
+.ws-status-badge--offline .ws-status-badge__dot {
+  background: rgb(220, 80, 80);
+  box-shadow: 0 0 6px rgba(220, 80, 80, 0.7);
+}
+
+@keyframes ws-status-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}

--- a/extension/components/ui/WsStatusBadge.tsx
+++ b/extension/components/ui/WsStatusBadge.tsx
@@ -1,0 +1,38 @@
+/**
+ * WsStatusBadge — tiny pill in the top-right corner of the app, rendered
+ * only when the realtime WS is not connected. Driven by useWsStatus which
+ * reads the SW-side wsStatus snapshot via chrome.storage.onChanged.
+ *
+ * States:
+ * - idle / connected → nothing rendered
+ * - connecting       → amber "Connecting…"
+ * - offline / error  → red "Offline — reconnecting…"
+ */
+
+import { useWsStatus } from "~/hooks"
+import "../styles/WsStatusBadge.css"
+
+const WsStatusBadge = () => {
+  const { status, lastError } = useWsStatus()
+
+  if (status === "idle" || status === "connected") return null
+
+  const label =
+    status === "connecting"
+      ? "Connecting…"
+      : "Offline — reconnecting…"
+
+  const variant =
+    status === "connecting" ? "connecting" : "offline"
+
+  return (
+    <div
+      className={`ws-status-badge ws-status-badge--${variant}`}
+      title={lastError ?? undefined}>
+      <span className="ws-status-badge__dot" />
+      <span className="ws-status-badge__label">{label}</span>
+    </div>
+  )
+}
+
+export default WsStatusBadge

--- a/extension/hooks/index.ts
+++ b/extension/hooks/index.ts
@@ -79,6 +79,7 @@ export { useStreakLeaderboard } from './useStreakLeaderboard'
 export type { LeaderboardEntry } from './useStreakLeaderboard'
 export { useOnChainStreak } from './useOnChainStreak'
 export type { OnChainStreakResult } from './useOnChainStreak'
+export { useWsStatus } from './useWsStatus'
 
 // Global Stake
 export { useGlobalStake, GS_FEE_DENOMINATOR } from './useGlobalStake'

--- a/extension/hooks/useWsStatus.ts
+++ b/extension/hooks/useWsStatus.ts
@@ -1,0 +1,63 @@
+/**
+ * useWsStatus — live WS connection status for the popup.
+ *
+ * The SW mirrors its in-memory wsStatus store into chrome.storage.local
+ * under `sofia-ws-status` on every change. This hook subscribes to that
+ * key via chrome.storage.onChanged and returns the current snapshot.
+ *
+ * Renders `WsStatusBadge` in the header when status !== "connected".
+ */
+
+import { useEffect, useState } from "react"
+
+import type { WsStatusSnapshot } from "~/lib/realtime/wsStatus"
+
+const STORAGE_KEY = "sofia-ws-status"
+
+const INITIAL: WsStatusSnapshot = {
+  status: "idle",
+  lastConnectedAt: 0,
+  lastDisconnectedAt: 0,
+  reconnectAttempts: 0,
+  lastError: null
+}
+
+export function useWsStatus(): WsStatusSnapshot {
+  const [snapshot, setSnapshot] = useState<WsStatusSnapshot>(INITIAL)
+
+  useEffect(() => {
+    let cancelled = false
+
+    // Initial read from storage so we hydrate with whatever the SW
+    // persisted before the popup mounted.
+    chrome.storage.local
+      .get(STORAGE_KEY)
+      .then((result) => {
+        if (cancelled) return
+        const stored = result[STORAGE_KEY] as WsStatusSnapshot | undefined
+        if (stored) setSnapshot(stored)
+      })
+      .catch(() => {
+        // First-mount race where storage isn't ready yet — stay on INITIAL.
+      })
+
+    const listener = (
+      changes: { [key: string]: chrome.storage.StorageChange },
+      area: string
+    ) => {
+      if (area !== "local") return
+      const change = changes[STORAGE_KEY]
+      if (!change) return
+      const next = change.newValue as WsStatusSnapshot | undefined
+      if (next) setSnapshot(next)
+    }
+
+    chrome.storage.onChanged.addListener(listener)
+    return () => {
+      cancelled = true
+      chrome.storage.onChanged.removeListener(listener)
+    }
+  }, [])
+
+  return snapshot
+}


### PR DESCRIPTION
SW mirrors wsStatus to chrome.storage.local; useWsStatus hook in popup subscribes via onChanged; WsStatusBadge pill in AppLayout top-right shows 'Connecting…' / 'Offline — reconnecting…' when status !== connected. Rebase base to dev after P4 merges.