### PR TITLE
feat(ui): Phase 6 — Discovery score transparency modal

### DIFF
--- a/extension/components/modals/DiscoveryScoreModal.tsx
+++ b/extension/components/modals/DiscoveryScoreModal.tsx
@@ -1,0 +1,158 @@
+/**
+ * DiscoveryScoreModal — transparency modal for the Discovery Score.
+ *
+ * Explains how the user's Gold earnings from discovery activity break
+ * down into Pioneer / Explorer / Contributor categories, with the
+ * exact formula and the path to earn more.
+ *
+ * Inspired by sofia-explorer's ScoreExplanationDialog but adapted to
+ * Sofia's model (no multi-platform topic scoring, no trust composite).
+ */
+
+import { createPortal } from "react-dom"
+import { useEffect } from "react"
+
+import type { UserDiscoveryStats } from "~/types/discovery"
+import "../styles/DiscoveryScoreModal.css"
+
+const PIONEER_GOLD = 50
+const EXPLORER_GOLD = 20
+const CONTRIBUTOR_GOLD = 10
+
+interface DiscoveryScoreModalProps {
+  isOpen: boolean
+  onClose: () => void
+  stats: UserDiscoveryStats | null
+}
+
+const DiscoveryScoreModal = ({
+  isOpen,
+  onClose,
+  stats
+}: DiscoveryScoreModalProps) => {
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose()
+    }
+    document.addEventListener("keydown", handleKey)
+    return () => document.removeEventListener("keydown", handleKey)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const pioneer = stats?.pioneerCount ?? 0
+  const explorer = stats?.explorerCount ?? 0
+  const contributor = stats?.contributorCount ?? 0
+  const fromPioneer = stats?.discoveryGold.fromPioneer ?? pioneer * PIONEER_GOLD
+  const fromExplorer =
+    stats?.discoveryGold.fromExplorer ?? explorer * EXPLORER_GOLD
+  const fromContributor =
+    stats?.discoveryGold.fromContributor ?? contributor * CONTRIBUTOR_GOLD
+  const totalGold =
+    stats?.discoveryGold.total ?? fromPioneer + fromExplorer + fromContributor
+  const totalCerts =
+    stats?.totalCertifications ?? pioneer + explorer + contributor
+
+  return createPortal(
+    <div className="score-modal-overlay" onClick={onClose}>
+      <div
+        className="score-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true">
+        <header className="score-modal__header">
+          <h2>Why is your Discovery Score {totalGold} Gold?</h2>
+          <button
+            className="score-modal__close"
+            onClick={onClose}
+            aria-label="Close">
+            ×
+          </button>
+        </header>
+
+        <div className="score-modal__body">
+          {totalCerts === 0 ? (
+            <p className="score-modal__empty">
+              No discoveries yet. Start certifying pages to earn Gold —
+              the earlier you certify a page that others certify later,
+              the more Gold you get.
+            </p>
+          ) : (
+            <>
+              <section className="score-modal__section">
+                <h3>Discovery Gold breakdown</h3>
+                <div className="score-row">
+                  <div className="score-row__label">
+                    <strong>Pioneer</strong>
+                    <span className="score-row__hint">
+                      First few to certify a page (×{PIONEER_GOLD} Gold)
+                    </span>
+                  </div>
+                  <div className="score-row__value">
+                    {pioneer} × {PIONEER_GOLD} ={" "}
+                    <strong>{fromPioneer}</strong>
+                  </div>
+                </div>
+                <div className="score-row">
+                  <div className="score-row__label">
+                    <strong>Explorer</strong>
+                    <span className="score-row__hint">
+                      Early certifiers (×{EXPLORER_GOLD} Gold)
+                    </span>
+                  </div>
+                  <div className="score-row__value">
+                    {explorer} × {EXPLORER_GOLD} ={" "}
+                    <strong>{fromExplorer}</strong>
+                  </div>
+                </div>
+                <div className="score-row">
+                  <div className="score-row__label">
+                    <strong>Contributor</strong>
+                    <span className="score-row__hint">
+                      Joined an existing discovery (×{CONTRIBUTOR_GOLD}{" "}
+                      Gold)
+                    </span>
+                  </div>
+                  <div className="score-row__value">
+                    {contributor} × {CONTRIBUTOR_GOLD} ={" "}
+                    <strong>{fromContributor}</strong>
+                  </div>
+                </div>
+                <div className="score-row score-row--total">
+                  <div className="score-row__label">
+                    <strong>Total Discovery Gold</strong>
+                  </div>
+                  <div className="score-row__value">
+                    <strong>{totalGold}</strong>
+                  </div>
+                </div>
+              </section>
+
+              <section className="score-modal__section score-modal__tip">
+                <h3>How to earn more</h3>
+                <ul>
+                  <li>
+                    Certify pages <em>before</em> others do — Pioneer
+                    earns the most per discovery
+                  </li>
+                  <li>
+                    Keep exploring new corners of the web, don't just
+                    re-certify the same domains
+                  </li>
+                  <li>
+                    Certifications, votes and daily quests also earn
+                    their own Gold (not counted here)
+                  </li>
+                </ul>
+              </section>
+            </>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+export default DiscoveryScoreModal

--- a/extension/components/pages/profile-tabs/StatsTab.tsx
+++ b/extension/components/pages/profile-tabs/StatsTab.tsx
@@ -6,6 +6,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { formatUnits } from 'viem'
 import { useDiscoveryScore, useGlobalStake } from "~/hooks"
+import DiscoveryScoreModal from '../../modals/DiscoveryScoreModal'
 import GlobalStakeModal from '../../modals/GlobalStakeModal'
 import SofiaLoader from '../../ui/SofiaLoader'
 import { DISCOVERY_GOLD_REWARDS } from "~/types/discovery"
@@ -52,6 +53,7 @@ const StatsTab = ({ walletAddress, trustedByCount, level = 1, totalXP = 0, signa
   const { config: gsConfig, position: gsPosition, vaultStats: gsVaultStats } = useGlobalStake()
   const [gsModalOpen, setGsModalOpen] = useState(false)
   const [gsModalMode, setGsModalMode] = useState<"deposit" | "redeem">("deposit")
+  const [isScoreModalOpen, setIsScoreModalOpen] = useState(false)
 
   // Tier badges carousel
   const currentTierIndex = getTierIndex(level)
@@ -114,6 +116,14 @@ const StatsTab = ({ walletAddress, trustedByCount, level = 1, totalXP = 0, signa
       {/* Discovery Badges Section */}
       <div className="discovery-section">
         <div className="discovery-section-header">
+          <button
+            type="button"
+            className="discovery-why-button"
+            onClick={() => setIsScoreModalOpen(true)}
+            aria-label="Why this score?"
+            title="Why this score?">
+            ? Why this score
+          </button>
         </div>
 
         <div className="discovery-badges-row">
@@ -288,6 +298,12 @@ const StatsTab = ({ walletAddress, trustedByCount, level = 1, totalXP = 0, signa
           />
         </div>
       )}
+
+      <DiscoveryScoreModal
+        isOpen={isScoreModalOpen}
+        onClose={() => setIsScoreModalOpen(false)}
+        stats={stats ?? null}
+      />
     </div>
   )
 }

--- a/extension/components/styles/AccountTab.css
+++ b/extension/components/styles/AccountTab.css
@@ -860,9 +860,26 @@
 
 .discovery-section-header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   margin-bottom: 16px;
+}
+
+.discovery-why-button {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.75);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.discovery-why-button:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.95);
 }
 
 .discovery-section-title {

--- a/extension/components/styles/DiscoveryScoreModal.css
+++ b/extension/components/styles/DiscoveryScoreModal.css
@@ -1,0 +1,173 @@
+.score-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  animation: score-modal-fade 0.18s ease-out;
+}
+
+.score-modal {
+  width: min(440px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  overflow: hidden auto;
+  background: rgba(24, 24, 28, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  color: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  animation: score-modal-scale 0.18s ease-out;
+}
+
+.score-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 20px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.score-modal__header h2 {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.score-modal__close {
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: background 0.15s ease;
+}
+
+.score-modal__close:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 1);
+}
+
+.score-modal__body {
+  padding: 16px 20px 20px;
+}
+
+.score-modal__empty {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.65);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.score-modal__section {
+  margin-bottom: 18px;
+}
+
+.score-modal__section:last-child {
+  margin-bottom: 0;
+}
+
+.score-modal__section h3 {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.55);
+  margin: 0 0 10px;
+}
+
+.score-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.06);
+  font-size: 13px;
+}
+
+.score-row:last-of-type {
+  border-bottom: none;
+}
+
+.score-row__label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.score-row__hint {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.score-row__value {
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.82);
+  white-space: nowrap;
+}
+
+.score-row--total {
+  margin-top: 6px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  font-size: 14px;
+}
+
+.score-modal__tip ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.score-modal__tip li {
+  position: relative;
+  padding-left: 14px;
+  margin-bottom: 6px;
+}
+
+.score-modal__tip li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.score-modal__tip em {
+  color: rgba(255, 255, 255, 0.92);
+  font-style: normal;
+  font-weight: 600;
+}
+
+@keyframes score-modal-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes score-modal-scale {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
Adapted from sofia-explorer's ScoreExplanationDialog (topic scores not applicable to Sofia). Breaks down Discovery Gold into Pioneer × 50 + Explorer × 20 + Contributor × 10 with tips. Wired into StatsTab via '? Why this score' pill. Rebase base to dev after P5 merges.