### PR TITLE
feat(mastra): port OAuth backend + signal fetchers from feature/oauth…

### DIFF
--- a/services/mastra/.env.example
+++ b/services/mastra/.env.example
@@ -1,4 +1,7 @@
-# GaiaNet Configuration
+# Sofia Mastra — environment variables
+# Copy to `.env` and fill in. Never commit secrets.
+
+# ── GaiaNet (LLM) ──────────────────────────────────────────────────────
 GAIANET_NODE_URL=https://your-node-id.gaia.domains/
 GAIANET_API_KEY=
 
@@ -7,8 +10,79 @@ GAIANET_MODEL=Qwen2.5-14B-Instruct-Q5_K_M
 GAIANET_TEXT_MODEL_SMALL=Qwen2.5-14B-Instruct-Q5_K_M
 GAIANET_TEXT_MODEL_LARGE=Qwen2.5-14B-Instruct-Q5_K_M
 
-# Embeddings Configuration
+# Embeddings
 GAIANET_EMBEDDING_MODEL=Nomic-embed-text-v1.5
 GAIANET_EMBEDDING_URL=https://your-node-id.gaia.domains/v1/embeddings
 
 USE_EMBEDDINGS=true
+
+# ── Storage ────────────────────────────────────────────────────────────
+# Local libSQL file (default). Use a Turso URL in prod if needed.
+DATABASE_URL=file:./data/mastra.db
+
+# ── On-chain bot ───────────────────────────────────────────────────────
+# Private key of the bot wallet that pays for atom/triple creation in
+# link-social-workflow + social-verifier-workflow.
+BOT_PRIVATE_KEY=
+
+# Override the Intuition mainnet RPC if you need to (default in code).
+# RPC_URL=https://rpc.intuition.systems
+
+# ── OAuth token encryption ─────────────────────────────────────────────
+# 64-char hex string (32 bytes) for AES-256-GCM. Generate with:
+#   openssl rand -hex 32
+# If unset, oauth_tokens storage is disabled (logged as a warning at boot).
+TOKEN_ENCRYPTION_KEY=
+
+# ── OAuth provider credentials ─────────────────────────────────────────
+# Each provider needs an app registered with the redirect URI:
+#   {VITE_MASTRA_URL}/oauth/{platformId}/callback
+# Setup details per provider: see docs/credentials-oauth-phase-1.md.
+
+# YouTube (Google Cloud Console — OAuth 2.0 client)
+YOUTUBE_CLIENT_ID=
+YOUTUBE_CLIENT_SECRET=
+
+# Spotify (developer.spotify.com → My Apps)
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+
+# Discord (discord.com/developers/applications)
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+
+# Twitch (dev.twitch.tv → Console → Applications)
+TWITCH_CLIENT_ID=
+TWITCH_CLIENT_SECRET=
+
+# GitHub (github.com/settings/developers → OAuth Apps)
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# Reddit (reddit.com/prefs/apps — type "web app")
+REDDIT_CLIENT_ID=
+REDDIT_CLIENT_SECRET=
+
+# Strava (strava.com/settings/api)
+STRAVA_CLIENT_ID=
+STRAVA_CLIENT_SECRET=
+
+# SoundCloud (manual approval — soundcloud.com/you/apps)
+SOUNDCLOUD_CLIENT_ID=
+SOUNDCLOUD_CLIENT_SECRET=
+
+# Mixcloud (mixcloud.com/developers)
+MIXCLOUD_CLIENT_ID=
+MIXCLOUD_CLIENT_SECRET=
+
+# Product Hunt (api.producthunt.com/v2/oauth/applications)
+PRODUCTHUNT_CLIENT_ID=
+PRODUCTHUNT_CLIENT_SECRET=
+
+# ORCID (orcid.org/developer-tools)
+ORCID_CLIENT_ID=
+ORCID_CLIENT_SECRET=
+
+# Coinbase (portal.cdp.coinbase.com)
+COINBASE_CLIENT_ID=
+COINBASE_CLIENT_SECRET=

--- a/services/mastra/.gitignore
+++ b/services/mastra/.gitignore
@@ -6,4 +6,3 @@ dist
 .env
 *.db
 *.db-*
-/docs

--- a/services/mastra/docs/credentials-oauth-phase-1.md
+++ b/services/mastra/docs/credentials-oauth-phase-1.md
@@ -1,0 +1,264 @@
+# OAuth Phase 1 — Credentials Setup Guide
+
+> 6 nouvelles plateformes a connecter : Reddit, Strava, SoundCloud, Mixcloud, Product Hunt, ORCID
+> Redirect URI a configurer partout :
+>   - Dev local : `http://localhost:5173/auth/callback`
+>   - Prod : `https://explorer.sofia.intuition.box/auth/callback`
+
+---
+
+## 1. Reddit
+
+### Dashboard
+https://www.reddit.com/prefs/apps
+
+### Steps
+1. Scroll en bas → **"Create App"** ou **"Create Another App"**
+2. Remplir :
+   - **Name** : `Sofia Explorer`
+   - **Type** : selectionner **"web app"** (pas "script" ou "installed app")
+   - **Description** : (optionnel) `Web3 reputation dashboard`
+   - **About URL** : `https://explorer.sofia.intuition.box`
+   - **Redirect URI** : `https://explorer.sofia.intuition.box/auth/callback`
+     - Note : Reddit ne supporte qu'UNE SEULE redirect URI par app. Pour tester en dev, creer une 2e app dediee dev avec `http://localhost:5173/auth/callback`
+3. Cliquer **"Create app"**
+4. **Client ID** : la chaine courte juste sous "web app" (ex: `AbCdEfGhIj12345`)
+5. **Client Secret** : le champ `secret`
+
+### Env vars a ajouter
+```
+REDDIT_CLIENT_ID=...
+REDDIT_CLIENT_SECRET=...
+```
+
+### Quirks
+- Reddit exige un header `User-Agent` explicite sur tous les appels API (deja gere dans le code)
+- Auth utilise Basic auth header (deja gere dans config.ts via `useBasicAuthHeader: true`)
+- `duration=permanent` dans les params pour obtenir un refresh token (deja gere)
+
+---
+
+## 2. Strava
+
+### Dashboard
+https://www.strava.com/settings/api
+
+### Steps
+1. Si pas deja une app : scroll en bas du formulaire **"My API Application"**
+2. Remplir :
+   - **Application Name** : `Sofia Explorer`
+   - **Category** : `Data Importer` ou `Visualizer`
+   - **Club** : laisser vide
+   - **Website** : `https://explorer.sofia.intuition.box`
+   - **Authorization Callback Domain** : `explorer.sofia.intuition.box`
+     - Note : Strava demande juste le DOMAINE (sans `https://` ni `/auth/callback`)
+     - Pour le dev, Strava accepte `localhost` en Authorization Callback Domain
+3. Upload une icone (optionnel mais recommande)
+4. Cliquer **"Create"**
+5. **Client ID** : visible en haut de la page
+6. **Client Secret** : cliquer **"Show"** ou le champ est masque
+
+### Env vars a ajouter
+```
+STRAVA_CLIENT_ID=...
+STRAVA_CLIENT_SECRET=...
+```
+
+### Quirks
+- Strava utilise `,` comme separateur de scopes au lieu d'espace (deja gere dans config.ts via `scopeSeparator: ","`)
+- Le refresh token Strava a une duree de vie limitee (6h pour l'access, 6 mois pour le refresh)
+- Une seule "Authorization Callback Domain" par app — pour supporter dev + prod, creer 2 apps
+
+---
+
+## 3. SoundCloud
+
+### Dashboard
+https://soundcloud.com/you/apps
+
+### Steps
+⚠️ **IMPORTANT** : SoundCloud n'accepte plus de nouvelles API apps depuis 2020 sans raison commerciale forte. Si la demande est refusee :
+- Option A : utiliser une app existante (si tu en as une)
+- Option B : remplir le formulaire https://soundcloud.com/comments-feedback/apps en expliquant l'usage (reputation/scoring, lecture seule)
+- Option C : skip SoundCloud jusqu'a approbation
+
+### Si autorise :
+1. **"Register a new application"**
+2. Remplir :
+   - **Name** : `Sofia Explorer`
+   - **Description** : `Web3 reputation dashboard`
+   - **Website** : `https://explorer.sofia.intuition.box`
+   - **Redirect URI for Authentication Code Flow** : `https://explorer.sofia.intuition.box/auth/callback`
+3. Sauvegarder → recuperer Client ID + Client Secret
+
+### Env vars a ajouter
+```
+SOUNDCLOUD_CLIENT_ID=...
+SOUNDCLOUD_CLIENT_SECRET=...
+```
+
+### Quirks
+- SoundCloud utilise le header `Authorization: OAuth <token>` au lieu de `Bearer <token>` (deja gere dans verify.ts)
+- Pas de scopes specifiques (on passe un array vide)
+
+---
+
+## 4. Mixcloud
+
+### Dashboard
+https://www.mixcloud.com/developers/
+
+### Steps
+1. Se connecter a Mixcloud
+2. Cliquer **"Create a new application"**
+3. Remplir :
+   - **Name** : `Sofia Explorer`
+   - **Description** : `Web3 reputation dashboard`
+   - **Website** : `https://explorer.sofia.intuition.box`
+   - **Redirect URI** : `https://explorer.sofia.intuition.box/auth/callback`
+4. Sauvegarder → recuperer les credentials
+
+### Env vars a ajouter
+```
+MIXCLOUD_CLIENT_ID=...
+MIXCLOUD_CLIENT_SECRET=...
+```
+
+### Quirks
+- Mixcloud accepte plusieurs redirect URIs (dev + prod sur la meme app)
+- API tres stable, rarement de breaking changes
+- Pas de scopes (array vide)
+
+---
+
+## 5. Product Hunt
+
+### Dashboard
+https://www.producthunt.com/v2/oauth/applications
+
+### Steps
+1. Cliquer **"Add an application"**
+2. Remplir :
+   - **Name** : `Sofia Explorer`
+   - **Redirect URI** : `https://explorer.sofia.intuition.box/auth/callback`
+   - **Description** : `Web3 reputation dashboard`
+3. Cliquer **"Create application"**
+4. Apres creation, la page affiche :
+   - **API Key** (c'est le Client ID)
+   - **API Secret** (c'est le Client Secret)
+   - **Developer Token** (pas utilise pour OAuth, c'est pour les appels sans user)
+
+### Env vars a ajouter
+```
+PRODUCTHUNT_CLIENT_ID=<API Key>
+PRODUCTHUNT_CLIENT_SECRET=<API Secret>
+```
+
+### Quirks
+- Product Hunt a UNE app = UNE redirect URI. Pour dev + prod, creer 2 apps
+- L'API est GraphQL (deja gere dans le fetcher)
+- Scope minimum `public` suffit pour lire le profil utilisateur
+
+---
+
+## 6. ORCID
+
+### Dashboard
+https://orcid.org/developer-tools
+
+### Steps
+1. Se connecter avec un compte ORCID (en creer un si besoin)
+2. **"Register for the free ORCID public API"** → cliquer
+3. Remplir :
+   - **Name of your application** : `Sofia Explorer`
+   - **Your website URL** : `https://explorer.sofia.intuition.box`
+   - **Description** : `Web3 reputation dashboard`
+   - **Redirect URIs** : ajouter les DEUX
+     - `http://localhost:5173/auth/callback`
+     - `https://explorer.sofia.intuition.box/auth/callback`
+     - Note : ORCID accepte plusieurs redirect URIs sur la meme app
+4. Sauvegarder → la page affiche :
+   - **Client ID** : `APP-XXXXXXXXXXXXXXX`
+   - **Client Secret** : `XXXXXXXX-...`
+
+### Env vars a ajouter
+```
+ORCID_CLIENT_ID=APP-...
+ORCID_CLIENT_SECRET=...
+```
+
+### Quirks
+- ORCID retourne l'**orcid iD du user directement dans la reponse token exchange** (champ `orcid` dans le JSON). Pas besoin de faire un call supplementaire pour obtenir le userId.
+- Scope `/authenticate` (literal, commence par un slash) suffit pour lire le profil
+- L'access token est permanent (pas d'expiration)
+- Possibilite d'etendre vers l'API Member (payante) plus tard pour ecriture
+
+### Important
+Le fetcher attend que `userId` soit l'ORCID iD (ex: `0000-0002-1825-0097`). Ca suppose que `exchange.ts` injecte l'ORCID iD dans le retour de l'exchange OU que linkSocialWorkflow le stocke. **A verifier** avant le deploy — sinon le fetcher throw "ORCID iD required to fetch metrics".
+
+---
+
+## Recap — 12 env vars a ajouter sur Phala Cloud
+
+```
+REDDIT_CLIENT_ID=...
+REDDIT_CLIENT_SECRET=...
+STRAVA_CLIENT_ID=...
+STRAVA_CLIENT_SECRET=...
+SOUNDCLOUD_CLIENT_ID=...
+SOUNDCLOUD_CLIENT_SECRET=...
+MIXCLOUD_CLIENT_ID=...
+MIXCLOUD_CLIENT_SECRET=...
+PRODUCTHUNT_CLIENT_ID=...
+PRODUCTHUNT_CLIENT_SECRET=...
+ORCID_CLIENT_ID=...
+ORCID_CLIENT_SECRET=...
+```
+
+A ajouter aussi dans le `.env` local pour test dev.
+
+---
+
+## Checklist de deploiement
+
+- [ ] Les 6 apps OAuth creees chez les providers
+- [ ] Les 12 env vars ajoutees dans `.env` local
+- [ ] `pnpm run dev` pour mastra → test local : `curl -I "http://localhost:4111/oauth/reddit/authorize?redirect_uri=http://localhost:5173/auth/callback&state=test"` → attendu `302 Found`
+- [ ] Les 12 env vars ajoutees dans Phala Cloud dashboard
+- [ ] Rebuild Docker image : `docker build -f sofia-mastra/phala-deploy/Dockerfile -t maximesaintjoannis/sofia-mastra:v1.8.0 .` (depuis `core/`)
+- [ ] Push : `docker push maximesaintjoannis/sofia-mastra:v1.8.0`
+- [ ] Phala dashboard → update image tag → redeploy
+- [ ] Smoke test chaque plateforme :
+  - [ ] Reddit
+  - [ ] Strava
+  - [ ] SoundCloud (si credentials)
+  - [ ] Mixcloud
+  - [ ] Product Hunt
+  - [ ] ORCID
+- [ ] Verifier signal fetcher sur chaque :
+  ```
+  curl -X POST "https://<phala>/api/workflows/signalFetcherWorkflow/start-async" \
+    -H "Content-Type: application/json" \
+    -d '{"inputData":{"platform":"reddit","walletAddress":"0x..."}}'
+  ```
+
+---
+
+## ORCID — note technique sur l'userId
+
+Le ORCID iD est retourne dans la reponse de l'exchange token, pas dans l'API `/me`. Regarde `exchange.ts` pour voir si le champ `orcid` du token response est propage comme `userId` dans `linkSocialWorkflow`. Si non, il faut ajouter un cas special :
+
+```typescript
+// Dans exchange.ts ou routes.ts, apres l'exchange ORCID :
+if (platform === 'orcid' && data.orcid) {
+  return {
+    ...tokens,
+    // inject orcid-id as userId for downstream use
+    userIdHint: data.orcid,
+  }
+}
+```
+
+Et propager ce `userIdHint` jusqu'au `linkSocialWorkflow` qui le stocke comme `userId` dans la table `oauth_tokens`.
+
+A tester apres le deploy — si ORCID fetcher retourne `"ORCID iD (userId) is required"`, c'est ce point qu'il faut fixer.

--- a/services/mastra/docs/credentials-web3.md
+++ b/services/mastra/docs/credentials-web3.md
@@ -1,0 +1,212 @@
+# Web3 Phase — Credentials Setup Guide
+
+> 10 plateformes web3 ajoutees. Seulement 3 necessitent des credentials.
+> Les 7 autres fonctionnent avec des endpoints publics (pas de dashboard a visiter).
+
+---
+
+## Vue d'ensemble
+
+| Plateforme | Type | Credentials requis |
+|---|---|---|
+| ens | on-chain | **aucun** (viem + public RPC) |
+| lido | on-chain | **aucun** (viem + public RPC) |
+| snapshot | GraphQL public | **aucun** |
+| the-graph | subgraph public | **aucun** (hosted service) |
+| wallet-siwe | on-chain | **aucun** (viem + public RPC) |
+| lens | GraphQL public | **aucun** |
+| aave | subgraph decentralise | `GRAPH_API_KEY` |
+| uniswap | subgraph decentralise | `GRAPH_API_KEY` (meme cle) |
+| farcaster | Neynar API | `NEYNAR_API_KEY` |
+| opensea | OpenSea v2 API | `OPENSEA_API_KEY` |
+| coinbase | OAuth2 | `COINBASE_CLIENT_ID` + `COINBASE_CLIENT_SECRET` |
+
+**Total credentials a creer** : 4 env vars (GRAPH_API_KEY, NEYNAR_API_KEY, OPENSEA_API_KEY, COINBASE pair).
+
+**Bonus recommande** : `ETH_MAINNET_RPC` — par defaut on utilise `eth.llamarpc.com` (public, peut rate-limit). En prod, mettre une URL Alchemy/Infura/QuickNode dediee.
+
+---
+
+## 1. GRAPH_API_KEY (pour Aave + Uniswap)
+
+### Dashboard
+https://thegraph.com/studio/apikeys/
+
+### Steps
+1. Se connecter avec un wallet Ethereum (Metamask, WalletConnect, etc.)
+2. Cliquer **"Create API Key"**
+3. Nommer la cle : `Sofia Mastra`
+4. **Important** : The Graph facture en GRT. Pour la free tier :
+   - Free queries : 100 000 queries/mois par API key
+   - Suffisant pour < 3000 users actifs par jour (notre cas)
+   - Si jamais on depasse : on paye en GRT (on peut buy GRT avec carte ou ETH)
+5. Copier la cle (format: `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`)
+
+### Env var
+```
+GRAPH_API_KEY=...
+```
+
+### Utilisation
+- Aave v3 subgraph ID : `JCNWRypm7FYwV8fx5HhzZPSFaMxgkPuw4TnR3Gpi81zk`
+- Uniswap v3 subgraph ID : `5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV`
+- Les deux utilisent la meme API key
+
+---
+
+## 2. NEYNAR_API_KEY (pour Farcaster)
+
+### Dashboard
+https://neynar.com/
+
+### Steps
+1. S'inscrire (email ou wallet)
+2. Aller dans Dashboard → **"API Keys"**
+3. Creer une cle pour "Sofia"
+4. **Plans** :
+   - Starter (free) : 100k requests/mois, 10 req/sec
+   - Growth : $200/mois si on depasse
+5. Copier la cle
+
+### Env var
+```
+NEYNAR_API_KEY=...
+```
+
+### Note importante
+Farcaster est "linked" au wallet — le fetcher cherche une Farcaster account liee a l'adresse Ethereum du user. Si le user n'a pas de compte Farcaster verifie avec son wallet, le fetcher retourne `has_account: 0` (pas une erreur). Normal.
+
+---
+
+## 3. OPENSEA_API_KEY (pour OpenSea)
+
+### Dashboard
+https://docs.opensea.io/reference/api-keys
+
+### Steps
+1. Se connecter avec un compte OpenSea (lien avec wallet Ethereum)
+2. Remplir le formulaire de demande :
+   - **Project name** : `Sofia Reputation`
+   - **Project description** : `Web3 reputation scoring — read-only NFT data per user wallet`
+   - **Use case** : mettre "Read-only aggregate stats for reputation scoring"
+3. Attendre approbation (peut prendre 1-2 jours)
+4. Une fois approuve, la cle est visible dans le dashboard
+
+### Env var
+```
+OPENSEA_API_KEY=...
+```
+
+### Alternative si approbation lente
+Utiliser [Reservoir API](https://reservoir.tools/) ou [Alchemy NFT API](https://www.alchemy.com/nft-api) — mais il faudrait modifier `signals/onchain/opensea.ts` pour pointer vers leur endpoint.
+
+---
+
+## 4. COINBASE_CLIENT_ID + COINBASE_CLIENT_SECRET (OAuth)
+
+### Dashboard
+https://www.coinbase.com/oauth/applications
+
+### Steps
+1. Se connecter a Coinbase (pas Coinbase Pro/Advanced)
+2. **"Create New Application"**
+3. Remplir :
+   - **Application Name** : `Sofia Explorer`
+   - **Description** : `Web3 reputation dashboard`
+   - **Redirect URIs** : (ajouter les DEUX — Coinbase accepte plusieurs)
+     - `http://localhost:5173/auth/callback`
+     - `https://explorer.sofia.intuition.box/auth/callback`
+   - **Permitted Origins** (CORS) : pareil
+4. **Scopes a demander** (cocher) :
+   - `wallet:user:read`
+   - `wallet:accounts:read`
+5. Sauvegarder → Client ID + Client Secret visibles
+
+### Env vars
+```
+COINBASE_CLIENT_ID=...
+COINBASE_CLIENT_SECRET=...
+```
+
+---
+
+## Bonus — ETH_MAINNET_RPC (recommande prod)
+
+Par defaut on utilise `https://eth.llamarpc.com` (public, gratuit, rate-limite).
+
+Pour la prod Phala, mieux vaut un endpoint dedie :
+
+### Alchemy (free tier : 300M compute units/mois)
+1. https://dashboard.alchemy.com/ → sign up
+2. **"Create new app"** → Ethereum Mainnet
+3. Copier l'URL HTTPS de l'endpoint
+
+### Infura (free tier : 100k requests/jour)
+1. https://infura.io/ → sign up
+2. **"Create new project"** → Ethereum Mainnet
+3. Copier l'URL mainnet
+
+### Env var
+```
+ETH_MAINNET_RPC=https://eth-mainnet.g.alchemy.com/v2/xxxxx
+```
+
+Sans cette var, le code utilise LlamaRPC. **Inutile de la bloquer** pour aller en prod.
+
+---
+
+## Recap — env vars a ajouter sur Phala Cloud
+
+```
+# Obligatoires
+GRAPH_API_KEY=...
+NEYNAR_API_KEY=...
+OPENSEA_API_KEY=...
+COINBASE_CLIENT_ID=...
+COINBASE_CLIENT_SECRET=...
+
+# Recommande (sinon fallback public)
+ETH_MAINNET_RPC=...
+```
+
+---
+
+## Plan de deploiement
+
+1. **Obtenir les 4 credentials** (GRAPH, NEYNAR, OPENSEA, COINBASE) — ~1 journee (OpenSea peut trainer)
+2. **Ajouter env vars** dans `.env` local + Phala dashboard
+3. **Rebuild Docker image** :
+   ```bash
+   cd core/
+   docker build -f sofia-mastra/phala-deploy/Dockerfile -t maximesaintjoannis/sofia-mastra:v2.0.0 .
+   docker push maximesaintjoannis/sofia-mastra:v2.0.0
+   ```
+4. **Phala dashboard** → update image tag → redeploy
+5. **Smoke test** chaque plateforme :
+   ```bash
+   for P in ens lido aave uniswap snapshot the-graph wallet-siwe lens farcaster opensea coinbase; do
+     echo "=== $P ==="
+     curl -s -X POST "https://<phala>/api/workflows/signalFetcherWorkflow/start-async" \
+       -H "Content-Type: application/json" \
+       -d "{\"inputData\":{\"platform\":\"$P\",\"walletAddress\":\"0xTonAdresse\"}}" \
+       | python3 -m json.tool
+   done
+   ```
+6. **Frontend** : les 10 plateformes wallet-based auto-connect via Privy. Coinbase passe par le flow OAuth standard.
+
+---
+
+## Plateformes qui marchent SANS credentials
+
+Si tu veux deployer MAINTENANT sans attendre les credentials OpenSea/Neynar/Graph, ces plateformes marchent avec le fallback public RPC :
+- ens
+- lido
+- snapshot (pas de key du tout)
+- wallet-siwe
+- lens
+
+Ca fait deja 5 plateformes web3 qui fonctionnent en prod immediatement apres le deploy v2.0.0, sans aucune setup supplementaire.
+
+Aave/Uniswap marchent mais avec limite de rate (pas terrible sans GRAPH_API_KEY).
+
+Farcaster/OpenSea/Coinbase attendent leurs credentials.

--- a/services/mastra/docs/plan-non-oauth-platforms.md
+++ b/services/mastra/docs/plan-non-oauth-platforms.md
@@ -1,0 +1,446 @@
+# Plan — Plateformes non-OAuth (public, api_key, siwe, siwf, none)
+
+> Date : 17 avril 2026
+> Cible : `core/sofia-mastra/` + `sofia-explorer/`
+> Prerequis : OAuth base fonctionne (cf. `plan-oauth-routes.md`)
+
+---
+
+## 1. Pourquoi ce plan
+
+Sur 137 plateformes au catalogue, **53 ne sont PAS OAuth** :
+
+- **24 public** — APIs publiques (chess.com, ens, wikipedia, etc.)
+- **5 api_key** — cle d'API backend (opensea, itch.io, etc.)
+- **2 siwe** — Sign-In with Ethereum (wallet-siwe, lens)
+- **1 siwf** — Sign-In with Farcaster (farcaster)
+- **18 none** — auto-connect ou pas d'API utile (netflix, bandcamp, etc.)
+
+Chaque type necessite sa propre strategie. Ce plan definit ce qui doit exister pour chaque.
+
+---
+
+## 2. Deux familles de plateformes publiques
+
+Parmi les 24 plateformes `public`, il y a **deux sous-familles** qui necessitent des strategies differentes :
+
+### 2.1 — Verification on-chain (pas de challenge)
+
+Le user a deja un wallet connecte. Ces plateformes lisent des donnees blockchain — on n'a besoin de RIEN du user (ni username, ni bio challenge).
+
+| Plateforme | ID | Source on-chain |
+|---|---|---|
+| ENS | `ens` | Mainnet Ethereum — lookup `resolver.name(addr)` |
+| Lido | `lido` | Mainnet — wstETH/stETH balance |
+| Aave | `aave` | Multi-chain — Aave subgraph |
+| Uniswap | `uniswap` | The Graph subgraphs |
+| Snapshot | `snapshot` | Snapshot Hub GraphQL `/graphql` |
+| The Graph | `the-graph` | Custom subgraphs |
+
+**Stratégie** : Connexion = auto-connect (comme `authType: none`), backend va direct chercher les donnees avec `walletAddress`.
+
+**Implementation** :
+- Ajouter un fetcher par plateforme qui prend juste `walletAddress` au lieu d'un token
+- Ajouter ces plateformes dans `SIGNAL_FETCHERS` registry avec une signature differente : `(walletAddress: string) => Promise<Metrics>`
+- Cote Explorer : bouton "Connect" fait juste un `updateConnection(platformId, { status: 'connected' })` sans popup
+
+### 2.2 — Verification username + challenge (proof of ownership)
+
+Le user doit prouver qu'il est bien proprietaire du compte. Deux patterns :
+
+#### Pattern A — Challenge code dans la bio
+
+Pour les plateformes ou le user peut editer sa bio/profil :
+- chess.com, leetcode, letterboxd, duolingo, openstreetmap, etc.
+
+**Flow existant (deja dans `oauthService.ts`)** :
+1. User clique "Connect" + entre son username
+2. `requestChallenge(platformId, username)` → backend genere un code unique
+3. User colle le code dans sa bio sur la plateforme
+4. `verifyChallengeCode(platformId)` → backend check la bio → confirme
+
+**MAIS** : pas de routes mastra pour ca ! Il faut les creer.
+
+#### Pattern B — Pas de challenge (username suffit)
+
+Pour les plateformes ou le username expose deja des donnees publiques utiles sans risque d'usurpation :
+- Wikipedia (`user contributions` visible publiquement)
+- HackerNews (pas d'impact si on "vole" un username — les donnees sont agregees)
+- arxiv, pubmed, google-scholar (publications liees au nom)
+- OpenFoodFacts, openlibrary (contributions)
+
+**Strategie** : demander juste le username, pas de challenge, juste stocker pour fetch ulterieur.
+
+**Tradeoff** : moins securise (on ne verifie pas que le user possede vraiment le compte), mais ok pour un MVP car l'impact de l'usurpation est faible.
+
+---
+
+## 3. Implementation par type
+
+### 3.1 — Public on-chain (6 plateformes)
+
+**Plateformes** : ens, lido, aave, uniswap, snapshot, the-graph
+
+**Fichiers a creer cote mastra** :
+
+```
+src/mastra/signals/
+├── ens.ts           — lookup ENS via viem
+├── lido.ts          — stETH balance via viem
+├── aave.ts          — subgraph query
+├── uniswap.ts       — The Graph query
+├── snapshot.ts      — GraphQL /graphql
+└── the-graph.ts     — custom subgraph queries
+```
+
+**Modification du workflow** :
+
+Le `signalFetcherWorkflow` actuel cherche un token via `getToken(wallet, platform)`. Pour les on-chain, il faut bypass le lookup token.
+
+```typescript
+// Dans signal-fetcher-workflow.ts
+const ONCHAIN_PLATFORMS = new Set(['ens', 'lido', 'aave', 'uniswap', 'snapshot', 'the-graph'])
+
+if (ONCHAIN_PLATFORMS.has(platform)) {
+  // Pas de token necessaire
+  const fetcher = ONCHAIN_FETCHERS[platform]
+  const metrics = await fetcher(walletAddress)
+  return { success: true, platformId: platform, metrics, fetchedAt: Date.now() }
+}
+
+// Flow existant avec token
+const tokenRow = await getToken(walletAddress, platform)
+// ...
+```
+
+**Cote Explorer** :
+
+Ajouter ces plateformes dans `usePlatformConnections.ts` dans la branche "auto" :
+
+```typescript
+// Dans connect() :
+if (strategy === 'auto' || ONCHAIN_AUTOCONNECT.has(platformId)) {
+  updateConnection(platformId, {
+    status: 'connected',
+    connectedAt: Date.now(),
+    userId: wallet?.address,
+  })
+  return
+}
+```
+
+**Pas de bouton Connect a modifier** — les user n'ont rien a faire, le backend fetche tout seul avec leur adresse wallet.
+
+### 3.2 — Public avec challenge (12 plateformes)
+
+**Plateformes** : chess-com, leetcode, letterboxd, duolingo, openstreetmap, (et autres ou le user peut editer sa bio)
+
+**Fichiers a creer cote mastra** :
+
+```
+src/mastra/challenge/
+├── types.ts         — types Challenge, ChallengeResult
+├── storage.ts       — table challenges (code, wallet, platform, expires_at)
+├── routes.ts        — POST /platforms/:id/challenge, POST /platforms/:id/verify
+├── verify.ts        — logique de verification bio par plateforme
+└── fetchers/        — fetchers qui utilisent le username stocke
+    ├── chess-com.ts
+    ├── leetcode.ts
+    └── ...
+```
+
+**Table challenges** (nouvelle) :
+
+```sql
+CREATE TABLE IF NOT EXISTS challenges (
+  wallet_address TEXT NOT NULL,
+  platform TEXT NOT NULL,
+  username TEXT NOT NULL,
+  challenge_code TEXT NOT NULL,
+  created_at INTEGER DEFAULT (unixepoch()),
+  expires_at INTEGER NOT NULL,  -- 10 minutes
+  verified_at INTEGER,
+  PRIMARY KEY (wallet_address, platform)
+)
+```
+
+**Table usernames** (nouvelle, pour les verifies) :
+
+```sql
+CREATE TABLE IF NOT EXISTS platform_usernames (
+  wallet_address TEXT NOT NULL,
+  platform TEXT NOT NULL,
+  username TEXT NOT NULL,
+  verified_at INTEGER NOT NULL,
+  PRIMARY KEY (wallet_address, platform)
+)
+```
+
+**Routes Mastra** (via `registerApiRoute` comme OAuth) :
+
+```
+POST /platforms/:platform/challenge
+  Body: { walletAddress, username }
+  Action:
+    1. Generer code (6 chars alphanumeriques genre "SF8K2X")
+    2. Stocker { wallet, platform, username, code, expires: now+10min }
+    3. Retourner { challengeCode, platformId, username, instruction: "Paste SF8K2X in your bio on X" }
+
+POST /platforms/:platform/verify
+  Body: { walletAddress }
+  Action:
+    1. Lire le challenge en cours pour (wallet, platform)
+    2. Verifier expires_at > now
+    3. Fetch la bio/profil de la plateforme pour `username`
+    4. Chercher le code dans la bio
+    5. Si trouve → deplacer vers platform_usernames, supprimer challenge
+    6. Retourner { success, platformId, userId, username }
+```
+
+**Exemple verify.ts pour chess.com** :
+
+```typescript
+export async function verifyChessChallenge(username: string, code: string): Promise<boolean> {
+  const res = await fetch(`https://api.chess.com/pub/player/${username}`)
+  if (!res.ok) return false
+  const data = await res.json()
+  return (data.location || '').includes(code) || (data.name || '').includes(code)
+}
+```
+
+**Fetcher avec username** :
+
+Le `signalFetcherWorkflow` doit savoir quels platforms utilisent username (pas token) :
+
+```typescript
+const USERNAME_PLATFORMS = new Set(['chess-com', 'leetcode', ...])
+
+if (USERNAME_PLATFORMS.has(platform)) {
+  const row = await getUsername(walletAddress, platform)
+  if (!row) return { error: 'not_connected' }
+  const fetcher = USERNAME_FETCHERS[platform]
+  return { success: true, metrics: await fetcher(row.username) }
+}
+```
+
+**Cote Explorer** :
+
+Le code existe deja (`requestChallenge`, `verifyChallengeCode` dans `oauthService.ts`, `usePlatformConnections.startChallenge`, `verifyChallengeCode`). Juste corriger les URLs :
+
+```typescript
+// Dans oauthService.ts
+`${MASTRA_URL}/api/platforms/${platformId}/challenge`   // ← garder /api ? non
+`${MASTRA_URL}/platforms/${platformId}/challenge`       // ← prefixe custom (comme /oauth/*)
+```
+
+Le prefixe `/platforms/*` est dispo (pas reserve par Mastra comme `/api/*`).
+
+### 3.3 — Public sans challenge (6 plateformes)
+
+**Plateformes** : wikipedia, hacker-news, arxiv, pubmed, google-scholar, openfoodfacts, openlibrary
+
+**Strategie** : demander juste le username, pas de verification.
+
+**Flow** :
+1. User entre son username dans l'input
+2. Frontend POST vers `/platforms/:id/link-username` avec `{ walletAddress, username }`
+3. Backend stocke directement dans `platform_usernames`
+4. Fetcher utilise le username
+
+**Warning UI** : afficher "Anyone can submit any username here. This is public data only, no ownership verification."
+
+**Simple et rapide a implementer** une fois que Pattern B (challenge) est en place.
+
+### 3.4 — API key (5 plateformes)
+
+**Plateformes** : opensea, itch.io, rawg, semantic-scholar, tracker-gg
+
+**Strategie** : le backend stocke SA PROPRE API key (env var), le user fournit juste son username/wallet.
+
+**Implementation** :
+
+```typescript
+// Dans oauth/config.ts, ajouter une section api_key_providers
+export const API_KEY_PROVIDERS = {
+  opensea: {
+    apiKey: process.env.OPENSEA_API_KEY!,
+    profileUrl: (addr: string) => `https://api.opensea.io/api/v2/accounts/${addr}`,
+    headers: (key: string) => ({ 'X-API-KEY': key }),
+  },
+  // ...
+}
+```
+
+**Fetcher** :
+
+```typescript
+export async function fetchOpenSeaSignals(walletAddress: string): Promise<Metrics> {
+  const config = API_KEY_PROVIDERS.opensea
+  const res = await fetch(config.profileUrl(walletAddress), { headers: config.headers(config.apiKey) })
+  const data = await res.json()
+  return {
+    nfts_owned: data.owned_count || 0,
+    collections: data.collections?.length || 0,
+    // ...
+  }
+}
+```
+
+**UI** : meme flow que les on-chain — auto-connect si wallet connecte.
+
+### 3.5 — SIWE / SIWF (3 plateformes)
+
+**Plateformes** : wallet-siwe (Ethereum), lens (Lens Protocol), farcaster
+
+**Strategie** : signature de message avec wallet via Privy.
+
+**Flow** :
+
+```
+1. User clique Connect SIWE
+2. Frontend demande un nonce au backend
+   POST /platforms/:id/siwe/nonce { walletAddress } → { nonce, message }
+3. User signe le message avec Privy (signMessage)
+4. Frontend envoie signature au backend
+   POST /platforms/:id/siwe/verify { walletAddress, signature, message } → { success, userId }
+5. Backend verifie signature (viem.verifyMessage)
+6. Backend stocke dans platform_usernames: userId = walletAddress
+7. Fetcher utilise walletAddress pour fetch
+```
+
+**Routes mastra a ajouter** :
+
+```
+POST /platforms/:platform/siwe/nonce
+POST /platforms/:platform/siwe/verify
+```
+
+**Cote Explorer** : `connectWithSIWE` existe deja dans `oauthService.ts`, il faut juste l'appeler depuis le hook.
+
+**Farcaster (SIWF)** : similar mais utilise Farcaster signer au lieu d'une cle Ethereum.
+
+### 3.6 — None (18 plateformes)
+
+**Plateformes** : netflix, disney+, crunchyroll, apple-music, amazon, coursera, udemy, goodreads, substack, researchgate, playstation, xbox, nintendo, imdb, rotten-tomatoes, nike-run-club, bandcamp, telegram
+
+**Strategie** : DEUX sous-cas :
+
+**Sub-case A — Public API dispo (5 plateformes)** :
+Bandcamp, Telegram (bots), Udemy, Apple Music, Goodreads (deprecated mais fonctionne)
+→ Traiter comme "public" mais sans meme demander username (derivable d'autre chose OU pas de signal utile).
+
+**Sub-case B — Pas d'API (13 plateformes)** :
+Netflix, Disney+, Crunchyroll, Amazon, Coursera, ResearchGate, PlayStation, Xbox, Nintendo, IMDb, Rotten Tomatoes, Nike Run Club
+→ **N'afficher meme pas de bouton Connect** dans PlatformGrid. Retirer du catalogue OU afficher "Scanning via extension" (si l'extension Chrome Sofia scrape ces sites).
+
+**Action** : audit de ces 13 plateformes — soit les retirer, soit voir si l'extension Sofia peut les couvrir differemment (tracking de navigation).
+
+---
+
+## 4. Resume des efforts
+
+| Categorie | Plateformes | Priorite | Effort |
+|---|---|---|---|
+| Public on-chain | 6 | **Haute** (impact web3) | 3-4 jours |
+| Public avec challenge | 12 | **Haute** (chess.com, leetcode) | 2 jours infra + 0.5j/plateforme |
+| Public sans challenge | 6 | Moyenne (edu/wiki) | 1 jour (reutilise infra challenge) |
+| API key | 5 | Moyenne (opensea = web3 crucial) | 0.5 jour/plateforme |
+| SIWE/SIWF | 3 | **Haute** (lens, farcaster = web3 social) | 2 jours infra |
+| None A (API dispo) | 5 | Basse | skip ou MVP simple |
+| None B (pas d'API) | 13 | **Retirer du catalogue** ou via extension | 0 jour (cleanup) |
+
+**Total MVP non-OAuth** : ~10 jours pour couvrir 32 plateformes (on-chain + challenge + SIWE + API key).
+
+---
+
+## 5. Ordre de priorite recommande
+
+1. **SIWE + on-chain public** (wallet-siwe, ens, aave, uniswap, lido, the-graph, snapshot, lens) — 5 jours
+   → Web3 natif, pas besoin d'apps tierces, impact immediat sur le scoring "web3-crypto"
+2. **Challenge flow + chess.com + leetcode** — 3 jours
+   → Tres demandes par les users (dev et gaming)
+3. **API key + opensea** — 0.5 jour
+   → NFT market cap signal
+4. **Farcaster (SIWF)** — 1 jour
+   → Web3 social
+5. **Cleanup plateformes sans API** — retirer 13 plateformes du catalogue
+   → Zero effort, UI plus claire
+
+---
+
+## 6. Fichiers a creer cote mastra
+
+```
+src/mastra/
+├── challenge/
+│   ├── types.ts
+│   ├── storage.ts           — tables challenges + platform_usernames
+│   ├── routes.ts            — /platforms/:id/challenge, /verify, /link-username
+│   ├── verify.ts            — verification bio par plateforme
+│   └── fetchers/            — fetchers username-based (chess-com, leetcode, etc.)
+├── siwe/
+│   ├── types.ts
+│   ├── routes.ts            — /platforms/:id/siwe/nonce, /verify
+│   └── verify.ts            — verification signature
+├── onchain/
+│   ├── types.ts
+│   └── fetchers/            — fetchers wallet-based (ens, aave, etc.)
+└── oauth/
+    └── config.ts            — ajouter API_KEY_PROVIDERS section
+```
+
+## 7. Fichiers a modifier
+
+**Mastra** :
+- `src/mastra/index.ts` — ajouter les nouvelles routes dans `server.apiRoutes`
+- `src/mastra/workflows/signal-fetcher-workflow.ts` — brancher les differents patterns (token vs username vs walletAddress)
+- `src/mastra/signals/registry.ts` — 3 types de fetchers : tokenBased, usernameBased, walletBased
+
+**Explorer** :
+- `src/services/oauthService.ts` — corriger les URLs `/api/platforms/*` → `/platforms/*` (comme on a fait pour OAuth)
+- `src/hooks/usePlatformConnections.ts` — brancher SIWE, auto-connect pour on-chain, integrer le challenge flow complet
+- `src/components/profile/PlatformGrid.tsx` — deja UI prete, juste connecter le bon `onConnect` par authType
+- `src/config/platformCatalog.ts` — retirer les 13 plateformes sans API OU les marquer `hidden: true`
+- `src/services/reputationScoreService.ts` — ajouter METRIC_COMPONENTS pour les nouvelles plateformes
+
+---
+
+## 8. Schema final du flow (multi-pattern)
+
+```
+User clique Connect
+      │
+      ├─ authType: oauth2 → plan-oauth-routes.md (existant)
+      │
+      ├─ authType: public (on-chain) → auto-connect, backend utilise walletAddress
+      │
+      ├─ authType: public (challenge) → username input → challenge code → bio verify
+      │
+      ├─ authType: public (no challenge) → username input → direct link
+      │
+      ├─ authType: api_key → auto-connect, backend utilise son API key + walletAddress
+      │
+      ├─ authType: siwe → Privy signMessage → verify signature → store
+      │
+      ├─ authType: siwf → Farcaster signer → verify → store
+      │
+      └─ authType: none → soit retirer, soit auto-connect sans fetch
+
+Puis toutes passent par :
+  signalFetcherWorkflow(platform, walletAddress)
+    → resolve la strategie fetcher (token/username/wallet)
+    → renvoie metrics
+```
+
+---
+
+## 9. Decision pour avancer
+
+**Recommendation** :
+
+1. **D'abord** nettoyer les 13 plateformes sans API du catalogue (ou les cacher) — 30 min
+2. **Ensuite** implementer le SIWE + on-chain (fort impact, pas de challenge complexe)
+3. **Puis** le challenge flow + chess.com comme premier test
+4. Les OAuth2 restantes (Phase 1 de `plan-oauth-extension.md`) peuvent avancer en parallele
+
+Les trois chantiers (OAuth extension, challenge flow, SIWE/on-chain) sont **independants** et peuvent etre implementes en parallele par differents devs.

--- a/services/mastra/docs/plan-oauth-extension.md
+++ b/services/mastra/docs/plan-oauth-extension.md
@@ -1,0 +1,344 @@
+# Plan d'extension — OAuth2 roadmap complet (79 plateformes)
+
+> Date : 17 avril 2026
+> Cible : `core/sofia-mastra/` + `sofia-explorer/`
+> Prerequis : `plan-oauth-routes.md` est implemente (routes /oauth/* fonctionnelles)
+> Etat actuel : 5 plateformes live (GitHub, Spotify, Discord, Twitch, YouTube)
+
+---
+
+## 1. Pourquoi ce plan
+
+Le systeme OAuth marche (v1.6.0+ en prod). Il reste **79 plateformes OAuth2** et **3 plateformes OAuth1** a connecter.
+
+**Chaque nouvelle plateforme = meme schema** :
+1. Creer l'app OAuth sur le dashboard du provider
+2. Obtenir `CLIENT_ID` + `CLIENT_SECRET`
+3. Ajouter ces env vars sur Phala
+4. Ajouter la config dans `OAUTH_PROVIDERS` (`oauth/config.ts`)
+5. Ajouter le fetcher de metriques (`signals/<platform>.ts`)
+6. Ajouter le support dans `verifyAndGetUserId` (`oauth/verify.ts`)
+7. Enregistrer dans `METRIC_COMPONENTS` cote Explorer (`reputationScoreService.ts`)
+
+Le travail est **repetitif mais simple**. Ce plan priorise les plateformes par phase.
+
+---
+
+## 2. Phases
+
+### Phase 1 — Quick Wins (7 plateformes OAuth2)
+
+Plateformes grand public, APIs stables, impact rapide sur le scoring.
+
+| Plateforme | ID | Scopes proposes | Complexite |
+|---|---|---|---|
+| Reddit | `reddit` | `identity, read, mysubreddits` | Facile — Bearer token classique |
+| Strava | `strava` | `read, activity:read` | Facile — endpoints clairs |
+| SoundCloud | `soundcloud` | (lecture publique) | Moyen — SoundCloud restreint les nouvelles apps |
+| Last.fm | `lastfm` | (API key-based en fait — auth differente) | Moyen — pas vraiment OAuth2 standard |
+| Mixcloud | `mixcloud` | (lecture publique) | Facile |
+| Product Hunt | `producthunt` | (GraphQL API) | Moyen — GraphQL au lieu de REST |
+| ORCID | `orcid` | `/authenticate` | Facile — standard academique |
+
+### Phase 2 — Domaines cles (7 plateformes OAuth2)
+
+Plateformes tech/creative qui enrichissent le scoring dev/design.
+
+| Plateforme | ID | Scopes | Complexite |
+|---|---|---|---|
+| Figma | `figma` | `files:read` | Facile |
+| Hugging Face | `huggingface` | (lecture profil + modeles) | Facile |
+| Kaggle | `kaggle` | (API key-based historique) | Moyen |
+| Steam | `steam` | OpenID | Moyen — pas OAuth2 classique, utilise OpenID |
+| Duolingo | `duolingo` | (API non-officielle) | Difficile — pas d'OAuth officiel |
+| Vercel | `vercel` | (read) | Facile |
+| Unsplash | `unsplash` | `public read_photos` | Facile |
+
+### Phase 3 — Web3 natif (3 OAuth2 + 1 OAuth1)
+
+Plateformes web3 avec OAuth.
+
+| Plateforme | ID | Stratégie |
+|---|---|---|
+| Coinbase | `coinbase` | OAuth2 `wallet:user:read` |
+| OpenSea | `opensea` | **api_key** — voir plan-non-oauth |
+| Lens | `lens` | **siwe** — voir plan-non-oauth |
+| Farcaster | `farcaster` | **siwf** — voir plan-non-oauth |
+| The Graph | `the-graph` | **public** on-chain — voir plan-non-oauth |
+
+### Phase 4 — Difficile mais fort (4 plateformes OAuth2)
+
+APIs restrictives ou partenariats necessaires.
+
+| Plateforme | ID | Obstacle |
+|---|---|---|
+| Behance | `behance` | API deprecated, peut retourner a la connexion Adobe |
+| 500px | `500px` | API payante pour acces complet |
+| LeetCode | `leetcode` | GraphQL non-officiel stable |
+| Bandcamp | `bandcamp` | Pas d'OAuth officiel — voir plan-non-oauth |
+
+### Phase 5 — Partenariats requis (2 plateformes OAuth2)
+
+| Plateforme | Obstacle |
+|---|---|
+| Blizzard | Partenariat Blizzard + Battle.net OAuth |
+| Riot Games | RSO (Riot Sign-On) — approbation explicite requise |
+
+### Phase 6 — OAuth2 residuel (65 plateformes)
+
+Toutes les autres OAuth2 du catalogue :
+
+**Dev/Tech** : gitlab, bitbucket, stackoverflow, devto, hashnode, hackerrank, codepen, replit, netlify, notion, linear, todoist, medium, slack
+
+**Creative** : dribbble, deviantart, sketchfab
+
+**Video/Media** : vimeo, dailymotion, twitch, wattpad
+
+**Music** : deezer, listenbrainz, musicbrainz, tidal, genius
+
+**Social** : mastodon, bluesky, pinterest, x-twitter, linkedin, facebook, instagram, tiktok, snapchat
+
+**Gaming** : lichess, riot-games, epic-games, gog, myanimelist, anilist, trakt
+
+**Sport/Health** : garmin, polar, wahoo, komoot, fitbit, myfitnesspal
+
+**Food/Lifestyle** : untappd, vivino, yelp, librarything, pocket, feedly, inaturalist, alltrails, openstreetmap, wikiloc, meetup, eventbrite
+
+**Education** : khan-academy
+
+**Commerce** : etsy, shopify
+
+---
+
+## 3. OAuth1 (3 plateformes) — non prioritaire
+
+`discogs`, `flickr`, `tumblr`
+
+OAuth1 est plus complexe (request token + verifier). **Recommendation : skip sauf demande specifique d'un user**. Ces plateformes ont peu d'impact pour un produit web3/dev.
+
+Si un jour on les fait, ajouter un flow separe `/oauth1/:platform/authorize` avec echange en 3 etapes.
+
+---
+
+## 4. Template a suivre pour chaque nouvelle plateforme OAuth2
+
+### Etape 1 — Creer l'app OAuth chez le provider
+
+| Provider | Dashboard | Redirect URI a configurer |
+|---|---|---|
+| Reddit | https://www.reddit.com/prefs/apps | `https://explorer.sofia.intuition.box/auth/callback` + `http://localhost:5173/auth/callback` |
+| Strava | https://www.strava.com/settings/api | idem |
+| Figma | https://www.figma.com/developers/apps | idem |
+| Hugging Face | https://huggingface.co/settings/applications/new | idem |
+| Unsplash | https://unsplash.com/oauth/applications | idem |
+| Vercel | https://vercel.com/account/tokens → OAuth | idem |
+| Product Hunt | https://api.producthunt.com/v2/oauth/applications | idem |
+| ORCID | https://orcid.org/developer-tools | idem |
+| ... | ... | idem |
+
+Noter CLIENT_ID + CLIENT_SECRET (sans les coller dans le chat).
+
+### Etape 2 — Ajouter env vars Phala
+
+Ajouter dans le dashboard Phala :
+```
+REDDIT_CLIENT_ID=xxx
+REDDIT_CLIENT_SECRET=xxx
+```
+
+### Etape 3 — Ajouter provider config
+
+Dans `core/sofia-mastra/src/mastra/oauth/config.ts` :
+
+```typescript
+export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
+  // existants (github, spotify, discord, twitch, youtube)
+  // ...
+
+  reddit: {
+    clientId: process.env.REDDIT_CLIENT_ID!,
+    clientSecret: process.env.REDDIT_CLIENT_SECRET!,
+    authUrl: 'https://www.reddit.com/api/v1/authorize',
+    tokenUrl: 'https://www.reddit.com/api/v1/access_token',
+    scopes: ['identity', 'read', 'mysubreddits'],
+    useBasicAuthHeader: true, // Reddit veut Basic auth
+    extraAuthParams: { duration: 'permanent' }, // pour refresh token
+  },
+
+  strava: {
+    clientId: process.env.STRAVA_CLIENT_ID!,
+    clientSecret: process.env.STRAVA_CLIENT_SECRET!,
+    authUrl: 'https://www.strava.com/oauth/authorize',
+    tokenUrl: 'https://www.strava.com/oauth/token',
+    scopes: ['read', 'activity:read'],
+  },
+
+  // ...
+}
+```
+
+### Etape 4 — Ajouter au `verifyAndGetUserId`
+
+Dans `core/sofia-mastra/src/mastra/oauth/verify.ts` :
+
+```typescript
+const OAUTH_ENDPOINTS = {
+  // existants...
+  reddit: {
+    url: 'https://oauth.reddit.com/api/v1/me',
+    authHeader: (token) => `Bearer ${token}`,
+    // Reddit requiert User-Agent
+    extraHeaders: { 'User-Agent': 'sofia-reputation/1.0' },
+  },
+  strava: {
+    url: 'https://www.strava.com/api/v3/athlete',
+    authHeader: (token) => `Bearer ${token}`,
+  },
+  // ...
+}
+
+// Ajouter la logique d'extraction du userId/username par plateforme :
+case 'reddit':
+  userId = data.id ? String(data.id) : undefined
+  username = data.name ? String(data.name) : undefined
+  break
+case 'strava':
+  userId = data.id ? String(data.id) : undefined
+  username = data.username ? String(data.username) : undefined
+  break
+```
+
+### Etape 5 — Creer le fetcher de metrics
+
+Dans `core/sofia-mastra/src/mastra/signals/reddit.ts` :
+
+```typescript
+export async function fetchRedditSignals(token: string): Promise<Record<string, number>> {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'sofia-reputation/1.0',
+  }
+
+  const [me, subs] = await Promise.all([
+    fetch('https://oauth.reddit.com/api/v1/me', { headers }).then(r => r.json()),
+    fetch('https://oauth.reddit.com/subreddits/mine/subscriber?limit=100', { headers }).then(r => r.json()),
+  ])
+
+  return {
+    comment_karma: me.comment_karma || 0,
+    link_karma: me.link_karma || 0,
+    subreddits_actifs: subs.data?.children?.length || 0,
+    anciennete_mois: monthsSince(new Date(me.created_utc * 1000)),
+  }
+}
+```
+
+Et register dans `signals/registry.ts` :
+
+```typescript
+import { fetchRedditSignals } from './reddit'
+
+export const SIGNAL_FETCHERS = {
+  // existants...
+  reddit: fetchRedditSignals,
+}
+```
+
+### Etape 6 — Ajouter au `METRIC_COMPONENTS` cote Explorer
+
+Dans `sofia-explorer/src/services/reputationScoreService.ts` :
+
+```typescript
+const METRIC_COMPONENTS = {
+  // existants...
+  reddit: {
+    comment_karma: 'community',
+    link_karma: 'community',
+    subreddits_actifs: 'community',
+    anciennete_mois: 'anciennete',
+  },
+}
+```
+
+### Etape 7 — Deploy
+
+1. Commit cote mastra
+2. Rebuild Docker image (nouveau tag)
+3. Push
+4. Phala Cloud dashboard → update tag + add env vars
+5. Redeploy
+
+### Etape 8 — Smoke test
+
+```bash
+# Connect depuis Explorer
+# Puis curl :
+curl -s -X POST "https://<phala>/api/workflows/signalFetcherWorkflow/start-async" \
+  -H "Content-Type: application/json" \
+  -d '{"inputData":{"platform":"reddit","walletAddress":"0x..."}}'
+# Verifier que metrics sont presentes
+```
+
+---
+
+## 5. Automatisation — ce qu'on peut industrialiser
+
+Apres quelques plateformes, on peut :
+
+1. **Generator de fetcher** — script qui prompte "platformId, authUrl, tokenUrl, scopes..." et genere la config + un fetcher skeleton
+2. **Fetcher template par pattern** — la plupart des fetchers suivent le meme pattern (GET /me + GET /stats). On peut avoir une factory `createSimpleFetcher({ profileEndpoint, metricsConfig })` pour reduire le boilerplate.
+3. **Script de scaffold** — `scripts/add-platform.ts reddit` qui fait toutes les etapes 3-6 automatiquement.
+
+---
+
+## 6. Planning estime
+
+| Phase | Plateformes | Effort par plateforme | Total |
+|---|---|---|---|
+| 1 (Quick Wins) | 7 | 1-2h chacune | 1-2 jours |
+| 2 (Domaines cles) | 7 | 2-3h (API plus complexes) | 2 jours |
+| 3 (Web3) | 1 OAuth + reste non-OAuth | 1h chacune | 0.5 jour |
+| 4 (Difficile) | 4 | 3-4h | 1-2 jours |
+| 5 (Partenariats) | 2 | Variable (attente externe) | — |
+| 6 (Residuel) | 65 | 1h chacune avec script | 5-7 jours |
+
+**Total MVP etendu (Phases 1-3)** : ~5 jours de travail concentre.
+
+---
+
+## 7. Quirks notables par provider
+
+- **Reddit** : Basic auth header pour l'exchange, User-Agent obligatoire partout, `duration=permanent` pour obtenir un refresh token
+- **Strava** : refresh token expire tous les 6 mois, il faut retester regulierement
+- **ORCID** : token permanent, pas de refresh necessaire
+- **Steam** : pas OAuth2 classique — utilise OpenID 2.0 (different flow)
+- **Mastodon** : federalise, chaque instance a son propre OAuth — probleme de config (pas 1 seule `authUrl`)
+- **Hugging Face** : token personnel (PAT) fonctionne aussi, pas obligatoirement OAuth
+- **LinkedIn** : acces tres restrictif, scope `r_basicprofile` deprecated
+- **Instagram/Facebook/TikTok** : Meta/Instagram Graph API demande une review Facebook, process long
+
+---
+
+## 8. Ce qui bloque certaines plateformes
+
+| Plateforme | Blocker | Workaround |
+|---|---|---|
+| Steam | OpenID 2.0 | Implementer OpenID separement |
+| Mastodon | Instance-specific | Permettre au user de choisir son instance, ou federer via une passerelle |
+| Duolingo | Pas d'OAuth officiel | API non-officielle via `www.duolingo.com/api/1/users/show` avec sessionid |
+| Facebook/Instagram/TikTok | App review Meta | Attendre approbation ou passer via API publique limitee |
+| Blizzard, Riot | Partenariat requis | Skip pour MVP |
+
+---
+
+## 9. Decision — comment avancer
+
+**Recommendation** :
+
+1. **Faire Phase 1** (7 OAuth + chess.com en public = 8 plateformes) — a peu de jours de travail
+2. **Tester l'impact** sur le scoring (regarder si les scores sont plus diversifies)
+3. **Faire Phase 2** si Phase 1 montre de la valeur
+4. **Automatiser** avant Phase 6 (script de scaffold)
+5. **Skip** Phases 4/5 jusqu'a besoin utilisateur concret
+
+Phase 3 est couvert dans `plan-non-oauth-platforms.md`.

--- a/services/mastra/docs/plan-oauth-routes.md
+++ b/services/mastra/docs/plan-oauth-routes.md
@@ -1,0 +1,819 @@
+# Plan d'implementation — Routes OAuth dans sofia-mastra
+
+> Date : 16 avril 2026
+> Cible : `core/sofia-mastra/`
+> Deploiement : Phala Cloud TEE
+> Consumer : Sofia Explorer (frontend React)
+
+---
+
+## 1. Pourquoi on fait ca
+
+L'Explorer a des boutons "Connect" pour chaque plateforme (Spotify, YouTube, Discord, etc.).
+Le flow OAuth2 necessite un serveur pour :
+1. **Redirect** : construire l'URL OAuth du provider avec le `client_id`
+2. **Exchange** : echanger le `code` d'autorisation contre un `access_token` (necessite `client_secret`)
+3. **Store** : stocker le token chiffre pour les signal fetchers
+
+Le frontend ne peut PAS faire l'exchange lui-meme car le `client_secret` ne doit jamais etre
+expose dans le JS bundle.
+
+Actuellement, le frontend appelle `${MASTRA_URL}/api/oauth/spotify/authorize` → 404 car ces
+routes n'existent pas encore dans mastra.
+
+---
+
+## 2. Ce qui existe deja — IMPORTANT a comprendre
+
+### Cote Explorer (frontend) — TOUT le flow est code
+
+**`src/services/oauthService.ts`** (verifie par agent explorer) :
+
+1. `startOAuthFlow(platformId)` :
+   - Genere un `state` CSRF
+   - Ouvre un popup vers `${MASTRA_URL}/api/oauth/${platformId}/authorize?redirect_uri=...&state=...`
+   - Ecoute les `postMessage` depuis le popup (type: 'oauth_callback')
+   - Retourne le `code` d'autorisation
+
+2. `OAuthCallbackPage.tsx` (route `/auth/callback`) :
+   - Extrait `code`, `state`, `error` des query params
+   - `window.opener.postMessage({ type: 'oauth_callback', code, state, error })`
+   - Affiche "Connecting... you can close this window"
+
+3. `exchangeOAuthCode(platformId, code)` :
+   - POST vers `${MASTRA_URL}/api/oauth/${platformId}/callback`
+   - Body : `{ code, redirectUri }`
+   - Recoit `{ success, userId, username }`
+
+4. `linkPlatformToWallet(walletAddress, platformId, oauthToken)` :
+   - POST vers `${MASTRA_URL}/api/workflows/linkSocialWorkflow/start-async`
+   - Cree le triple on-chain
+
+**`src/config/platformCatalog.ts`** — contient deja les URLs OAuth par plateforme :
+
+| Plateforme | authUrl | tokenUrl | scopes |
+|---|---|---|---|
+| YouTube | `https://accounts.google.com/o/oauth2/v2/auth` | `https://oauth2.googleapis.com/token` | `youtube.readonly` |
+| Spotify | `https://accounts.spotify.com/authorize` | `https://accounts.spotify.com/api/token` | `user-read-private, user-top-read, user-follow-read, playlist-read-private` |
+| Discord | `https://discord.com/api/oauth2/authorize` | `https://discord.com/api/oauth2/token` | `identify, guilds` |
+| Twitch | `https://id.twitch.tv/oauth2/authorize` | `https://id.twitch.tv/oauth2/token` | `user:read:follows` |
+| GitHub | non defini (utilise les defaults GitHub) | non defini | `read:user, repo` |
+
+### Cote Mastra (backend) — DEJA implemente (verifie par agent)
+
+**Token storage** :
+- `db/tokens.ts` : chiffrement AES-256-GCM, table `oauth_tokens`, fonctions
+  `storeToken(walletAddress, platform, accessToken, refreshToken?, userId?, username?, expiresAt?)`
+  et `getToken(walletAddress, platform)`
+- `TOKEN_ENCRYPTION_KEY` definie en env var
+- `initTokenTable()` appele au demarrage dans `index.ts`
+
+**Workflows** :
+- `link-social-workflow.ts` : appelle deja `storeToken()` apres verification OAuth.
+  Contient `verifyAndGetUserId(platform, token, clientId?)` qui appelle l'API du provider pour
+  extraire `{ userId, username }`
+- `signal-fetcher-workflow.ts` : lit les tokens via `getToken()` et appelle les fetchers
+
+### Ce qui MANQUE
+
+Les routes HTTP `/api/oauth/{platform}/authorize` et `/api/oauth/{platform}/callback`
+n'existent pas dans mastra. **C'est le seul maillon manquant.**
+
+---
+
+## 3. Contrainte Mastra : pas de routes `/api/*`
+
+Verifie directement dans le code source `@mastra/core/dist/server/index.js` :
+
+```
+Error: MASTRA_SERVER_API_PATH_RESERVED
+Path must not start with "/api", it's reserved for internal API routes
+```
+
+Le prefixe `/api` est reserve pour les routes auto-generees (`/api/workflows/*`, `/api/agents/*`).
+Les routes custom doivent utiliser un prefixe different.
+
+**Decision : utiliser `/oauth/*`** au lieu de `/api/oauth/*`.
+
+Impact cote Explorer : une seule modification dans `oauthService.ts` pour changer le prefixe
+des 2 endpoints appeles.
+
+---
+
+## 4. API Mastra pour routes custom
+
+Verifie dans `@mastra/core/dist/server/index.d.ts` (source de verite) :
+
+```typescript
+import { registerApiRoute } from '@mastra/core/server'
+
+registerApiRoute('/path/:param', {
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'ALL',
+  handler: (c: Context) => c.json({ ... }),  // Hono Context
+  middleware?: MiddlewareHandler | MiddlewareHandler[],
+  requiresAuth?: boolean,  // default true
+})
+```
+
+Le handler recoit un **Context Hono standard** : `c.req.param()`, `c.req.query()`,
+`c.req.json()`, `c.json()`, `c.redirect()`.
+
+Les routes sont enregistrees via `server.apiRoutes` dans la config Mastra :
+
+```typescript
+new Mastra({
+  workflows: { ... },
+  server: {
+    apiRoutes: [
+      registerApiRoute('/oauth/:platform/authorize', { method: 'GET', handler: ... }),
+      registerApiRoute('/oauth/:platform/callback', { method: 'POST', handler: ... }),
+    ]
+  }
+})
+```
+
+---
+
+## 5. Architecture des routes
+
+### Routes a creer
+
+```
+GET  /oauth/:platform/authorize    → 302 Redirect vers le provider OAuth
+POST /oauth/:platform/callback     → Exchange code contre token, stocke le token
+```
+
+### Flow detaille
+
+#### GET /oauth/:platform/authorize
+
+```
+Input (query params) :
+  redirect_uri : URL de callback du frontend (ex: http://localhost:5173/auth/callback)
+  state        : Token CSRF genere par le frontend
+
+Steps :
+  1. Lire platform depuis c.req.param('platform')
+  2. Lire redirect_uri et state depuis c.req.query()
+  3. Chercher la config OAuth du provider dans OAUTH_PROVIDERS[platform]
+  4. Si provider inconnu → return 404 { error: 'unsupported_platform' }
+  5. Construire l'URL d'autorisation du provider :
+
+     https://accounts.spotify.com/authorize?
+       client_id=<SPOTIFY_CLIENT_ID>
+       &response_type=code
+       &redirect_uri=<redirect_uri>
+       &scope=<scopes joined>
+       &state=<state>
+       &<...extraAuthParams>
+
+  6. return c.redirect(authorizeUrl, 302)
+```
+
+Note : le **redirect_uri** passe au provider DOIT correspondre EXACTEMENT a celui configure
+dans le dashboard du provider, sinon echec de l'exchange a l'etape callback.
+
+#### POST /oauth/:platform/callback
+
+```
+Input (JSON body) :
+  code         : Code d'autorisation recu du provider
+  redirectUri  : Le meme redirect_uri qu'a l'authorize (requis par certains providers)
+
+Steps :
+  1. Lire platform depuis c.req.param('platform')
+  2. Lire { code, redirectUri } depuis c.req.json()
+  3. Chercher la config OAuth du provider
+  4. Construire la requete d'echange selon les quirks du provider (voir section 7)
+  5. POST <tokenUrl> → recevoir { access_token, refresh_token?, expires_in?, token_type }
+  6. Si erreur → return 400 { error: 'exchange_failed', details }
+  7. Verifier le token en appelant l'API du provider via verifyAndGetUserId()
+     → extrait { userId, username }
+  8. Si pas de walletAddress dans la requete, on ne peut pas storeToken (la requete vient
+     du popup OAuth, on n'a pas encore le wallet).
+     → Retourner le token au frontend qui appellera linkSocialWorkflow
+     → OU : faire le storeToken + linkSocialWorkflow ici (a decider — voir section 6)
+
+  9. return c.json({ success: true, platformId, userId, username, accessToken, refreshToken? })
+```
+
+---
+
+## 6. Decision critique : quand/ou stocker le token ?
+
+Il y a 2 approches possibles :
+
+### Approche A : Token retourne au frontend, storeToken via linkSocialWorkflow
+
+```
+1. GET /oauth/spotify/authorize → redirect provider
+2. Provider redirect → /auth/callback → postMessage code au parent
+3. Frontend POST /oauth/spotify/callback { code, redirectUri }
+   → Backend echange code contre token
+   → Backend retourne { accessToken, refreshToken, userId, username } au frontend
+4. Frontend POST /api/workflows/linkSocialWorkflow/start-async
+   { walletAddress, platform, oauthToken: accessToken, refreshToken }
+   → Workflow appelle storeToken() + cree le triple on-chain
+```
+
+**Avantages** : separation claire des responsabilites, le token passe par le frontend mais
+dans un fetch local (pas expose). Cohorent avec le code actuel.
+
+**Inconvenients** : le token transite temporairement par le frontend. Dans un XSS il serait
+exposable. Mais il est deja passe au postMessage et au exchangeOAuthCode.
+
+### Approche B : Backend fait tout (exchange + store + triple)
+
+```
+1. GET /oauth/spotify/authorize → redirect provider
+2. Provider redirect → /auth/callback → postMessage code + walletAddress au parent
+3. Frontend POST /oauth/spotify/callback { code, redirectUri, walletAddress }
+   → Backend echange code, verifie, storeToken, cree le triple on-chain
+   → Backend retourne { success, userId, username, txHash }
+```
+
+**Avantages** : token ne transite jamais par le frontend. Un seul aller-retour.
+
+**Inconvenients** : le backend fait l'on-chain → tx qui peut echouer. Si elle echoue, le token
+est quand meme stocke (ce qui est OK car reutilisable pour retry).
+
+### Decision recommandee : **Approche A** (plus simple, cohorent avec existant)
+
+Raison : le code de `linkSocialWorkflow` est deja deploye et teste. Il stocke le token ET
+cree le triple. On ne duplique pas cette logique.
+
+Le flow devient :
+```
+1. startOAuthFlow → GET /oauth/spotify/authorize → redirect
+2. callback → exchangeOAuthCode(POST /oauth/spotify/callback) → { accessToken, userId }
+3. linkPlatformToWallet → POST /api/workflows/linkSocialWorkflow/start-async → store + triple
+```
+
+La route `/oauth/:platform/callback` ne fait QUE l'echange et la verification du token.
+Elle retourne le token au frontend qui le passe au linkSocialWorkflow existant.
+
+---
+
+## 7. Config OAuth par plateforme
+
+### Structure
+
+```typescript
+// src/mastra/oauth/config.ts
+
+export interface OAuthProviderConfig {
+  clientId: string
+  clientSecret: string
+  authUrl: string
+  tokenUrl: string
+  scopes: string[]
+  /** Extra params for the authorize URL (ex: Google needs access_type=offline) */
+  extraAuthParams?: Record<string, string>
+  /** Token exchange headers override */
+  tokenRequestHeaders?: Record<string, string>
+  /** Use Basic auth header instead of client_secret in body (Spotify) */
+  useBasicAuthHeader?: boolean
+}
+
+export function getOAuthProvider(platform: string): OAuthProviderConfig | null {
+  return OAUTH_PROVIDERS[platform] ?? null
+}
+```
+
+### Config des 5 plateformes
+
+```typescript
+export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
+  youtube: {
+    clientId: process.env.YOUTUBE_CLIENT_ID!,
+    clientSecret: process.env.YOUTUBE_CLIENT_SECRET!,
+    authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
+    scopes: ['https://www.googleapis.com/auth/youtube.readonly'],
+    extraAuthParams: {
+      access_type: 'offline',      // Necessaire pour obtenir un refresh_token
+      prompt: 'consent',            // Force le consentement pour le refresh_token
+    },
+  },
+  spotify: {
+    clientId: process.env.SPOTIFY_CLIENT_ID!,
+    clientSecret: process.env.SPOTIFY_CLIENT_SECRET!,
+    authUrl: 'https://accounts.spotify.com/authorize',
+    tokenUrl: 'https://accounts.spotify.com/api/token',
+    scopes: ['user-read-private', 'user-top-read', 'user-follow-read', 'playlist-read-private'],
+    useBasicAuthHeader: true,       // Spotify veut Authorization: Basic base64(id:secret)
+  },
+  discord: {
+    clientId: process.env.DISCORD_CLIENT_ID!,
+    clientSecret: process.env.DISCORD_CLIENT_SECRET!,
+    authUrl: 'https://discord.com/api/oauth2/authorize',
+    tokenUrl: 'https://discord.com/api/oauth2/token',
+    scopes: ['identify', 'guilds'],
+  },
+  twitch: {
+    clientId: process.env.TWITCH_CLIENT_ID!,
+    clientSecret: process.env.TWITCH_CLIENT_SECRET!,
+    authUrl: 'https://id.twitch.tv/oauth2/authorize',
+    tokenUrl: 'https://id.twitch.tv/oauth2/token',
+    scopes: ['user:read:follows'],
+  },
+  github: {
+    clientId: process.env.GITHUB_CLIENT_ID!,
+    clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+    authUrl: 'https://github.com/login/oauth/authorize',
+    tokenUrl: 'https://github.com/login/oauth/access_token',
+    scopes: ['read:user', 'repo'],
+    tokenRequestHeaders: {
+      Accept: 'application/json',   // Force GitHub a retourner du JSON
+    },
+  },
+}
+```
+
+### Quirks par provider — details critiques
+
+**YouTube (Google)** :
+- `access_type=offline` + `prompt=consent` → pour obtenir un `refresh_token`
+- Sans ces params, Google ne retourne QUE un access_token qui expire en 1h sans possibilite
+  de refresh. Les signal fetchers ne marcheront plus apres 1h.
+
+**Spotify** :
+- L'exchange veut un header `Authorization: Basic base64(clientId:clientSecret)` au lieu
+  d'inclure clientId/clientSecret dans le body.
+- access_token expire en 1h, refresh_token est permanent.
+
+**Discord** :
+- Standard, aucun quirk.
+- access_token expire en 7 jours.
+
+**Twitch** :
+- `TWITCH_CLIENT_ID` est deja en env var (utilise par le verifier).
+- Ajouter `TWITCH_CLIENT_SECRET`.
+- access_token expire en ~4h.
+
+**GitHub** :
+- Retourne du `application/x-www-form-urlencoded` par defaut.
+- Ajouter `Accept: application/json` dans le header pour avoir du JSON.
+- access_token permanent (pas d'expiration).
+
+---
+
+## 8. Verification du token (userId extraction)
+
+La fonction `verifyAndGetUserId()` existe deja dans `link-social-workflow.ts` (lignes ~140-220).
+Elle :
+1. Appelle l'API du provider avec le token
+2. Parse la reponse selon le format de chaque provider
+3. Extrait `{ userId, username }`
+
+**Action** : extraire cette fonction dans `src/mastra/oauth/verify.ts` pour pouvoir la
+reutiliser depuis les routes OAuth sans duplication.
+
+```typescript
+// src/mastra/oauth/verify.ts
+export type Platform = 'discord' | 'youtube' | 'spotify' | 'twitch' | 'twitter' | 'github'
+
+export interface OAuthVerificationResult {
+  valid: boolean
+  userId?: string
+  username?: string
+  error?: string
+}
+
+export async function verifyAndGetUserId(
+  platform: Platform,
+  token: string,
+  clientId?: string,
+): Promise<OAuthVerificationResult> {
+  // Logique actuelle de link-social-workflow.ts
+  // Ajouter le support GitHub (actuellement pas dans OAUTH_ENDPOINTS)
+}
+```
+
+**Ajout GitHub** : la fonction actuelle ne supporte pas GitHub. Ajouter :
+```typescript
+github: {
+  url: 'https://api.github.com/user',
+  authHeader: (token) => `Bearer ${token}`,
+},
+// Extraction :
+case 'github':
+  userId = data.id ? String(data.id) : undefined
+  username = data.login ? String(data.login) : undefined
+  break
+```
+
+---
+
+## 9. Logique d'echange code → token
+
+```typescript
+// src/mastra/oauth/exchange.ts
+
+import { getOAuthProvider } from './config'
+
+export interface TokenExchangeResult {
+  accessToken: string
+  refreshToken?: string
+  expiresIn?: number
+  tokenType?: string
+}
+
+export async function exchangeCodeForToken(
+  platform: string,
+  code: string,
+  redirectUri: string,
+): Promise<TokenExchangeResult> {
+  const provider = getOAuthProvider(platform)
+  if (!provider) {
+    throw new Error(`unsupported_platform: ${platform}`)
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+  })
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    ...provider.tokenRequestHeaders,
+  }
+
+  if (provider.useBasicAuthHeader) {
+    // Spotify : Authorization: Basic base64(clientId:clientSecret)
+    const basic = Buffer.from(`${provider.clientId}:${provider.clientSecret}`).toString('base64')
+    headers.Authorization = `Basic ${basic}`
+  } else {
+    // Standard : clientId + clientSecret dans le body
+    body.append('client_id', provider.clientId)
+    body.append('client_secret', provider.clientSecret)
+  }
+
+  const res = await fetch(provider.tokenUrl, {
+    method: 'POST',
+    headers,
+    body,
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`token_exchange_failed: ${res.status} ${text}`)
+  }
+
+  const data = await res.json()
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresIn: data.expires_in,
+    tokenType: data.token_type,
+  }
+}
+```
+
+---
+
+## 10. Les routes
+
+```typescript
+// src/mastra/oauth/routes.ts
+
+import { registerApiRoute } from '@mastra/core/server'
+import { getOAuthProvider } from './config'
+import { exchangeCodeForToken } from './exchange'
+import { verifyAndGetUserId } from './verify'
+
+export const oauthRoutes = [
+  registerApiRoute('/oauth/:platform/authorize', {
+    method: 'GET',
+    requiresAuth: false,
+    handler: async (c) => {
+      const platform = c.req.param('platform')
+      const redirectUri = c.req.query('redirect_uri')
+      const state = c.req.query('state')
+
+      if (!redirectUri || !state) {
+        return c.json({ error: 'missing_params' }, 400)
+      }
+
+      const provider = getOAuthProvider(platform)
+      if (!provider) {
+        return c.json({ error: 'unsupported_platform' }, 404)
+      }
+
+      const params = new URLSearchParams({
+        client_id: provider.clientId,
+        response_type: 'code',
+        redirect_uri: redirectUri,
+        scope: provider.scopes.join(' '),
+        state,
+        ...provider.extraAuthParams,
+      })
+
+      return c.redirect(`${provider.authUrl}?${params.toString()}`, 302)
+    },
+  }),
+
+  registerApiRoute('/oauth/:platform/callback', {
+    method: 'POST',
+    requiresAuth: false,
+    handler: async (c) => {
+      const platform = c.req.param('platform')
+      const { code, redirectUri } = await c.req.json()
+
+      if (!code || !redirectUri) {
+        return c.json({ success: false, error: 'missing_params' }, 400)
+      }
+
+      try {
+        // 1. Exchange code for token
+        const tokens = await exchangeCodeForToken(platform, code, redirectUri)
+
+        // 2. Verify token + extract userId
+        const verification = await verifyAndGetUserId(
+          platform as Platform,
+          tokens.accessToken,
+        )
+
+        if (!verification.valid) {
+          return c.json({
+            success: false,
+            platformId: platform,
+            error: verification.error || 'verification_failed',
+          }, 400)
+        }
+
+        // 3. Return token + userId to frontend (frontend will call linkSocialWorkflow)
+        return c.json({
+          success: true,
+          platformId: platform,
+          userId: verification.userId,
+          username: verification.username,
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          expiresIn: tokens.expiresIn,
+        })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return c.json({
+          success: false,
+          platformId: platform,
+          error: message,
+        }, 500)
+      }
+    },
+  }),
+]
+```
+
+---
+
+## 11. Modifications necessaires
+
+### Fichiers a creer (mastra)
+
+```
+src/mastra/oauth/
+├── config.ts       ← OAUTH_PROVIDERS map + getOAuthProvider()
+├── verify.ts       ← verifyAndGetUserId() (extrait de link-social-workflow.ts)
+├── exchange.ts     ← exchangeCodeForToken() avec gestion des quirks
+└── routes.ts       ← Les 2 routes registerApiRoute
+```
+
+### Fichiers a modifier (mastra)
+
+**`src/mastra/index.ts`** :
+
+```typescript
+import { oauthRoutes } from './oauth/routes'
+// ... existing imports
+
+export const mastra = new Mastra({
+  workflows: { ... },
+  agents: { ... },
+  storage: ...,
+  logger: ...,
+  server: {                    // ← NOUVEAU
+    apiRoutes: oauthRoutes,
+  },
+})
+```
+
+**`src/mastra/workflows/link-social-workflow.ts`** :
+- Extraire `verifyAndGetUserId` vers `oauth/verify.ts`
+- Importer depuis la au lieu de le redefinir
+
+### Fichier a modifier (Explorer)
+
+**`src/services/oauthService.ts`** :
+
+```diff
+- const url = `${MASTRA_URL}/api/oauth/${platformId}/authorize?${params}`
++ const url = `${MASTRA_URL}/oauth/${platformId}/authorize?${params}`
+
+- const response = await fetch(`${MASTRA_URL}/api/oauth/${platformId}/callback`, {
++ const response = await fetch(`${MASTRA_URL}/oauth/${platformId}/callback`, {
+```
+
+Mettre a jour aussi le commentaire au debut du fichier :
+```diff
+- * through sofia-mastra backend at MASTRA_URL/api/oauth/*
++ * through sofia-mastra backend at MASTRA_URL/oauth/*
+```
+
+Le `linkPlatformToWallet` garde `${MASTRA_URL}/api/workflows/linkSocialWorkflow/start-async`
+(route auto-generee, prefixe `/api` ok).
+
+---
+
+## 12. Env vars a ajouter
+
+### .env local (pour dev)
+
+```
+# OAuth Client Credentials
+YOUTUBE_CLIENT_ID=xxx
+YOUTUBE_CLIENT_SECRET=xxx
+SPOTIFY_CLIENT_ID=xxx
+SPOTIFY_CLIENT_SECRET=xxx
+DISCORD_CLIENT_ID=xxx
+DISCORD_CLIENT_SECRET=xxx
+TWITCH_CLIENT_SECRET=xxx    # TWITCH_CLIENT_ID existe deja
+GITHUB_CLIENT_ID=xxx
+GITHUB_CLIENT_SECRET=xxx
+```
+
+### Phala Cloud dashboard
+
+Ajouter les memes variables en production.
+
+### Comment obtenir les credentials
+
+| Provider | Dashboard | Redirect URI a configurer |
+|---|---|---|
+| YouTube | https://console.cloud.google.com/apis/credentials | Les deux : `http://localhost:5173/auth/callback` ET `https://0xsofia.com/auth/callback` |
+| Spotify | https://developer.spotify.com/dashboard | Les deux |
+| Discord | https://discord.com/developers/applications | Les deux |
+| Twitch | https://dev.twitch.tv/console/apps | Les deux |
+| GitHub | https://github.com/settings/developers | Les deux |
+
+Chaque provider permet d'enregistrer plusieurs redirect URIs. Enregistrer les 2 (dev + prod).
+
+---
+
+## 13. Planning
+
+| Jour | Tache | Livrable |
+|---|---|---|
+| **J1 matin** | Creer les 5 OAuth apps + obtenir clientId/clientSecret | Credentials dans .env |
+| **J1 apres-midi** | `oauth/config.ts` + `oauth/verify.ts` (extrait de link-social-workflow) | Config testable, verify reutilisable |
+| **J2 matin** | `oauth/exchange.ts` avec gestion des quirks par provider | Exchange testable en isolation |
+| **J2 apres-midi** | `oauth/routes.ts` + modifier `index.ts` | Routes montees et accessibles |
+| **J3 matin** | Modifier Explorer `oauthService.ts` (prefixe `/oauth`) | Frontend branche sur nouveau endpoint |
+| **J3 apres-midi** | Test E2E : connecter Spotify depuis Explorer dev local | Flow complet marche |
+| **J4** | Tester les 5 plateformes + fix quirks + rebuild Docker + deploy Phala | Tout live en prod |
+
+---
+
+## 14. Tests de verification
+
+### Test 1 — Route authorize (curl)
+
+```bash
+curl -I "http://localhost:4111/oauth/spotify/authorize?redirect_uri=http://localhost:5173/auth/callback&state=test123"
+
+# Attendu :
+# HTTP/1.1 302 Found
+# Location: https://accounts.spotify.com/authorize?client_id=xxx&response_type=code&...
+```
+
+### Test 2 — Route callback (curl, avec un vrai code)
+
+```bash
+# D'abord obtenir un code en completant le flow dans le browser
+curl -X POST http://localhost:4111/oauth/spotify/callback \
+  -H "Content-Type: application/json" \
+  -d '{"code":"AQD...", "redirectUri":"http://localhost:5173/auth/callback"}'
+
+# Attendu :
+# { "success": true, "platformId": "spotify", "userId": "xxx", "username": "xxx",
+#   "accessToken": "BQD...", "refreshToken": "AQD...", "expiresIn": 3600 }
+```
+
+### Test 3 — Flow complet dans l'Explorer
+
+```
+1. Ouvrir http://localhost:5173 (Explorer en dev)
+2. Se connecter avec Privy
+3. Aller sur Profile → Platforms (ou Interest page avec topic)
+4. Cliquer sur "Connect" pour Spotify
+5. Popup s'ouvre vers Spotify
+6. Autoriser
+7. Popup se ferme, statut Spotify passe a "Connected"
+8. Le token est stocke en DB mastra
+9. Le Triple on-chain est cree
+10. Aller sur Profile → le score reputation utilise les metriques Spotify reelles
+```
+
+### Test 4 — Token persiste et utilisable par signal fetcher
+
+```bash
+curl -X POST http://localhost:4111/api/workflows/signalFetcherWorkflow/start-async \
+  -H "Content-Type: application/json" \
+  -d '{"inputData":{"platform":"spotify","walletAddress":"0x..."}}'
+
+# Attendu :
+# {
+#   "result": {
+#     "success": true,
+#     "platformId": "spotify",
+#     "fetchedAt": 1776...,
+#     "metrics": {
+#       "diversite_genres": 12,
+#       "playlists_creees": 5,
+#       "top_artists_count": 50
+#     }
+#   }
+# }
+```
+
+---
+
+## 15. Gestion des erreurs
+
+| Scenario | Comportement attendu |
+|---|---|
+| Platform inconnue dans le redirect | 404 `{ error: 'unsupported_platform' }` |
+| Credentials manquants (env var) | 500 `{ error: 'missing_credentials' }` au moment de l'exchange |
+| Code d'authorization invalide | 400 `{ error: 'token_exchange_failed', details }` |
+| Token retourne mais API provider rejette | 400 `{ error: 'verification_failed' }` |
+| Rate limit sur provider | 500 avec message du provider |
+| Refresh token manquant (pour YouTube notamment) | OK mais warning log — le user devra reconnecter dans 1h |
+
+---
+
+## 16. Securite
+
+- `client_secret` **jamais** expose au frontend → uniquement en env var cote mastra
+- Tokens chiffres AES-256-GCM **avant** stockage en DB via storeToken() existant
+- State CSRF valide cote frontend (sessionStorage) — pas de validation cote backend
+  (le frontend est le seul a connaitre le state, on ne peut pas le valider cote backend)
+- Redirect URI valide cote provider (whitelist sur chaque dashboard)
+- Routes OAuth avec `requiresAuth: false` car le user n'est pas encore authentifie au moment
+  du redirect (c'est le but du flow OAuth)
+- Le callback verifie le token en appelant l'API du provider avant de le retourner au frontend
+- Tokens transitent en HTTPS uniquement (TEE Phala = HTTPS par defaut)
+
+---
+
+## 17. Apres le MVP — Phase V2
+
+Choses a ajouter **apres** que les 5 plateformes marchent :
+
+1. **Refresh token automatique** : job periodique qui refresh les tokens avant expiration
+2. **Revocation** : endpoint pour deconnecter une plateforme (DELETE /oauth/:platform)
+3. **Gestion multi-device** : aujourd'hui un token par (wallet, platform) → si le user se
+   connecte depuis 2 devices, le dernier ecrase
+4. **Audit log** : tracer les connexions/deconnexions pour debug
+5. **Plateformes supplementaires** : Reddit, Strava, chess.com, ORCID (Phase 1 du signalMatrix)
+
+---
+
+## 18. Deploiement Phala
+
+### Process
+
+```bash
+# 1. Implementation terminee, test local OK
+cd core/sofia-mastra && pnpm run dev
+# → curl test des routes /oauth/*
+
+# 2. Build Docker depuis core/
+cd core/
+docker build -f sofia-mastra/phala-deploy/Dockerfile -t maximesaintjoannis/sofia-mastra:v1.6.0 .
+
+# 3. Push
+docker push maximesaintjoannis/sofia-mastra:v1.6.0
+
+# 4. Phala Cloud dashboard :
+#    - Mettre a jour tag image → v1.6.0
+#    - Ajouter les 9 nouvelles env vars (CLIENT_ID/SECRET pour 5 providers)
+#    - Redeployer (volume /dstack/data persiste → tokens existants gardes)
+
+# 5. Verifier
+curl -I https://<phala-url>/oauth/spotify/authorize?redirect_uri=https://0xsofia.com/auth/callback&state=test
+# → Doit retourner 302 vers Spotify
+```
+
+### Impact ressources Phala — **negligeable**
+
+| Metrique | Impact |
+|---|---|
+| CPU | 0 au repos, ~50ms par connexion OAuth (1 fetch HTTP) |
+| RAM | ~0 MB (handlers dans le meme process Hono) |
+| Disque | ~1 KB par token stocke en SQLite |
+| Reseau | 1 requete HTTP sortante par connexion |
+| Nouveau process | **Aucun** |
+
+Les routes OAuth sont des handlers HTTP legers dans le serveur Hono qui tourne deja.
+Pas de nouveau service, pas de nouveau port. Moins consommateur qu'un workflow Mastra.

--- a/services/mastra/docs/plan-signal-fetchers.md
+++ b/services/mastra/docs/plan-signal-fetchers.md
@@ -1,0 +1,670 @@
+# Signal Fetchers — Plan d'implementation complet
+
+> Date : 16 avril 2026
+> Repo cible : `core/sofia-mastra/`
+> Deploiement : Phala Cloud TEE (image Docker `maximesaintjoannis/sofia-mastra`)
+> Consumer : Sofia Explorer (React frontend, repo separe `sofia-explorer/`)
+
+---
+
+## 1. Pourquoi on fait ca — le probleme
+
+### Scoring actuel (Explorer)
+
+L'Explorer a un systeme de reputation par topic (tech-dev, music, web3, etc.).
+Le score d'un user est calcule dans `sofia-explorer/src/services/reputationScoreService.ts` :
+
+```typescript
+const POINTS_PER_PLATFORM = 10
+// Score = nombre de plateformes connectees × 10 + bonus EthCC + trust boost
+```
+
+**C'est un compteur, pas un score de reputation.** Un user qui connecte GitHub avec 0 commit
+a le meme score qu'un dev avec 5 ans de contributions.
+
+### Ce qui existe mais n'est pas utilise
+
+L'Explorer a 50 formules de scoring detaillees dans `sofia-explorer/src/config/signalMatrix.ts`
+qui prennent en compte des metriques reelles (commits, followers, stream hours, etc.).
+Mais AUCUN code ne fetch ces metriques depuis les APIs des plateformes.
+
+### Le but final
+
+Quand un user connecte GitHub, on veut :
+1. Verifier son token (ca existe deja : `linkSocialWorkflow`)
+2. **NOUVEAU : Stocker son token de maniere chiffree**
+3. **NOUVEAU : Fetcher ses metriques reelles** (commits, repos, stars, streak)
+4. L'Explorer applique les formules du signalMatrix pour calculer un vrai score
+
+---
+
+## 2. Architecture globale
+
+```
+Sofia Explorer (React, port 5173)          sofia-mastra (Mastra, port 4111)
+─────────────────────────────────          ─────────────────────────────────
+
+CONNEXION (existe deja) :
+  User clique "Connect GitHub"
+    → OAuth popup
+    → Explorer recoit le code
+    → Explorer appelle linkSocialWorkflow
+      avec { walletAddress, platform, oauthToken }
+    → Mastra verifie le token, cree le triple on-chain
+    → NOUVEAU : Mastra stocke le token chiffre en DB
+
+SCORING (nouveau) :
+  User ouvre son dashboard
+    → Explorer appelle signalFetcherWorkflow
+      avec { platform: "github", walletAddress: "0x..." }
+    → Mastra lit le token chiffre en DB
+    → Mastra appelle GitHub API avec le token
+    → Mastra retourne les metriques brutes
+    → Explorer applique les formules du signalMatrix
+    → Score reel affiche
+```
+
+### Pourquoi les fetchers sont dans Mastra (pas dans l'Explorer)
+
+1. **Les tokens OAuth sont des secrets** — ils ne doivent jamais transiter par le frontend
+2. **Rate limits** — les appels API doivent etre server-side avec cache
+3. **Mastra gere deja les tokens** — `linkSocialWorkflow` recoit le token pour verification
+4. **Phala TEE** — les tokens sont stockes dans un environnement securise hardware
+
+---
+
+## 3. Ce qui existe dans sofia-mastra
+
+### Workflows existants
+
+| Workflow | Fichier | Input | Ce qu'il fait |
+|---|---|---|---|
+| `linkSocialWorkflow` | `workflows/link-social-workflow.ts` | `{walletAddress, platform, oauthToken}` | Verifie le token OAuth, extrait userId/username, cree le triple on-chain `[wallet] [has verified {platform} id] [userId]` |
+| `socialVerifierWorkflow` | `workflows/social-verifier-workflow.ts` | `{walletAddress, tokens: {youtube?, spotify?, discord?, twitch?, twitter?}}` | Verifie 5 tokens en parallele, cree triple attestation si 4/5+ valides |
+
+### Comment l'Explorer appelle les workflows
+
+```typescript
+// Dans sofia-explorer/src/services/oauthService.ts :
+const MASTRA_URL = import.meta.env.VITE_MASTRA_URL || 'http://localhost:4111'
+
+// Appel au workflow :
+fetch(`${MASTRA_URL}/api/workflows/linkSocialWorkflow/start-async`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    inputData: { walletAddress, platform, oauthToken }
+  })
+})
+
+// Mastra retourne automatiquement :
+// { result: { steps: { 'step-id': { output: {...} } } } }
+```
+
+### Plateformes supportees pour la verification OAuth
+
+Le `linkSocialWorkflow` sait verifier : **YouTube, Spotify, Discord, Twitch, Twitter**.
+Il appelle l'API de chaque plateforme pour valider le token et extraire le userId :
+
+```typescript
+// Endpoints de verification (dans link-social-workflow.ts) :
+const OAUTH_ENDPOINTS = {
+  youtube:  { url: 'https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true' },
+  spotify:  { url: 'https://api.spotify.com/v1/me' },
+  discord:  { url: 'https://discord.com/api/users/@me' },
+  twitch:   { url: 'https://api.twitch.tv/helix/users' },  // + TWITCH_CLIENT_ID header
+  twitter:  { url: 'https://api.twitter.com/2/users/me' },
+}
+```
+
+### Stockage actuel
+
+- **LibSQL** via `@mastra/libsql` : `file:./data/mastra.db` (dev) ou `file:/dstack/data/mastra.db` (Phala)
+- Tables gerees par Mastra (workflow runs, conversations, etc.)
+- **AUCUNE table custom** — on peut en ajouter via `@libsql/client` directement
+
+### Ce qui n'existe PAS (a creer)
+
+1. **Stockage de tokens** — les tokens sont passes aux workflows et jetes apres usage
+2. **Refresh tokens** — pas de mecanisme de renouvellement
+3. **Signal fetchers** — aucun code ne fetch des metriques depuis les APIs des plateformes
+4. **Routes OAuth** — les endpoints `/api/oauth/*` appeles par l'Explorer ne sont pas implementes dans mastra (le flow OAuth complet reste a clarifier, mais le linkSocialWorkflow recoit deja le token)
+
+---
+
+## 4. Deploiement Phala Cloud — ce qu'il faut savoir
+
+### Image Docker actuelle
+
+```
+Image : maximesaintjoannis/sofia-mastra:v1.4.2
+Base : node:22-slim
+Supervisor lance 2 services :
+  ├── MCP Server (port 3001)
+  └── Mastra (port 4111)
+
+Volume : /dstack/data → mastra.db (chiffre par le TEE Phala)
+```
+
+### Dockerfile (phala-deploy/Dockerfile)
+
+Build depuis le repertoire `core/` :
+```bash
+docker build -f sofia-mastra/phala-deploy/Dockerfile -t sofia-mastra .
+```
+
+Le Dockerfile copie `sofia-mastra/` + `intuition-mcp-server/`, installe les deps, build, lance supervisor.
+
+### Env vars actuelles
+
+```
+GAIANET_NODE_URL, GAIANET_MODEL, GAIANET_TEXT_MODEL_SMALL, GAIANET_TEXT_MODEL_LARGE
+GAIANET_EMBEDDING_MODEL, GAIANET_EMBEDDING_URL, USE_EMBEDDINGS
+DATABASE_URL=file:/dstack/data/mastra.db
+MCP_SERVER_URL=http://127.0.0.1:3001/sse
+BOT_PRIVATE_KEY=0x...
+TWITCH_CLIENT_ID=pyz5o7...
+```
+
+### Apres implementation — changements de deploiement
+
+```
+Nouvelle env var : TOKEN_ENCRYPTION_KEY=<64 chars hex = 32 bytes random>
+Generer avec : openssl rand -hex 32
+
+Nouvelle image : maximesaintjoannis/sofia-mastra:v1.5.0
+
+Pas de changement au Dockerfile (crypto est natif Node.js, pas de nouvelle dep).
+La table oauth_tokens est creee automatiquement au premier boot.
+Le volume /dstack/data persiste — pas de perte de donnees au redeploy.
+```
+
+---
+
+## 5. Ce qu'on implemente — en detail
+
+### 5.1 Module de stockage chiffre des tokens
+
+**Fichier : `src/mastra/db/tokens.ts`**
+
+**Concept :** On utilise le meme client LibSQL que Mastra (meme DB file) pour creer une table
+`oauth_tokens`. Les tokens sont chiffres avec AES-256-GCM avant insertion. La cle de chiffrement
+est dans `TOKEN_ENCRYPTION_KEY` (env var).
+
+**Pourquoi AES-256-GCM :**
+- GCM fournit chiffrement + authentification (on detecte si le ciphertext a ete modifie)
+- AES-256 est le standard pour les donnees sensibles
+- Node.js `crypto` le supporte nativement (pas de dep supplementaire)
+- Chaque token a son propre IV (vecteur d'initialisation) → meme token chiffre differemment a chaque fois
+
+**Schema de la table :**
+
+```sql
+CREATE TABLE IF NOT EXISTS oauth_tokens (
+  wallet_address TEXT NOT NULL,
+  platform TEXT NOT NULL,
+  access_token_encrypted TEXT NOT NULL,    -- AES-256-GCM chiffre, format: iv:authTag:ciphertext (hex)
+  refresh_token_encrypted TEXT,            -- Meme format, nullable
+  user_id TEXT,                            -- userId extrait de l'API (ex: UCxxxxx pour YouTube)
+  username TEXT,                           -- Display name
+  expires_at INTEGER,                      -- Timestamp d'expiration du access_token (nullable)
+  created_at INTEGER DEFAULT (unixepoch()),
+  updated_at INTEGER DEFAULT (unixepoch()),
+  PRIMARY KEY (wallet_address, platform)
+)
+```
+
+**Fonctions a exporter :**
+
+```typescript
+// Init — appeler au demarrage de Mastra
+initTokenTable(): Promise<void>
+
+// Stocker un token (chiffre automatiquement)
+storeToken(walletAddress, platform, accessToken, refreshToken?, userId?, username?, expiresAt?): Promise<void>
+
+// Lire un token (dechiffre automatiquement)
+getToken(walletAddress, platform): Promise<TokenRecord | null>
+
+// Lire tous les tokens d'un wallet
+getAllTokens(walletAddress): Promise<TokenRecord[]>
+
+// Supprimer un token
+deleteToken(walletAddress, platform): Promise<void>
+```
+
+**Format de chiffrement :** `iv:authTag:ciphertext` (tout en hex, separe par `:`)
+
+```typescript
+function encrypt(plaintext: string): string {
+  const key = Buffer.from(process.env.TOKEN_ENCRYPTION_KEY!, 'hex') // 32 bytes
+  const iv = crypto.randomBytes(12) // 96 bits pour GCM
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  const authTag = cipher.getAuthTag()
+  return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`
+}
+
+function decrypt(encoded: string): string {
+  const [ivHex, authTagHex, ciphertextHex] = encoded.split(':')
+  const key = Buffer.from(process.env.TOKEN_ENCRYPTION_KEY!, 'hex')
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, Buffer.from(ivHex, 'hex'))
+  decipher.setAuthTag(Buffer.from(authTagHex, 'hex'))
+  return decipher.update(ciphertextHex, 'hex', 'utf8') + decipher.final('utf8')
+}
+```
+
+### 5.2 Modification de linkSocialWorkflow
+
+**Fichier : `src/mastra/workflows/link-social-workflow.ts`**
+
+**Modification :** Apres que `verifyAndGetUserId()` reussit (ligne ~257), AVANT la creation on-chain, ajouter :
+
+```typescript
+import { storeToken } from '../db/tokens'
+
+// Dans executeLinkSocial, apres verification.valid :
+await storeToken(
+  walletAddress,
+  platform,
+  oauthToken,         // access_token
+  undefined,          // refresh_token (pas dispo dans le flow actuel)
+  verification.userId,
+  verification.username,
+)
+```
+
+**Pourquoi avant la creation on-chain :** Si la tx on-chain echoue, on a quand meme le token stocke.
+Le user ne devra pas reconnecter la plateforme.
+
+### 5.3 Signal Fetchers
+
+**Dossier : `src/mastra/signals/`**
+
+Chaque fetcher est une fonction pure : `(token: string, userId?: string) => Promise<Record<string, number>>`
+
+Les fetchers ne font PAS de scoring — ils retournent des metriques brutes.
+Le scoring est fait cote Explorer avec les formules du signalMatrix.
+
+#### YouTube fetcher — `signals/youtube.ts`
+
+```
+API : YouTube Data API v3
+Base URL : https://www.googleapis.com/youtube/v3
+Auth : Bearer token (scope: youtube.readonly)
+
+Endpoints appeles :
+  GET /channels?part=statistics,snippet&mine=true
+    → subscriberCount, videoCount, viewCount, publishedAt
+
+  GET /search?forMine=true&type=video&order=date&publishedAfter={90j}&maxResults=50&part=id
+    → nombre de videos recentes
+
+Metriques retournees :
+  videos_postees        → creation
+  vues_totales          → community
+  subscribers           → community
+  videos_recentes_90j   → regularity
+  anciennete_mois       → anciennete
+```
+
+#### Spotify fetcher — `signals/spotify.ts`
+
+```
+API : Spotify Web API
+Base URL : https://api.spotify.com/v1
+Auth : Bearer token (scopes: user-read-private, user-top-read, user-follow-read, playlist-read-private)
+
+Endpoints appeles :
+  GET /me/top/artists?time_range=medium_term&limit=50
+    → top artists → extract unique genres
+
+  GET /me/playlists?limit=50
+    → playlists creees par le user
+
+Metriques retournees :
+  diversite_genres      → qualite d'ecoute
+  playlists_creees      → creation
+  top_artists_count     → diversite
+```
+
+#### Discord fetcher — `signals/discord.ts`
+
+```
+API : Discord API v10
+Base URL : https://discord.com/api/v10
+Auth : Bearer token (scopes: identify, guilds)
+
+Endpoints appeles :
+  GET /users/@me/guilds
+    → liste des serveurs
+
+Metriques retournees :
+  serveurs_specialises  → community
+  roles_obtenus         → serveurs ou le user a ADMINISTRATOR permission
+```
+
+#### Twitch fetcher — `signals/twitch.ts`
+
+```
+API : Twitch Helix API
+Base URL : https://api.twitch.tv/helix
+Auth : Bearer token + Client-Id header (scope: user:read:follows)
+
+Endpoints appeles :
+  GET /users
+    → user info (created_at, broadcaster_type)
+
+  GET /channels/followers?broadcaster_id={id}&first=1
+    → follower count
+
+  GET /videos?type=archive&first=100
+    → past broadcasts → estimer heures de stream
+
+Metriques retournees :
+  heures_stream_mois    → regularity
+  followers             → community
+  anciennete_mois       → anciennete
+  is_affiliate          → monetisation (0 ou 1)
+  is_partner            → monetisation (0 ou 1)
+```
+
+#### GitHub fetcher — `signals/github.ts` (Phase 2)
+
+```
+API : GitHub REST API
+Base URL : https://api.github.com
+Auth : Bearer token (scopes: read:user, repo)
+Note : les tokens GitHub n'expirent PAS (OAuth app tokens sont permanents)
+
+Endpoints appeles :
+  GET /user
+    → login, public_repos, created_at
+
+  GET /user/repos?sort=pushed&per_page=100
+    → repos actifs, stars, langages
+
+  GET /users/{login}/events/public?per_page=100
+    → events recents (PushEvent) → streak, commits quotidiens
+
+Metriques retournees :
+  streak_jours          → regularity
+  commits_moy_quotidien → creation
+  repos_actifs          → creation (pushes dans les 90 derniers jours)
+  stars_recus           → community
+  anciennete_mois       → anciennete
+  langages_distincts    → creation
+  repos_total           → creation
+```
+
+#### Registry — `signals/registry.ts`
+
+```typescript
+import type { SignalFetcher } from './types'
+
+export const SIGNAL_FETCHERS: Record<string, SignalFetcher> = {}
+
+// Les fetchers sont ajoutes dynamiquement pour eviter d'importer
+// des modules non necessaires au demarrage
+export function registerFetcher(platform: string, fetcher: SignalFetcher) {
+  SIGNAL_FETCHERS[platform] = fetcher
+}
+```
+
+### 5.4 Signal Fetcher Workflow
+
+**Fichier : `src/mastra/workflows/signal-fetcher-workflow.ts`**
+
+```
+Input :  { platform: string, walletAddress: string }
+Output : { success: boolean, platformId: string, fetchedAt?: number, metrics?: Record<string, number>, error?: string }
+
+Logique :
+  1. Lire le token chiffre en DB via getToken(walletAddress, platform)
+  2. Si pas de token → { success: false, error: "no_token" }
+  3. Chercher le fetcher dans le registry
+  4. Si pas de fetcher → { success: false, error: "no_fetcher" }
+  5. Appeler le fetcher avec le token dechiffre
+  6. Si 401/403 → { success: false, error: "token_expired" }
+  7. Retourner les metriques brutes
+```
+
+### 5.5 Enregistrement dans Mastra
+
+**Fichier modifie : `src/mastra/index.ts`**
+
+```typescript
+import { signalFetcherWorkflow } from './workflows/signal-fetcher-workflow'
+import { initTokenTable } from './db/tokens'
+
+// Ajouter au demarrage
+initTokenTable().catch(err => console.error('[TokenDB] Init failed:', err))
+
+export const mastra = new Mastra({
+  workflows: {
+    sofiaWorkflow, chatbotWorkflow, socialVerifierWorkflow,
+    linkSocialWorkflow, signalFetcherWorkflow  // ← NOUVEAU
+  },
+  // ... reste inchange
+})
+```
+
+---
+
+## 6. Formules de scoring (reference — cote Explorer)
+
+Ces formules sont dans `sofia-explorer/src/config/signalMatrix.ts`.
+Les fetchers n'appliquent PAS ces formules — ils retournent les metriques brutes.
+L'Explorer applique les formules. Mais il faut que les metriques retournees
+correspondent aux variables des formules.
+
+### Formules des plateformes Phase 0-1
+
+```
+YOUTUBE :
+  formula = (videos_postees * 10) + (vues_totales / 1000) + (commentaires_pertinents * 2)
+  weights = { creation: 10, regularity: 1.5, community: 2, monetization: 3, anciennete: 0.5 }
+  burstPenalty = -0.2
+
+SPOTIFY :
+  formula = (diversite_genres * 2) + (playlists_creees * 3) + (heures_semaine * 1)
+  weights = { creation: 1, regularity: 1.2, community: 1, monetization: 0, anciennete: 0.5 }
+  burstPenalty = -0.1
+
+DISCORD :
+  formula = (serveurs_specialises * 3) + (roles_obtenus * 5)
+  weights = { creation: 1, regularity: 1.5, community: 5, monetization: 0, anciennete: 0.5 }
+  burstPenalty = -0.1
+
+TWITCH :
+  formula = (heures_stream_mois * 2) + (followers / 100) + (subs * 10)
+  weights = { creation: 5, regularity: 2, community: 2, monetization: 4, anciennete: 0.5 }
+  burstPenalty = -0.2
+
+GITHUB :
+  formula = (streak_jours * 1.5) + (commits_moy_quotidien * 3) + (repos_actifs * 2) - burst_malus
+  weights = { creation: 3, regularity: 1.5, community: 2, monetization: 3, anciennete: 0.5 }
+  burstPenalty = -0.2
+```
+
+### Principes de scoring (cote Explorer)
+
+```
+SINGLE_SOURCE_PENALTY = 0.5     → 1 seule plateforme par topic = score × 0.5
+MULTI_SOURCE_BONUS = 1.5        → 3+ plateformes croisees = score × 1.5
+ENS_BONUS = 15                  → +15 pts si le user a un ENS
+ANCIENNETE_LOG_FACTOR = 0.5     → log(mois_actifs) × 0.5
+CROSS_PLATFORM_MIN_CONFIDENCE = 0.3
+```
+
+### Topic scoring models (14 topics)
+
+```
+tech-dev:          regularityMultiplier=1.5, qualityMultiplier=2.0, monetizationMultiplier=3.0
+design-creative:   regularityMultiplier=1.3, qualityMultiplier=2.0, monetizationMultiplier=3.0
+music-audio:       regularityMultiplier=1.2, qualityMultiplier=2.5, monetizationMultiplier=4.0
+video-cinema:      regularityMultiplier=1.5, qualityMultiplier=2.0, monetizationMultiplier=3.0
+web3-crypto:       regularityMultiplier=1.4, qualityMultiplier=3.0, monetizationMultiplier=4.0
+gaming:            regularityMultiplier=1.2, qualityMultiplier=2.0, monetizationMultiplier=3.0
+science:           regularityMultiplier=2.0, qualityMultiplier=3.0, monetizationMultiplier=4.0
+entrepreneurship:  regularityMultiplier=1.5, qualityMultiplier=2.0, monetizationMultiplier=5.0
+sport-health:      regularityMultiplier=1.8, qualityMultiplier=1.5, monetizationMultiplier=3.0
+performing-arts:   regularityMultiplier=1.3, qualityMultiplier=2.5, monetizationMultiplier=3.5
+nature-environment:regularityMultiplier=1.5, qualityMultiplier=2.0, monetizationMultiplier=2.0
+food-lifestyle:    regularityMultiplier=1.3, qualityMultiplier=2.0, monetizationMultiplier=3.0
+literature:        regularityMultiplier=1.5, qualityMultiplier=2.5, monetizationMultiplier=3.0
+personal-dev:      regularityMultiplier=1.5, qualityMultiplier=2.0, monetizationMultiplier=3.0
+```
+
+---
+
+## 7. Contraintes
+
+### Securite
+- Les tokens sont des secrets — JAMAIS en clair dans les logs
+- Chiffrement AES-256-GCM avec cle en env var
+- Le TEE Phala chiffre aussi le volume disque au niveau hardware → double protection
+- Les scopes OAuth sont read-only (on ne modifie jamais les comptes des users)
+
+### Rate limits des APIs
+- GitHub : 5000 req/h par token
+- Spotify : ~180 req/min
+- Discord : 50 req/s global
+- Twitch : 800 req/min
+- YouTube : 10000 unites/jour (1 unite = 1 req simple)
+
+Mitigation : les metriques sont cachees cote Explorer (React Query staleTime = 1h).
+Un user ne fetch ses signaux qu'une fois par session.
+
+### Tokens et expiration
+- GitHub : token permanent (OAuth app) → pas de refresh necessaire
+- Spotify : access_token expire apres 1h, refresh_token = permanent
+- Discord : access_token expire apres ~7 jours, refresh_token = permanent
+- Twitch : access_token expire apres ~4h, refresh_token = permanent
+- Twitter : access_token expire apres 2h, refresh_token = 6 mois
+
+Pour le MVP : on stocke l'access_token au moment de la connexion.
+Si le token a expire quand on fetch les signaux → erreur "token_expired" → l'Explorer
+propose au user de reconnecter la plateforme.
+
+Le refresh token sera implemente en V2.
+
+### Fallback scoring
+Si un fetcher echoue (token expire, API down, pas de fetcher) :
+→ L'Explorer affiche "score unavailable" pour cette plateforme
+→ PAS de fallback a 10 pts — le score doit representer la realite
+
+---
+
+## 8. Fichiers a creer
+
+```
+src/mastra/
+├── db/
+│   └── tokens.ts                          ← Stockage chiffre AES-256-GCM dans LibSQL
+├── signals/
+│   ├── types.ts                           ← Interfaces PlatformSignals, SignalFetcher
+│   ├── registry.ts                        ← Map platformId → fetcher function
+│   ├── utils.ts                           ← Helpers (monthsSince, calculateStreak)
+│   ├── youtube.ts                         ← Fetcher YouTube Data API v3
+│   ├── spotify.ts                         ← Fetcher Spotify Web API
+│   ├── discord.ts                         ← Fetcher Discord API v10
+│   ├── twitch.ts                          ← Fetcher Twitch Helix API
+│   └── github.ts                          ← Fetcher GitHub REST API (Phase 2)
+└── workflows/
+    └── signal-fetcher-workflow.ts         ← Workflow Mastra pour fetch les metriques
+```
+
+## 9. Fichiers a modifier
+
+```
+src/mastra/index.ts
+  → Importer signalFetcherWorkflow, l'ajouter dans workflows: {}
+  → Appeler initTokenTable() au demarrage
+
+src/mastra/workflows/link-social-workflow.ts
+  → Apres verifyAndGetUserId() reussit (~ligne 257)
+  → Ajouter : await storeToken(walletAddress, platform, oauthToken, undefined, userId, username)
+```
+
+## 10. Env vars a ajouter
+
+```
+TOKEN_ENCRYPTION_KEY=<64 chars hex>    # Generer : openssl rand -hex 32
+```
+
+A ajouter dans :
+- `.env` local (dev)
+- Phala Cloud dashboard (production)
+
+## 11. Process de deploiement
+
+```bash
+# 1. Implementer les changements dans sofia-mastra/
+# 2. Test local
+cd sofia-mastra && pnpm run dev
+# → Tester : POST /api/workflows/signalFetcherWorkflow/start-async
+#   Body : { "inputData": { "platform": "youtube", "walletAddress": "0x..." } }
+
+# 3. Build Docker (depuis core/)
+cd core/
+docker build -f sofia-mastra/phala-deploy/Dockerfile -t maximesaintjoannis/sofia-mastra:v1.5.0 .
+
+# 4. Push
+docker push maximesaintjoannis/sofia-mastra:v1.5.0
+
+# 5. Phala Cloud dashboard :
+#    - Mettre a jour le tag image → v1.5.0
+#    - Ajouter env var TOKEN_ENCRYPTION_KEY
+#    - Redeployer
+
+# 6. Verifier
+curl -X POST https://<phala-url>/api/workflows/signalFetcherWorkflow/start-async \
+  -H "Content-Type: application/json" \
+  -d '{"inputData":{"platform":"youtube","walletAddress":"0xTEST"}}'
+# → Doit retourner { success: false, error: "no_token" } (normal, pas de token stocke)
+```
+
+## 12. Planning
+
+| Jour | Tache | Livrable |
+|---|---|---|
+| J1 | `db/tokens.ts` — chiffrement AES-256-GCM + table LibSQL | Tokens stockables et lisibles |
+| J1 | Modifier `link-social-workflow.ts` — stocker le token | Token persiste apres connexion |
+| J2 | `signals/types.ts` + `signals/utils.ts` + `signals/registry.ts` | Infrastructure fetchers |
+| J2 | `signals/youtube.ts` + `signals/spotify.ts` | 2 fetchers |
+| J3 | `signals/discord.ts` + `signals/twitch.ts` | 2 fetchers |
+| J3 | `signal-fetcher-workflow.ts` + modifier `index.ts` | Workflow fonctionnel |
+| J4 | Test local complet + fix bugs | Flow end-to-end OK |
+| J5 | `signals/github.ts` + build Docker + deploy Phala | 5 fetchers en prod |
+
+## 13. Tests de verification
+
+### Test 1 — Token storage
+```
+1. Demarrer mastra en dev
+2. Appeler linkSocialWorkflow avec un vrai token YouTube
+3. Verifier que le token est stocke en DB (chiffre)
+4. Appeler getToken() → verifier que le token dechiffre est correct
+```
+
+### Test 2 — Signal fetcher
+```
+1. Avoir un token YouTube stocke en DB (test 1)
+2. Appeler signalFetcherWorkflow avec { platform: "youtube", walletAddress: "0x..." }
+3. Verifier que les metriques sont retournees (videos_postees, vues_totales, etc.)
+```
+
+### Test 3 — Token expire
+```
+1. Stocker un token expire en DB
+2. Appeler signalFetcherWorkflow
+3. Verifier que la reponse est { success: false, error: "token_expired" }
+```
+
+### Test 4 — Plateforme sans fetcher
+```
+1. Stocker un token pour une plateforme non supportee (ex: "figma")
+2. Appeler signalFetcherWorkflow avec { platform: "figma" }
+3. Verifier que la reponse est { success: false, error: "no_fetcher" }
+```

--- a/services/mastra/docs/verification-plan-web3.md
+++ b/services/mastra/docs/verification-plan-web3.md
@@ -1,0 +1,287 @@
+# Plan de verification — Web3 Phase (pour l'agent dans core/)
+
+> A destination de l'agent Claude Code dans le repo `core/`.
+> Branche : `feature/oauth-phase-1`
+> Commit reference : (celui qui ajoute les 10 plateformes web3)
+
+---
+
+## Objectif
+
+Un agent externe (session Claude Code dans sofia-explorer) a implemente 10 nouvelles plateformes web3 dans sofia-mastra. Ton job : **verifier que l'implementation est correcte et stable** avant le deploy Phala.
+
+## Perimetre — 10 plateformes web3
+
+| Plateforme | Type | Credentials | Fichier |
+|---|---|---|---|
+| ens | on-chain | aucun | `signals/onchain/ens.ts` |
+| lido | on-chain | aucun | `signals/onchain/lido.ts` |
+| aave | subgraph | GRAPH_API_KEY | `signals/onchain/aave.ts` |
+| uniswap | subgraph | GRAPH_API_KEY | `signals/onchain/uniswap.ts` |
+| snapshot | public GraphQL | aucun | `signals/onchain/snapshot.ts` |
+| the-graph | public subgraph | aucun | `signals/onchain/the-graph.ts` |
+| wallet-siwe | on-chain | aucun | `signals/onchain/wallet-siwe.ts` |
+| lens | public GraphQL | aucun | `signals/onchain/lens.ts` |
+| farcaster | API key | NEYNAR_API_KEY | `signals/onchain/farcaster.ts` |
+| opensea | API key | OPENSEA_API_KEY | `signals/onchain/opensea.ts` |
+| coinbase | OAuth2 | COINBASE_CLIENT_ID/SECRET | `signals/coinbase.ts` |
+
+## Fichiers modifies
+
+```
+src/mastra/signals/registry.ts          ← Ajout WALLET_BASED_PLATFORMS + 10 register
+src/mastra/workflows/signal-fetcher-workflow.ts ← Handle wallet-based (pas de token lookup)
+src/mastra/oauth/config.ts              ← Ajout coinbase
+src/mastra/oauth/verify.ts              ← Ajout coinbase (Platform type + endpoint + switch)
+```
+
+## Fichiers crees
+
+```
+src/mastra/signals/onchain/utils.ts     ← mainnet viem client + subgraph helpers
+src/mastra/signals/onchain/ens.ts
+src/mastra/signals/onchain/lido.ts
+src/mastra/signals/onchain/aave.ts
+src/mastra/signals/onchain/uniswap.ts
+src/mastra/signals/onchain/snapshot.ts
+src/mastra/signals/onchain/the-graph.ts
+src/mastra/signals/onchain/wallet-siwe.ts
+src/mastra/signals/onchain/lens.ts
+src/mastra/signals/onchain/farcaster.ts
+src/mastra/signals/onchain/opensea.ts
+src/mastra/signals/coinbase.ts
+docs/credentials-web3.md                ← Guide credentials
+docs/verification-plan-web3.md          ← Ce document
+```
+
+---
+
+## Checklist de verification
+
+### 1. TypeScript — compile
+
+```bash
+cd core/sofia-mastra
+pnpm run build
+```
+
+**Attendu** : 0 erreur. Si `viem` n'est pas encore dans les deps :
+
+```bash
+pnpm install viem
+```
+
+(viem est probablement deja installe — utilise deja par les workflows blockchain existants `link-social-workflow.ts` et `social-verifier-workflow.ts`).
+
+### 2. Tests isoles par fetcher (sans credentials)
+
+Les 5 fetchers sans credentials peuvent etre testes des maintenant :
+
+```bash
+pnpm run dev
+# Une fois le serveur up (port 4111) :
+
+for P in ens lido snapshot wallet-siwe lens; do
+  echo "=== $P ==="
+  curl -s -X POST "http://localhost:4111/api/workflows/signalFetcherWorkflow/start-async" \
+    -H "Content-Type: application/json" \
+    -d "{\"inputData\":{\"platform\":\"$P\",\"walletAddress\":\"0xc634457ad68b037e2d5aa1c10c3930d7e4e2d551\"}}" \
+    | python3 -m json.tool
+done
+```
+
+**Attendu** :
+- `success: true` pour chacune des 5
+- `metrics` contient des cles (pas vide)
+- `warnings` array present (peut etre vide)
+
+Si `success: false, error: "no_fetcher"` → le registry n'a pas bien charge la plateforme. Verifier `registry.ts`.
+
+### 3. Tests avec credentials
+
+Apres avoir setup les env vars (voir `credentials-web3.md`) :
+
+```bash
+for P in aave uniswap farcaster opensea; do
+  echo "=== $P ==="
+  curl -s -X POST "http://localhost:4111/api/workflows/signalFetcherWorkflow/start-async" \
+    -H "Content-Type: application/json" \
+    -d "{\"inputData\":{\"platform\":\"$P\",\"walletAddress\":\"0xTonVraiWallet\"}}" \
+    | python3 -m json.tool
+done
+```
+
+**Attendu** :
+- Si credentials ok → `success: true` avec metrics
+- Si credentials manquants → `error: "missing_graph_api_key"` ou `"missing_neynar_api_key"` ou `"missing_opensea_api_key"`
+
+### 4. Test OAuth Coinbase
+
+Meme flow que les OAuth Phase 1 (Reddit, Strava, etc.) :
+
+```bash
+curl -I "http://localhost:4111/oauth/coinbase/authorize?redirect_uri=http://localhost:5173/auth/callback&state=test"
+```
+
+**Attendu** : `302 Found` avec `Location: https://login.coinbase.com/oauth2/auth?...`
+
+### 5. Verifier WALLET_BASED_PLATFORMS
+
+```typescript
+// Dans signal-fetcher-workflow.ts
+const isWalletBased = WALLET_BASED_PLATFORMS.has(platform)
+```
+
+**Points a verifier** :
+- [ ] `WALLET_BASED_PLATFORMS` contient bien les 10 platforms (ens, lido, aave, uniswap, snapshot, the-graph, wallet-siwe, lens, farcaster, opensea)
+- [ ] coinbase **n'est PAS** dans WALLET_BASED_PLATFORMS (c'est OAuth classique)
+- [ ] Quand `isWalletBased === true`, le workflow skip `getToken()` et passe walletAddress comme credential
+
+### 6. Verifier Platform type dans verify.ts
+
+`verify.ts` doit inclure `coinbase` dans le type `Platform` ET dans OAUTH_ENDPOINTS ET dans le switch :
+
+```typescript
+export type Platform = "..." | "coinbase"
+// ...
+const OAUTH_ENDPOINTS: Record<Platform, OAuthEndpoint> = {
+  // ...
+  coinbase: { url: "...", authHeader: (t) => `Bearer ${t}` },
+}
+// ...
+case "coinbase":
+  userId = data.data?.id ? String(data.data.id) : undefined
+  // ...
+```
+
+### 7. Tests d'integration
+
+Une fois les env vars + OAuth app coinbase creees :
+
+```bash
+# Simuler le flow OAuth Coinbase
+# 1. Creer une app Coinbase OAuth
+# 2. Connecter depuis l'Explorer
+# 3. Verifier que le token est stocke dans oauth_tokens
+# 4. Appeler signalFetcherWorkflow pour "coinbase" → doit retourner metrics
+```
+
+---
+
+## Points sensibles a verifier (code review)
+
+### A. `onchain/utils.ts`
+
+- [ ] `getMainnetClient()` cree un seul client (cache via variable module-scope)
+- [ ] `querySubgraph()` throw `missing_graph_api_key` si env manque
+- [ ] `queryPublicGraphQL()` verifie bien `response.ok` ET `data.errors`
+
+### B. Fetchers on-chain
+
+- [ ] Tous les fetchers utilisent `ctx?.safeStep` pour les calls secondaires (pattern identique a `github.ts`)
+- [ ] `addr` est bien lowercase pour les subgraphs (IDs sensibles a la casse)
+- [ ] Pour Lido : les adresses stETH/wstETH sont bonnes (checksum correct)
+- [ ] Pour Lens : la query utilise bien l'API v2 (pas v1 deprecated)
+
+### C. registry.ts
+
+- [ ] `WALLET_BASED_PLATFORMS` est exporte (nommage exact : `WALLET_BASED_PLATFORMS`)
+- [ ] Les 10 platforms wallet-based sont dedans
+- [ ] Les 10 fetchers sont bien `registerFetcher`-es
+- [ ] Coinbase est `registerFetcher`-e aussi (mais PAS dans WALLET_BASED_PLATFORMS)
+
+### D. signal-fetcher-workflow.ts
+
+- [ ] Import de `WALLET_BASED_PLATFORMS` depuis `../signals/registry`
+- [ ] Branch `isWalletBased` bypass `getToken()` et passe `walletAddress` comme `credential`
+- [ ] Les warnings sont propages dans l'output
+
+### E. config.ts
+
+- [ ] `coinbase` est ajoute avec `clientId`/`clientSecret` via `process.env`
+- [ ] Les scopes sont `["wallet:user:read", "wallet:accounts:read"]`
+
+---
+
+## Problemes connus / TODO
+
+### 1. ENS subgraph deprecated (hosted service)
+L'endpoint `https://api.thegraph.com/subgraphs/name/ensdomains/ens` est l'ancien hosted service qui devait etre migre vers le decentralized network. A la date de l'implementation, il fonctionne encore mais peut etre deprecie. Fallback : la reverse lookup via viem reste, juste les counts de domaines passeraient a 0.
+
+**Action** : tester avec un vrai wallet qui a un ENS (ex: vitalik.eth). Si le subgraph retourne 0, investiguer.
+
+### 2. The Graph network subgraph — meme chose
+`https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-mainnet` peut aussi etre migre. Verifier que l'endpoint repond.
+
+### 3. Aave/Uniswap subgraph IDs
+Les subgraph IDs hardcodes dans `aave.ts` et `uniswap.ts` sont des IDs valides au moment de l'implementation. **A verifier** :
+- Aave v3 : `JCNWRypm7FYwV8fx5HhzZPSFaMxgkPuw4TnR3Gpi81zk`
+- Uniswap v3 : `5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV`
+
+Si jamais ils changent, mettre a jour ces constantes.
+
+### 4. OpenSea API approval
+L'API key OpenSea necessite une approbation manuelle (1-2 jours). **Skippable au deploy** : si pas de key, le fetcher throw `missing_opensea_api_key` → le front affiche "score unavailable" pour OpenSea. Le reste marche.
+
+### 5. Coinbase OAuth — nouveau provider
+Le code Coinbase utilise les endpoints `login.coinbase.com/oauth2/*`. Il y a une ambiguite : historiquement l'API etait sur `www.coinbase.com/oauth/*`. Verifier que les endpoints sont bons (testables via une vraie creation d'app + flow).
+
+### 6. Farcaster sans Neynar
+Le fetcher Farcaster depend de Neynar. Si Neynar API change ou devient trop cher, fallback potentiel :
+- Utiliser le Hub Farcaster directement (plus complexe)
+- Utiliser Warpcast search API (moins riche mais gratuit)
+
+---
+
+## Deploiement
+
+Une fois toutes les verifications passees :
+
+```bash
+# Build
+cd core/
+docker build -f sofia-mastra/phala-deploy/Dockerfile -t maximesaintjoannis/sofia-mastra:v2.0.0 .
+
+# Push
+docker push maximesaintjoannis/sofia-mastra:v2.0.0
+
+# Phala Cloud dashboard :
+# - Update image tag → v2.0.0
+# - Ajouter env vars : GRAPH_API_KEY, NEYNAR_API_KEY, OPENSEA_API_KEY, COINBASE_CLIENT_ID/SECRET
+# - (optionnel) ETH_MAINNET_RPC si on a une cle Alchemy/Infura
+# - Redeploy
+```
+
+### Smoke test post-deploy
+
+```bash
+# Les 5 plateformes sans credentials doivent marcher immediatement
+for P in ens lido snapshot wallet-siwe lens; do
+  curl -s -X POST "https://<phala>/api/workflows/signalFetcherWorkflow/start-async" \
+    -H "Content-Type: application/json" \
+    -d "{\"inputData\":{\"platform\":\"$P\",\"walletAddress\":\"0x...\"}}" \
+    | python3 -m json.tool
+done
+```
+
+### UI end-to-end
+
+1. Frontend Explorer deploye avec `feature/oauth-phase-1`
+2. User connecte son wallet Privy → cliquer "Connect" sur ENS
+3. Statut passe a "Connected" immediatement (pas de popup — auto-connect)
+4. Score `web3-crypto` calcule sur le profile
+
+---
+
+## Liste de questions que l'agent doit se poser
+
+1. Est-ce que `WALLET_BASED_PLATFORMS` est bien exporte ET importe dans workflow ?
+2. Est-ce que viem est dans `package.json` ?
+3. Est-ce que tous les fetchers retournent **des nombres uniquement** (PlatformMetrics) ?
+4. Est-ce que les metrics ne contiennent pas de `NaN`, `Infinity`, `null` ?
+5. Est-ce que les fetchers qui necessitent une API key **throw** si la key manque (au lieu de retourner un objet vide silencieusement) ?
+6. Est-ce que les fetchers on-chain utilisent `safeStep` pour les calls secondaires ?
+7. Est-ce que le fetcher OAuth Coinbase suit le meme pattern que github/spotify/etc. ?
+8. Est-ce qu'il y a des tests unitaires ? (probablement non — ajouter serait un plus)
+
+Si toutes les reponses sont "oui" → pret pour le deploy.

--- a/services/mastra/package.json
+++ b/services/mastra/package.json
@@ -6,7 +6,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "mastra dev",
     "build": "mastra build",
-    "start": "mastra start"
+    "start": "mastra start",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",
@@ -17,6 +18,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^1.0.29",
+    "@libsql/client": "^0.15.0",
     "@mastra/core": "^0.24.8",
     "@mastra/evals": "^0.14.4",
     "@mastra/libsql": "^0.16.4",

--- a/services/mastra/src/mastra/db/tokens.ts
+++ b/services/mastra/src/mastra/db/tokens.ts
@@ -1,0 +1,199 @@
+const ALGORITHM = "aes-256-gcm"
+const IV_LENGTH = 12 // 96 bits for GCM
+
+let db: any = null
+
+async function getDb() {
+  if (!db) {
+    const { createClient } = await import("@libsql/client")
+    db = createClient({
+      url: process.env.DATABASE_URL || "file:./data/mastra.db",
+    })
+  }
+  return db
+}
+
+async function getCrypto() {
+  return await import("node:crypto")
+}
+
+function getEncryptionKey(): Buffer {
+  const hex = process.env.TOKEN_ENCRYPTION_KEY
+  if (!hex || hex.length !== 64) {
+    throw new Error(
+      "[TokenDB] TOKEN_ENCRYPTION_KEY must be a 64-char hex string (32 bytes)"
+    )
+  }
+  return Buffer.from(hex, "hex")
+}
+
+async function encrypt(plaintext: string): Promise<string> {
+  const crypto = await getCrypto()
+  const key = getEncryptionKey()
+  const iv = crypto.randomBytes(IV_LENGTH)
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv)
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ])
+  const authTag = cipher.getAuthTag()
+  return `${iv.toString("hex")}:${authTag.toString("hex")}:${encrypted.toString("hex")}`
+}
+
+async function decrypt(encoded: string): Promise<string> {
+  const crypto = await getCrypto()
+  const [ivHex, authTagHex, ciphertextHex] = encoded.split(":")
+  const key = getEncryptionKey()
+  const decipher = crypto.createDecipheriv(
+    ALGORITHM,
+    key,
+    Buffer.from(ivHex, "hex")
+  )
+  decipher.setAuthTag(Buffer.from(authTagHex, "hex"))
+  return decipher.update(ciphertextHex, "hex", "utf8") + decipher.final("utf8")
+}
+
+// --- Public API ---
+
+export interface TokenRecord {
+  wallet_address: string
+  platform: string
+  access_token: string // decrypted
+  refresh_token?: string // decrypted
+  user_id?: string
+  username?: string
+  expires_at?: number
+}
+
+export async function initTokenTable(): Promise<void> {
+  if (!process.env.TOKEN_ENCRYPTION_KEY) {
+    console.warn(
+      "[TokenDB] TOKEN_ENCRYPTION_KEY not set — token storage disabled"
+    )
+    return
+  }
+  const client = await getDb()
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS oauth_tokens (
+      wallet_address TEXT NOT NULL,
+      platform TEXT NOT NULL,
+      access_token_encrypted TEXT NOT NULL,
+      refresh_token_encrypted TEXT,
+      user_id TEXT,
+      username TEXT,
+      expires_at INTEGER,
+      created_at INTEGER DEFAULT (unixepoch()),
+      updated_at INTEGER DEFAULT (unixepoch()),
+      PRIMARY KEY (wallet_address, platform)
+    )
+  `)
+  console.log("[TokenDB] Table oauth_tokens ready")
+}
+
+export async function storeToken(
+  walletAddress: string,
+  platform: string,
+  accessToken: string,
+  refreshToken?: string,
+  userId?: string,
+  username?: string,
+  expiresAt?: number
+): Promise<void> {
+  const client = await getDb()
+  const accessEncrypted = await encrypt(accessToken)
+  const refreshEncrypted = refreshToken ? await encrypt(refreshToken) : null
+
+  await client.execute({
+    sql: `
+      INSERT INTO oauth_tokens
+        (wallet_address, platform, access_token_encrypted, refresh_token_encrypted, user_id, username, expires_at, updated_at)
+      VALUES
+        (?, ?, ?, ?, ?, ?, ?, unixepoch())
+      ON CONFLICT (wallet_address, platform) DO UPDATE SET
+        access_token_encrypted = excluded.access_token_encrypted,
+        refresh_token_encrypted = excluded.refresh_token_encrypted,
+        user_id = excluded.user_id,
+        username = excluded.username,
+        expires_at = excluded.expires_at,
+        updated_at = unixepoch()
+    `,
+    args: [
+      walletAddress.toLowerCase(),
+      platform,
+      accessEncrypted,
+      refreshEncrypted,
+      userId ?? null,
+      username ?? null,
+      expiresAt ?? null,
+    ],
+  })
+  console.log(
+    `[TokenDB] Token stored for ${platform} (wallet: ${walletAddress.slice(0, 8)}...)`
+  )
+}
+
+export async function getToken(
+  walletAddress: string,
+  platform: string
+): Promise<TokenRecord | null> {
+  const client = await getDb()
+  const result = await client.execute({
+    sql: `SELECT * FROM oauth_tokens WHERE wallet_address = ? AND platform = ?`,
+    args: [walletAddress.toLowerCase(), platform],
+  })
+
+  if (result.rows.length === 0) return null
+
+  const row = result.rows[0]
+  return {
+    wallet_address: row.wallet_address as string,
+    platform: row.platform as string,
+    access_token: await decrypt(row.access_token_encrypted as string),
+    refresh_token: row.refresh_token_encrypted
+      ? await decrypt(row.refresh_token_encrypted as string)
+      : undefined,
+    user_id: (row.user_id as string) ?? undefined,
+    username: (row.username as string) ?? undefined,
+    expires_at: (row.expires_at as number) ?? undefined,
+  }
+}
+
+export async function getAllTokens(
+  walletAddress: string
+): Promise<TokenRecord[]> {
+  const client = await getDb()
+  const result = await client.execute({
+    sql: `SELECT * FROM oauth_tokens WHERE wallet_address = ?`,
+    args: [walletAddress.toLowerCase()],
+  })
+
+  const records: TokenRecord[] = []
+  for (const row of result.rows) {
+    records.push({
+      wallet_address: row.wallet_address as string,
+      platform: row.platform as string,
+      access_token: await decrypt(row.access_token_encrypted as string),
+      refresh_token: row.refresh_token_encrypted
+        ? await decrypt(row.refresh_token_encrypted as string)
+        : undefined,
+      user_id: (row.user_id as string) ?? undefined,
+      username: (row.username as string) ?? undefined,
+      expires_at: (row.expires_at as number) ?? undefined,
+    })
+  }
+  return records
+}
+
+export async function deleteToken(
+  walletAddress: string,
+  platform: string
+): Promise<void> {
+  const client = await getDb()
+  await client.execute({
+    sql: `DELETE FROM oauth_tokens WHERE wallet_address = ? AND platform = ?`,
+    args: [walletAddress.toLowerCase(), platform],
+  })
+  console.log(
+    `[TokenDB] Token deleted for ${platform} (wallet: ${walletAddress.slice(0, 8)}...)`
+  )
+}

--- a/services/mastra/src/mastra/index.ts
+++ b/services/mastra/src/mastra/index.ts
@@ -6,21 +6,33 @@ import { sofiaWorkflow } from './workflows/sofia-workflow';
 import { chatbotWorkflow } from './workflows/chatbot-workflow';
 import { socialVerifierWorkflow } from './workflows/social-verifier-workflow';
 import { linkSocialWorkflow } from './workflows/link-social-workflow';
+import { signalFetcherWorkflow } from './workflows/signal-fetcher-workflow';
 import { themeExtractorAgent } from './agents/theme-extractor-agent';
 import { pulseAgent } from './agents/pulse-agent';
 import { recommendationAgent } from './agents/recommendation-agent';
 import { chatbotAgent } from './agents/chatbot-agent';
 import { predicateAgent } from './agents/predicate-agent';
 import { skillsAnalysisAgent } from './agents/skills-analysis-agent';
+import { oauthRoutes } from './oauth/routes';
+import { initTokenTable } from './db/tokens';
 
 export const mastra = new Mastra({
-  workflows: { sofiaWorkflow, chatbotWorkflow, socialVerifierWorkflow, linkSocialWorkflow },
+  workflows: {
+    sofiaWorkflow,
+    chatbotWorkflow,
+    socialVerifierWorkflow,
+    linkSocialWorkflow,
+    signalFetcherWorkflow,
+  },
   agents: { themeExtractorAgent, pulseAgent, recommendationAgent, chatbotAgent, predicateAgent, skillsAnalysisAgent },
   scorers: {
   },
   storage: new LibSQLStore({
     url: process.env.DATABASE_URL || 'file:./data/mastra.db',
   }),
+  server: {
+    apiRoutes: oauthRoutes,
+  },
   logger: new PinoLogger({
     name: 'Mastra',
     level: 'info',
@@ -34,4 +46,10 @@ export const mastra = new Mastra({
   bundler: {
     externals: ['pino', 'pino-pretty', 'bufferutil', 'utf-8-validate'],
   },
+});
+
+// Fire-and-forget: ensure the encrypted oauth_tokens table exists at boot.
+// Warns silently if TOKEN_ENCRYPTION_KEY isn't set (token storage disabled).
+initTokenTable().catch((err) => {
+  console.error('[Mastra] initTokenTable failed:', err);
 });

--- a/services/mastra/src/mastra/oauth/config.ts
+++ b/services/mastra/src/mastra/oauth/config.ts
@@ -1,0 +1,132 @@
+export interface OAuthProviderConfig {
+  clientId: string
+  clientSecret: string
+  authUrl: string
+  tokenUrl: string
+  scopes: string[]
+  /** Extra params for the authorize URL (e.g. Google needs access_type=offline) */
+  extraAuthParams?: Record<string, string>
+  /** Extra headers for the token exchange request (e.g. GitHub needs Accept: application/json) */
+  tokenRequestHeaders?: Record<string, string>
+  /** Use Basic auth header instead of sending client_secret in body (Spotify, Reddit) */
+  useBasicAuthHeader?: boolean
+  /** Separator for the scope query param. Default: " " (space). Strava uses "," */
+  scopeSeparator?: string
+}
+
+export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
+  youtube: {
+    clientId: process.env.YOUTUBE_CLIENT_ID || "",
+    clientSecret: process.env.YOUTUBE_CLIENT_SECRET || "",
+    authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+    tokenUrl: "https://oauth2.googleapis.com/token",
+    scopes: ["https://www.googleapis.com/auth/youtube.readonly"],
+    extraAuthParams: {
+      access_type: "offline",
+      prompt: "consent",
+    },
+  },
+  spotify: {
+    clientId: process.env.SPOTIFY_CLIENT_ID || "",
+    clientSecret: process.env.SPOTIFY_CLIENT_SECRET || "",
+    authUrl: "https://accounts.spotify.com/authorize",
+    tokenUrl: "https://accounts.spotify.com/api/token",
+    scopes: [
+      "user-read-private",
+      "user-top-read",
+      "user-follow-read",
+      "playlist-read-private",
+    ],
+    useBasicAuthHeader: true,
+  },
+  discord: {
+    clientId: process.env.DISCORD_CLIENT_ID || "",
+    clientSecret: process.env.DISCORD_CLIENT_SECRET || "",
+    authUrl: "https://discord.com/api/oauth2/authorize",
+    tokenUrl: "https://discord.com/api/oauth2/token",
+    scopes: ["identify", "guilds"],
+  },
+  twitch: {
+    clientId: process.env.TWITCH_CLIENT_ID || "",
+    clientSecret: process.env.TWITCH_CLIENT_SECRET || "",
+    authUrl: "https://id.twitch.tv/oauth2/authorize",
+    tokenUrl: "https://id.twitch.tv/oauth2/token",
+    scopes: [
+      "user:read:email",
+      "user:read:follows",
+      "moderator:read:followers",
+      "channel:read:subscriptions",
+    ],
+  },
+  github: {
+    clientId: process.env.GITHUB_CLIENT_ID || "",
+    clientSecret: process.env.GITHUB_CLIENT_SECRET || "",
+    authUrl: "https://github.com/login/oauth/authorize",
+    tokenUrl: "https://github.com/login/oauth/access_token",
+    scopes: ["read:user", "repo"],
+    tokenRequestHeaders: {
+      Accept: "application/json",
+    },
+  },
+  reddit: {
+    clientId: process.env.REDDIT_CLIENT_ID || "",
+    clientSecret: process.env.REDDIT_CLIENT_SECRET || "",
+    authUrl: "https://www.reddit.com/api/v1/authorize",
+    tokenUrl: "https://www.reddit.com/api/v1/access_token",
+    scopes: ["identity", "read", "mysubreddits"],
+    useBasicAuthHeader: true,
+    extraAuthParams: {
+      duration: "permanent",
+    },
+  },
+  strava: {
+    clientId: process.env.STRAVA_CLIENT_ID || "",
+    clientSecret: process.env.STRAVA_CLIENT_SECRET || "",
+    authUrl: "https://www.strava.com/oauth/authorize",
+    tokenUrl: "https://www.strava.com/oauth/token",
+    scopes: ["read", "activity:read"],
+    scopeSeparator: ",",
+    extraAuthParams: {
+      approval_prompt: "auto",
+    },
+  },
+  soundcloud: {
+    clientId: process.env.SOUNDCLOUD_CLIENT_ID || "",
+    clientSecret: process.env.SOUNDCLOUD_CLIENT_SECRET || "",
+    authUrl: "https://secure.soundcloud.com/authorize",
+    tokenUrl: "https://secure.soundcloud.com/oauth/token",
+    scopes: [],
+  },
+  mixcloud: {
+    clientId: process.env.MIXCLOUD_CLIENT_ID || "",
+    clientSecret: process.env.MIXCLOUD_CLIENT_SECRET || "",
+    authUrl: "https://www.mixcloud.com/oauth/authorize",
+    tokenUrl: "https://www.mixcloud.com/oauth/access_token",
+    scopes: [],
+  },
+  producthunt: {
+    clientId: process.env.PRODUCTHUNT_CLIENT_ID || "",
+    clientSecret: process.env.PRODUCTHUNT_CLIENT_SECRET || "",
+    authUrl: "https://api.producthunt.com/v2/oauth/authorize",
+    tokenUrl: "https://api.producthunt.com/v2/oauth/token",
+    scopes: ["public"],
+  },
+  orcid: {
+    clientId: process.env.ORCID_CLIENT_ID || "",
+    clientSecret: process.env.ORCID_CLIENT_SECRET || "",
+    authUrl: "https://orcid.org/oauth/authorize",
+    tokenUrl: "https://orcid.org/oauth/token",
+    scopes: ["/authenticate"],
+  },
+  coinbase: {
+    clientId: process.env.COINBASE_CLIENT_ID || "",
+    clientSecret: process.env.COINBASE_CLIENT_SECRET || "",
+    authUrl: "https://login.coinbase.com/oauth2/auth",
+    tokenUrl: "https://login.coinbase.com/oauth2/token",
+    scopes: ["wallet:user:read", "wallet:accounts:read"],
+  },
+}
+
+export function getOAuthProvider(platform: string): OAuthProviderConfig | null {
+  return OAUTH_PROVIDERS[platform] ?? null
+}

--- a/services/mastra/src/mastra/oauth/exchange.ts
+++ b/services/mastra/src/mastra/oauth/exchange.ts
@@ -1,0 +1,74 @@
+import { getOAuthProvider } from "./config"
+
+export interface TokenExchangeResult {
+  accessToken: string
+  refreshToken?: string
+  expiresIn?: number
+  tokenType?: string
+}
+
+/**
+ * Exchange an OAuth authorization code for an access token.
+ * Handles provider-specific quirks (Spotify basic auth, GitHub accept header, etc.)
+ */
+export async function exchangeCodeForToken(
+  platform: string,
+  code: string,
+  redirectUri: string
+): Promise<TokenExchangeResult> {
+  const provider = getOAuthProvider(platform)
+  if (!provider) {
+    throw new Error(`unsupported_platform: ${platform}`)
+  }
+
+  if (!provider.clientId || !provider.clientSecret) {
+    throw new Error(`missing_credentials: ${platform}`)
+  }
+
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+  })
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    ...(provider.tokenRequestHeaders ?? {}),
+  }
+
+  if (provider.useBasicAuthHeader) {
+    const basic = Buffer.from(
+      `${provider.clientId}:${provider.clientSecret}`
+    ).toString("base64")
+    headers["Authorization"] = `Basic ${basic}`
+  } else {
+    body.append("client_id", provider.clientId)
+    body.append("client_secret", provider.clientSecret)
+  }
+
+  const res = await fetch(provider.tokenUrl, {
+    method: "POST",
+    headers,
+    body,
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`token_exchange_failed: ${res.status} ${text}`)
+  }
+
+  const data = await res.json()
+
+  if (!data.access_token) {
+    throw new Error(
+      `token_exchange_failed: no access_token in response: ${JSON.stringify(data)}`
+    )
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresIn: data.expires_in,
+    tokenType: data.token_type,
+  }
+}

--- a/services/mastra/src/mastra/oauth/routes.ts
+++ b/services/mastra/src/mastra/oauth/routes.ts
@@ -1,0 +1,117 @@
+import { registerApiRoute } from "@mastra/core/server"
+import { getOAuthProvider } from "./config"
+import { exchangeCodeForToken } from "./exchange"
+import { verifyAndGetUserId, type Platform } from "./verify"
+
+/**
+ * OAuth routes for Sofia Explorer frontend.
+ *
+ * Flow:
+ *   1. GET /oauth/:platform/authorize → 302 redirect to provider OAuth page
+ *   2. POST /oauth/:platform/callback → exchange code for token, return to frontend
+ *
+ * The frontend then calls linkSocialWorkflow to create the on-chain triple
+ * and store the token encrypted.
+ *
+ * Note: these are mounted under /oauth/* (not /api/oauth/*) because the /api
+ * prefix is reserved by Mastra for auto-generated routes.
+ */
+export const oauthRoutes = [
+  registerApiRoute("/oauth/:platform/authorize", {
+    method: "GET",
+    handler: async (c) => {
+      const platform = c.req.param("platform")
+      const redirectUri = c.req.query("redirect_uri")
+      const state = c.req.query("state")
+
+      if (!redirectUri || !state) {
+        return c.json({ error: "missing_params" }, 400)
+      }
+
+      const provider = getOAuthProvider(platform)
+      if (!provider) {
+        return c.json({ error: "unsupported_platform" }, 404)
+      }
+
+      if (!provider.clientId) {
+        return c.json({ error: "missing_credentials" }, 500)
+      }
+
+      const scopeSeparator = provider.scopeSeparator ?? " "
+      const params = new URLSearchParams({
+        client_id: provider.clientId,
+        response_type: "code",
+        redirect_uri: redirectUri,
+        state,
+        ...(provider.extraAuthParams ?? {}),
+      })
+      if (provider.scopes.length > 0) {
+        params.set("scope", provider.scopes.join(scopeSeparator))
+      }
+
+      const authorizeUrl = `${provider.authUrl}?${params.toString()}`
+      return c.redirect(authorizeUrl, 302)
+    },
+  }),
+
+  registerApiRoute("/oauth/:platform/callback", {
+    method: "POST",
+    handler: async (c) => {
+      const platform = c.req.param("platform")
+
+      let body: { code?: string; redirectUri?: string }
+      try {
+        body = await c.req.json()
+      } catch {
+        return c.json({ success: false, error: "invalid_json" }, 400)
+      }
+
+      const { code, redirectUri } = body
+
+      if (!code || !redirectUri) {
+        return c.json({ success: false, error: "missing_params" }, 400)
+      }
+
+      try {
+        const tokens = await exchangeCodeForToken(platform, code, redirectUri)
+
+        const verification = await verifyAndGetUserId(
+          platform as Platform,
+          tokens.accessToken
+        )
+
+        if (!verification.valid) {
+          return c.json(
+            {
+              success: false,
+              platformId: platform,
+              error: verification.error || "verification_failed",
+            },
+            400
+          )
+        }
+
+        return c.json({
+          success: true,
+          platformId: platform,
+          userId: verification.userId,
+          username: verification.username,
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          expiresIn: tokens.expiresIn,
+        })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        console.error(`[OAuth.callback] ${platform}: ${message}`)
+        return c.json(
+          {
+            success: false,
+            platformId: platform,
+            error: message,
+          },
+          500
+        )
+      }
+    },
+  }),
+]

--- a/services/mastra/src/mastra/oauth/verify.ts
+++ b/services/mastra/src/mastra/oauth/verify.ts
@@ -1,0 +1,231 @@
+export type Platform =
+  | "discord"
+  | "youtube"
+  | "spotify"
+  | "twitch"
+  | "twitter"
+  | "github"
+  | "reddit"
+  | "strava"
+  | "soundcloud"
+  | "mixcloud"
+  | "producthunt"
+  | "orcid"
+  | "coinbase"
+
+export interface OAuthVerificationResult {
+  valid: boolean
+  userId?: string
+  username?: string
+  error?: string
+}
+
+interface OAuthEndpoint {
+  url: string
+  authHeader: (token: string) => string
+  requiresClientId?: boolean
+}
+
+const OAUTH_ENDPOINTS: Record<Platform, OAuthEndpoint> = {
+  youtube: {
+    url: "https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true",
+    authHeader: (token) => `Bearer ${token}`,
+  },
+  spotify: {
+    url: "https://api.spotify.com/v1/me",
+    authHeader: (token) => `Bearer ${token}`,
+  },
+  discord: {
+    url: "https://discord.com/api/users/@me",
+    authHeader: (token) => `Bearer ${token}`,
+  },
+  twitch: {
+    url: "https://api.twitch.tv/helix/users",
+    authHeader: (token) => `Bearer ${token}`,
+    requiresClientId: true,
+  },
+  twitter: {
+    url: "https://api.twitter.com/2/users/me",
+    authHeader: (token) => `Bearer ${token}`,
+  },
+  github: {
+    url: "https://api.github.com/user",
+    authHeader: (token) => `Bearer ${token}`,
+  },
+  reddit: {
+    url: "https://oauth.reddit.com/api/v1/me",
+    authHeader: (token) => `Bearer ${token}`,
+  },
+  strava: {
+    url: "https://www.strava.com/api/v3/athlete",
+    authHeader: (token) => `Bearer ${token}`,
+  },
+  soundcloud: {
+    url: "https://api.soundcloud.com/me",
+    authHeader: (token) => `OAuth ${token}`,
+  },
+  mixcloud: {
+    url: "https://api.mixcloud.com/me/",
+    authHeader: (token) => `Bearer ${token}`,
+  },
+  producthunt: {
+    // ProductHunt offers GraphQL but REST /me works for the simple verify step.
+    url: "https://api.producthunt.com/v2/api/me",
+    authHeader: (token) => `Bearer ${token}`,
+  },
+  orcid: {
+    // ORCID returns the orcid-id in the token response itself; we still verify
+    // by hitting the public record. The real userId (ORCID iD) is best injected
+    // by exchange.ts — this verify path is a best-effort fallback.
+    url: "https://pub.orcid.org/v3.0/record",
+    authHeader: (token) => `Bearer ${token}`,
+  },
+  coinbase: {
+    url: "https://api.coinbase.com/v2/user",
+    authHeader: (token) => `Bearer ${token}`,
+  },
+}
+
+/**
+ * Verify OAuth token by calling the provider's user info API.
+ * Returns userId and username (used for the on-chain triple).
+ */
+export async function verifyAndGetUserId(
+  platform: Platform,
+  token: string,
+  clientId?: string
+): Promise<OAuthVerificationResult> {
+  const endpoint = OAUTH_ENDPOINTS[platform]
+  if (!endpoint) {
+    return { valid: false, error: `Unsupported platform: ${platform}` }
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      Authorization: endpoint.authHeader(token),
+    }
+
+    if (platform === "twitch") {
+      const twitchClientId = clientId || process.env.TWITCH_CLIENT_ID
+      if (!twitchClientId) {
+        return { valid: false, error: "Twitch Client ID required" }
+      }
+      headers["Client-Id"] = twitchClientId
+    }
+
+    if (platform === "github") {
+      headers["Accept"] = "application/vnd.github+json"
+    }
+
+    if (platform === "reddit") {
+      headers["User-Agent"] = "sofia-reputation/1.0"
+    }
+
+    const response = await fetch(endpoint.url, { headers })
+
+    if (!response.ok) {
+      return { valid: false, error: `API returned ${response.status}` }
+    }
+
+    const data = await response.json()
+
+    let userId: string | undefined
+    let username: string | undefined
+
+    switch (platform) {
+      case "discord":
+        userId = data.id ? String(data.id) : undefined
+        username = data.username ? String(data.username) : undefined
+        break
+      case "youtube":
+        userId = data.items?.[0]?.id ? String(data.items[0].id) : undefined
+        username = data.items?.[0]?.snippet?.title
+          ? String(data.items[0].snippet.title)
+          : undefined
+        break
+      case "spotify":
+        userId = data.id ? String(data.id) : undefined
+        username = data.display_name ? String(data.display_name) : undefined
+        break
+      case "twitch":
+        userId = data.data?.[0]?.id ? String(data.data[0].id) : undefined
+        username = data.data?.[0]?.login ? String(data.data[0].login) : undefined
+        break
+      case "twitter":
+        userId = data.data?.id ? String(data.data.id) : undefined
+        username = data.data?.username ? String(data.data.username) : undefined
+        break
+      case "github":
+        userId = data.id ? String(data.id) : undefined
+        username = data.login ? String(data.login) : undefined
+        break
+      case "reddit":
+        userId = data.id ? String(data.id) : undefined
+        username = data.name ? String(data.name) : undefined
+        break
+      case "strava":
+        userId = data.id ? String(data.id) : undefined
+        username = data.username
+          ? String(data.username)
+          : data.firstname
+            ? String(data.firstname)
+            : undefined
+        break
+      case "soundcloud":
+        userId = data.id ? String(data.id) : undefined
+        username = data.permalink
+          ? String(data.permalink)
+          : data.username
+            ? String(data.username)
+            : undefined
+        break
+      case "mixcloud":
+        userId = data.username ? String(data.username) : undefined
+        username = data.username ? String(data.username) : undefined
+        break
+      case "producthunt":
+        userId = data.user?.id
+          ? String(data.user.id)
+          : data.data?.viewer?.user?.id
+            ? String(data.data.viewer.user.id)
+            : undefined
+        username = data.user?.username
+          ? String(data.user.username)
+          : data.data?.viewer?.user?.username
+            ? String(data.data.viewer.user.username)
+            : undefined
+        break
+      case "orcid":
+        userId = data["orcid-identifier"]?.path
+          ? String(data["orcid-identifier"].path)
+          : undefined
+        username = data.person?.name?.["credit-name"]?.value
+          ? String(data.person.name["credit-name"].value)
+          : undefined
+        break
+      case "coinbase":
+        userId = data.data?.id ? String(data.data.id) : undefined
+        username = data.data?.username
+          ? String(data.data.username)
+          : data.data?.name
+            ? String(data.data.name)
+            : undefined
+        break
+    }
+
+    if (!userId) {
+      return {
+        valid: false,
+        error: `Could not extract user ID from ${platform} response`,
+      }
+    }
+
+    return { valid: true, userId, username }
+  } catch (error) {
+    console.error(`[OAuth.verify] ${platform}: Verification failed:`, error)
+    return {
+      valid: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    }
+  }
+}

--- a/services/mastra/src/mastra/signals/coinbase.ts
+++ b/services/mastra/src/mastra/signals/coinbase.ts
@@ -1,0 +1,54 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { safeFetch, monthsSince, safeNumber } from "./utils"
+
+const BASE = "https://api.coinbase.com/v2"
+
+export const fetchCoinbaseSignals: SignalFetcher = async (
+  token,
+  _userId,
+  ctx
+): Promise<PlatformMetrics> => {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json",
+    "CB-VERSION": "2024-01-01",
+  }
+
+  const safe = ctx?.safeStep ?? (async (fn, fallback) => {
+    try { return await fn() } catch { return fallback }
+  })
+
+  const userRes = await safeFetch(`${BASE}/user`, headers)
+  const userData = await userRes.json()
+  const user = userData.data ?? {}
+
+  const accountsData = await safe(
+    async () => {
+      const res = await safeFetch(`${BASE}/accounts?limit=100`, headers)
+      return await res.json()
+    },
+    { data: [] } as any,
+    "coinbase_accounts"
+  )
+
+  const accounts: any[] = accountsData.data ?? []
+  const assetsDistinct = new Set<string>()
+  let totalBalanceUsd = 0
+
+  for (const acc of accounts) {
+    const currency = acc.balance?.currency ?? acc.currency?.code
+    const amount = safeNumber(parseFloat(acc.balance?.amount ?? "0"))
+    if (amount > 0 && currency) {
+      assetsDistinct.add(currency)
+    }
+    totalBalanceUsd += safeNumber(parseFloat(acc.native_balance?.amount ?? "0"))
+  }
+
+  return {
+    assets_distinct: assetsDistinct.size,
+    accounts_total: accounts.length,
+    balance_usd: Math.round(totalBalanceUsd * 100) / 100,
+    anciennete_mois: user.created_at ? monthsSince(user.created_at) : 0,
+    has_legacy_id: user.legacy_id ? 1 : 0,
+  }
+}

--- a/services/mastra/src/mastra/signals/discord.ts
+++ b/services/mastra/src/mastra/signals/discord.ts
@@ -1,0 +1,68 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { safeFetch, monthsSince } from "./utils"
+
+const BASE = "https://discord.com/api/v10"
+
+const ADMINISTRATOR = 0x8n
+const MANAGE_GUILD = 0x20n
+const MANAGE_CHANNELS = 0x10n
+const MANAGE_ROLES = 0x10000000n
+const MOD_MASK = MANAGE_GUILD | MANAGE_CHANNELS | MANAGE_ROLES
+
+const DISCORD_EPOCH_MS = 1420070400000n
+
+function snowflakeToDate(id: string): Date | null {
+  try {
+    const ms = (BigInt(id) >> 22n) + DISCORD_EPOCH_MS
+    return new Date(Number(ms))
+  } catch {
+    return null
+  }
+}
+
+export const fetchDiscordSignals: SignalFetcher = async (
+  token,
+  _userId,
+  ctx
+): Promise<PlatformMetrics> => {
+  const headers = { Authorization: `Bearer ${token}` }
+  const safe = ctx?.safeStep ?? (async (fn, fallback) => {
+    try { return await fn() } catch { return fallback }
+  })
+
+  const guildsRes = await safeFetch(`${BASE}/users/@me/guilds`, headers)
+  const guilds: any[] = await guildsRes.json()
+
+  let adminGuilds = 0
+  let moderatorGuilds = 0
+  let ownedGuilds = 0
+
+  for (const g of guilds) {
+    const perms = (() => {
+      try { return BigInt(g.permissions ?? "0") } catch { return 0n }
+    })()
+    if ((perms & ADMINISTRATOR) !== 0n) adminGuilds++
+    if ((perms & MOD_MASK) !== 0n) moderatorGuilds++
+    if (g.owner === true) ownedGuilds++
+  }
+
+  const anciennete_mois = await safe(
+    async () => {
+      const meRes = await safeFetch(`${BASE}/users/@me`, headers)
+      const me = await meRes.json()
+      if (!me.id) return 0
+      const createdAt = snowflakeToDate(String(me.id))
+      return createdAt ? monthsSince(createdAt.toISOString()) : 0
+    },
+    0,
+    "discord_account_age"
+  )
+
+  return {
+    serveurs_specialises: guilds.length,
+    roles_obtenus: adminGuilds,
+    moderator_guilds: moderatorGuilds,
+    owned_guilds: ownedGuilds,
+    anciennete_mois,
+  }
+}

--- a/services/mastra/src/mastra/signals/github.ts
+++ b/services/mastra/src/mastra/signals/github.ts
@@ -1,0 +1,137 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { safeFetch, monthsSince, calculateStreak, safeNumber } from "./utils"
+
+const BASE = "https://api.github.com"
+const MAX_REPO_PAGES = 5
+const MAX_EVENT_PAGES = 3
+
+export const fetchGithubSignals: SignalFetcher = async (
+  token,
+  _userId,
+  ctx
+): Promise<PlatformMetrics> => {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+  }
+  const safe = ctx?.safeStep ?? (async (fn, fallback) => {
+    try { return await fn() } catch { return fallback }
+  })
+
+  const userRes = await safeFetch(`${BASE}/user`, headers)
+  const user = await userRes.json()
+  const login = user.login
+
+  const repos: any[] = []
+  const firstPageRes = await safeFetch(
+    `${BASE}/user/repos?sort=pushed&per_page=100&page=1`,
+    headers
+  )
+  const firstPage: any[] = await firstPageRes.json()
+  repos.push(...firstPage)
+
+  if (firstPage.length === 100) {
+    for (let page = 2; page <= MAX_REPO_PAGES; page++) {
+      const more = await safe(
+        async () => {
+          const res = await safeFetch(
+            `${BASE}/user/repos?sort=pushed&per_page=100&page=${page}`,
+            headers
+          )
+          const data = await res.json()
+          return Array.isArray(data) ? data : []
+        },
+        [] as any[],
+        `github_repos_page_${page}`
+      )
+      repos.push(...more)
+      if (more.length < 100) break
+    }
+  }
+
+  const ninetyDaysAgo = new Date()
+  ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90)
+  const activeRepos = repos.filter(
+    (r) => r.pushed_at && new Date(r.pushed_at) >= ninetyDaysAgo
+  )
+
+  const starsTotal = repos.reduce(
+    (sum: number, r: any) => sum + safeNumber(r.stargazers_count),
+    0
+  )
+
+  const languages = new Set<string>()
+  for (const repo of repos) {
+    if (repo.language) languages.add(repo.language)
+  }
+
+  const events: any[] = []
+  for (let page = 1; page <= MAX_EVENT_PAGES; page++) {
+    const pageEvents = await safe(
+      async () => {
+        const res = await safeFetch(
+          `${BASE}/users/${login}/events/public?per_page=100&page=${page}`,
+          headers
+        )
+        const data = await res.json()
+        return Array.isArray(data) ? data : []
+      },
+      [] as any[],
+      `github_events_page_${page}`
+    )
+    events.push(...pageEvents)
+    if (pageEvents.length < 100) break
+  }
+
+  const pushEvents = events
+    .filter((e) => e.type === "PushEvent")
+    .map((e) => ({ created_at: e.created_at }))
+
+  const streak = calculateStreak(pushEvents)
+
+  const thirtyDaysAgo = new Date()
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+
+  const recentPushes = events.filter(
+    (e) => e.type === "PushEvent" && new Date(e.created_at) >= thirtyDaysAgo
+  )
+
+  const totalCommits = recentPushes.reduce(
+    (sum: number, e: any) => sum + safeNumber(e.payload?.commits?.length),
+    0
+  )
+
+  const daysSinceStart = Math.max(
+    1,
+    Math.ceil((Date.now() - thirtyDaysAgo.getTime()) / (1000 * 60 * 60 * 24))
+  )
+
+  const pullRequestsOpened30d = events.filter(
+    (e) =>
+      e.type === "PullRequestEvent" &&
+      e.payload?.action === "opened" &&
+      new Date(e.created_at) >= thirtyDaysAgo
+  ).length
+
+  const issuesOpened30d = events.filter(
+    (e) =>
+      e.type === "IssuesEvent" &&
+      e.payload?.action === "opened" &&
+      new Date(e.created_at) >= thirtyDaysAgo
+  ).length
+
+  return {
+    streak_jours: streak,
+    commits_moy_quotidien:
+      Math.round((totalCommits / daysSinceStart) * 10) / 10,
+    repos_actifs: activeRepos.length,
+    stars_recus: starsTotal,
+    anciennete_mois: user.created_at ? monthsSince(user.created_at) : 0,
+    langages_distincts: languages.size,
+    repos_total: safeNumber(user.public_repos ?? repos.length),
+    followers: safeNumber(user.followers),
+    following: safeNumber(user.following),
+    pull_requests_opened_30d: pullRequestsOpened30d,
+    issues_opened_30d: issuesOpened30d,
+  }
+}

--- a/services/mastra/src/mastra/signals/mixcloud.ts
+++ b/services/mastra/src/mastra/signals/mixcloud.ts
@@ -1,0 +1,50 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { safeFetch, monthsSince, safeNumber } from "./utils"
+
+const BASE = "https://api.mixcloud.com"
+
+export const fetchMixcloudSignals: SignalFetcher = async (
+  token,
+  _userId,
+  ctx
+): Promise<PlatformMetrics> => {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  const safe = ctx?.safeStep ?? (async (fn, fallback) => {
+    try { return await fn() } catch { return fallback }
+  })
+
+  const meRes = await safeFetch(`${BASE}/me/`, headers)
+  const me = await meRes.json()
+  const username = me.username
+
+  const totalListens = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/${username}/cloudcasts/?limit=50`,
+        headers
+      )
+      const data = await res.json()
+      if (!Array.isArray(data?.data)) return 0
+      return data.data.reduce(
+        (sum: number, c: any) => sum + safeNumber(c.play_count),
+        0
+      )
+    },
+    0,
+    "mixcloud_listens"
+  )
+
+  return {
+    cloudcast_count: safeNumber(me.cloudcast_count),
+    favorite_count: safeNumber(me.favorite_count),
+    follower_count: safeNumber(me.follower_count),
+    following_count: safeNumber(me.following_count),
+    listen_count_50: totalListens,
+    is_pro: me.is_pro ? 1 : 0,
+    is_premium: me.is_premium ? 1 : 0,
+    anciennete_mois: me.created_time ? monthsSince(me.created_time) : 0,
+  }
+}

--- a/services/mastra/src/mastra/signals/orcid.ts
+++ b/services/mastra/src/mastra/signals/orcid.ts
@@ -1,0 +1,74 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { safeFetch, monthsSince, safeNumber } from "./utils"
+
+const BASE = "https://pub.orcid.org/v3.0"
+
+export const fetchOrcidSignals: SignalFetcher = async (
+  token,
+  userId,
+  ctx
+): Promise<PlatformMetrics> => {
+  // ORCID's token response includes the orcid iD as `orcid` — it is passed to the
+  // fetcher via `userId`. Without it we cannot query the record.
+  if (!userId) {
+    throw new Error("ORCID iD (userId) is required to fetch metrics")
+  }
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json",
+  }
+
+  const safe = ctx?.safeStep ?? (async (fn, fallback) => {
+    try { return await fn() } catch { return fallback }
+  })
+
+  const recordRes = await safeFetch(`${BASE}/${userId}/record`, headers)
+  const record = await recordRes.json()
+
+  const works = safeNumber(
+    record["activities-summary"]?.works?.group?.length
+  )
+  const fundings = safeNumber(
+    record["activities-summary"]?.fundings?.group?.length
+  )
+  const peerReviews = safeNumber(
+    record["activities-summary"]?.["peer-reviews"]?.group?.length
+  )
+  const educations = safeNumber(
+    record["activities-summary"]?.educations?.["affiliation-group"]?.length
+  )
+  const employments = safeNumber(
+    record["activities-summary"]?.employments?.["affiliation-group"]?.length
+  )
+
+  const worksDetailed = await safe(
+    async () => {
+      const res = await safeFetch(`${BASE}/${userId}/works`, headers)
+      const data = await res.json()
+      return Array.isArray(data.group) ? data.group.length : 0
+    },
+    works,
+    "orcid_works"
+  )
+
+  const createdMs = safeNumber(
+    record.history?.["submission-date"]?.value
+  )
+  const anciennete = createdMs
+    ? monthsSince(new Date(createdMs).toISOString())
+    : 0
+
+  return {
+    works: worksDetailed,
+    peer_reviews: peerReviews,
+    fundings: fundings,
+    educations: educations,
+    employments: employments,
+    anciennete_mois: anciennete,
+    is_verified_email: record.history?.["verified-email"] ? 1 : 0,
+    is_verified_primary_email: record.history?.["verified-primary-email"]
+      ? 1
+      : 0,
+  }
+}

--- a/services/mastra/src/mastra/signals/producthunt.ts
+++ b/services/mastra/src/mastra/signals/producthunt.ts
@@ -1,0 +1,65 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { monthsSince, safeNumber, TokenExpiredError } from "./utils"
+
+const GRAPHQL_URL = "https://api.producthunt.com/v2/api/graphql"
+
+const VIEWER_QUERY = `
+  query ViewerMetrics {
+    viewer {
+      user {
+        id
+        username
+        createdAt
+        followersCount
+        followingsCount
+        madePosts {
+          totalCount
+        }
+        votedPosts {
+          totalCount
+        }
+      }
+    }
+  }
+`
+
+export const fetchProducthuntSignals: SignalFetcher = async (
+  token,
+  _userId,
+  _ctx
+): Promise<PlatformMetrics> => {
+  const response = await fetch(GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({ query: VIEWER_QUERY }),
+  })
+
+  if (response.status === 401 || response.status === 403) {
+    throw new TokenExpiredError(
+      `API returned ${response.status} — token expired or revoked`
+    )
+  }
+
+  if (!response.ok) {
+    throw new Error(`API returned ${response.status}: ${response.statusText}`)
+  }
+
+  const data = await response.json()
+  const user = data?.data?.viewer?.user
+
+  if (!user) {
+    throw new Error("No viewer.user in Product Hunt response")
+  }
+
+  return {
+    posts_made: safeNumber(user.madePosts?.totalCount),
+    posts_voted: safeNumber(user.votedPosts?.totalCount),
+    followers_count: safeNumber(user.followersCount),
+    followings_count: safeNumber(user.followingsCount),
+    anciennete_mois: user.createdAt ? monthsSince(user.createdAt) : 0,
+  }
+}

--- a/services/mastra/src/mastra/signals/reddit.ts
+++ b/services/mastra/src/mastra/signals/reddit.ts
@@ -1,0 +1,59 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { safeFetch, monthsSince, safeNumber } from "./utils"
+
+const BASE = "https://oauth.reddit.com"
+const USER_AGENT = "sofia-reputation/1.0"
+
+export const fetchRedditSignals: SignalFetcher = async (
+  token,
+  _userId,
+  ctx
+): Promise<PlatformMetrics> => {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "User-Agent": USER_AGENT,
+  }
+
+  const safe = ctx?.safeStep ?? (async (fn, fallback) => {
+    try { return await fn() } catch { return fallback }
+  })
+
+  const meRes = await safeFetch(`${BASE}/api/v1/me`, headers)
+  const me = await meRes.json()
+
+  const subs = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/subreddits/mine/subscriber?limit=100`,
+        headers
+      )
+      const data = await res.json()
+      return Array.isArray(data.data?.children) ? data.data.children.length : 0
+    },
+    0,
+    "reddit_subreddits"
+  )
+
+  const trophyCount = await safe(
+    async () => {
+      const res = await safeFetch(`${BASE}/api/v1/me/trophies`, headers)
+      const data = await res.json()
+      return Array.isArray(data.data?.trophies) ? data.data.trophies.length : 0
+    },
+    0,
+    "reddit_trophies"
+  )
+
+  return {
+    comment_karma: safeNumber(me.comment_karma),
+    link_karma: safeNumber(me.link_karma),
+    total_karma: safeNumber(me.total_karma ?? me.comment_karma + me.link_karma),
+    subreddits_actifs: subs,
+    anciennete_mois: me.created_utc
+      ? monthsSince(new Date(me.created_utc * 1000).toISOString())
+      : 0,
+    trophies: trophyCount,
+    is_gold: me.is_gold ? 1 : 0,
+    is_mod: me.is_mod ? 1 : 0,
+  }
+}

--- a/services/mastra/src/mastra/signals/registry.ts
+++ b/services/mastra/src/mastra/signals/registry.ts
@@ -1,0 +1,112 @@
+import type { FetcherContext, SignalFetcher } from "./types"
+import { fetchYoutubeSignals } from "./youtube"
+import { fetchSpotifySignals } from "./spotify"
+import { fetchDiscordSignals } from "./discord"
+import { fetchTwitchSignals } from "./twitch"
+import { fetchGithubSignals } from "./github"
+import { fetchRedditSignals } from "./reddit"
+import { fetchStravaSignals } from "./strava"
+import { fetchSoundcloudSignals } from "./soundcloud"
+import { fetchMixcloudSignals } from "./mixcloud"
+import { fetchProducthuntSignals } from "./producthunt"
+import { fetchOrcidSignals } from "./orcid"
+import { fetchCoinbaseSignals } from "./coinbase"
+import { fetchEnsSignals } from "./onchain/ens"
+import { fetchLidoSignals } from "./onchain/lido"
+import { fetchAaveSignals } from "./onchain/aave"
+import { fetchUniswapSignals } from "./onchain/uniswap"
+import { fetchSnapshotSignals } from "./onchain/snapshot"
+import { fetchTheGraphSignals } from "./onchain/the-graph"
+import { fetchWalletSiweSignals } from "./onchain/wallet-siwe"
+import { fetchLensSignals } from "./onchain/lens"
+import { fetchFarcasterSignals } from "./onchain/farcaster"
+import { fetchOpenseaSignals } from "./onchain/opensea"
+import { safeStep, validateMetrics } from "./utils"
+
+export const SIGNAL_FETCHERS: Record<string, SignalFetcher> = {}
+
+/**
+ * Platforms whose fetcher receives the user's walletAddress as its "credential"
+ * argument instead of an OAuth access token. These don't need a stored token
+ * in the oauth_tokens table — on-chain reads or public APIs are enough.
+ */
+export const WALLET_BASED_PLATFORMS = new Set<string>([
+  "ens",
+  "lido",
+  "aave",
+  "uniswap",
+  "snapshot",
+  "the-graph",
+  "wallet-siwe",
+  "lens",
+  "farcaster",
+  "opensea",
+])
+
+export function registerFetcher(
+  platform: string,
+  fetcher: SignalFetcher
+): void {
+  SIGNAL_FETCHERS[platform] = fetcher
+}
+
+export interface FetcherExecution {
+  metrics: Record<string, number>
+  warnings: string[]
+}
+
+/**
+ * Execute a fetcher with a shared FetcherContext so sub-fetches can log warnings,
+ * then validate the returned metrics.
+ */
+export async function runFetcher(
+  platform: string,
+  token: string,
+  userId?: string
+): Promise<FetcherExecution> {
+  const fetcher = SIGNAL_FETCHERS[platform]
+  if (!fetcher) {
+    throw new Error(`no_fetcher_registered:${platform}`)
+  }
+
+  const warnings: string[] = []
+  const ctx: FetcherContext = {
+    warnings,
+    safeStep: (fn, fallback, label) =>
+      safeStep(fn, fallback, label, warnings),
+  }
+
+  const raw = await fetcher(token, userId, ctx)
+  const validated = validateMetrics(raw)
+
+  return {
+    metrics: validated.metrics,
+    warnings: [...warnings, ...validated.warnings],
+  }
+}
+
+// OAuth-based fetchers
+registerFetcher("youtube", fetchYoutubeSignals)
+registerFetcher("spotify", fetchSpotifySignals)
+registerFetcher("discord", fetchDiscordSignals)
+registerFetcher("twitch", fetchTwitchSignals)
+registerFetcher("github", fetchGithubSignals)
+registerFetcher("reddit", fetchRedditSignals)
+registerFetcher("strava", fetchStravaSignals)
+registerFetcher("soundcloud", fetchSoundcloudSignals)
+registerFetcher("mixcloud", fetchMixcloudSignals)
+registerFetcher("producthunt", fetchProducthuntSignals)
+registerFetcher("orcid", fetchOrcidSignals)
+registerFetcher("coinbase", fetchCoinbaseSignals)
+
+// Wallet-based (on-chain or API-key) fetchers
+registerFetcher("ens", fetchEnsSignals)
+registerFetcher("lido", fetchLidoSignals)
+registerFetcher("aave", fetchAaveSignals)
+registerFetcher("uniswap", fetchUniswapSignals)
+registerFetcher("snapshot", fetchSnapshotSignals)
+registerFetcher("the-graph", fetchTheGraphSignals)
+registerFetcher("wallet-siwe", fetchWalletSiweSignals)
+registerFetcher("lens", fetchLensSignals)
+registerFetcher("farcaster", fetchFarcasterSignals)
+registerFetcher("opensea", fetchOpenseaSignals)

--- a/services/mastra/src/mastra/signals/soundcloud.ts
+++ b/services/mastra/src/mastra/signals/soundcloud.ts
@@ -1,0 +1,47 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { safeFetch, safeNumber } from "./utils"
+
+const BASE = "https://api.soundcloud.com"
+
+export const fetchSoundcloudSignals: SignalFetcher = async (
+  token,
+  _userId,
+  ctx
+): Promise<PlatformMetrics> => {
+  // SoundCloud uses OAuth-scheme Authorization header ("OAuth <token>"), not Bearer.
+  const headers = {
+    Authorization: `OAuth ${token}`,
+  }
+
+  const safe = ctx?.safeStep ?? (async (fn, fallback) => {
+    try { return await fn() } catch { return fallback }
+  })
+
+  const meRes = await safeFetch(`${BASE}/me`, headers)
+  const me = await meRes.json()
+
+  const tracksCount = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/me/tracks?limit=1&linked_partitioning=1`,
+        headers
+      )
+      const data = await res.json()
+      return safeNumber(data?.collection?.length) > 0
+        ? safeNumber(me.track_count)
+        : safeNumber(me.track_count)
+    },
+    safeNumber(me.track_count),
+    "soundcloud_tracks"
+  )
+
+  return {
+    tracks_count: tracksCount,
+    playlist_count: safeNumber(me.playlist_count),
+    followers_count: safeNumber(me.followers_count),
+    followings_count: safeNumber(me.followings_count),
+    reposts_count: safeNumber(me.reposts_count),
+    public_favorites_count: safeNumber(me.public_favorites_count),
+    is_verified: me.verified ? 1 : 0,
+  }
+}

--- a/services/mastra/src/mastra/signals/spotify.ts
+++ b/services/mastra/src/mastra/signals/spotify.ts
@@ -1,0 +1,80 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { safeFetch, safeNumber } from "./utils"
+
+const BASE = "https://api.spotify.com/v1"
+
+export const fetchSpotifySignals: SignalFetcher = async (
+  token,
+  _userId,
+  ctx
+): Promise<PlatformMetrics> => {
+  const headers = { Authorization: `Bearer ${token}` }
+  const safe = ctx?.safeStep ?? (async (fn, fallback) => {
+    try { return await fn() } catch { return fallback }
+  })
+
+  const meRes = await safeFetch(`${BASE}/me`, headers)
+  const meData = await meRes.json()
+  const userId: string = meData.id
+  const followersTotal = safeNumber(meData.followers?.total)
+
+  const { genres, topArtistsCount } = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/me/top/artists?time_range=medium_term&limit=50`,
+        headers
+      )
+      const data = await res.json()
+      const artists = data.items ?? []
+      const set = new Set<string>()
+      for (const a of artists) for (const g of a.genres ?? []) set.add(g)
+      return { genres: set.size, topArtistsCount: artists.length }
+    },
+    { genres: 0, topArtistsCount: 0 },
+    "spotify_top_artists"
+  )
+
+  const { topTracksCount, avgTrackPopularity } = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/me/top/tracks?time_range=medium_term&limit=50`,
+        headers
+      )
+      const data = await res.json()
+      const tracks = data.items ?? []
+      if (tracks.length === 0) {
+        return { topTracksCount: 0, avgTrackPopularity: 0 }
+      }
+      const totalPop = tracks.reduce(
+        (sum: number, t: any) => sum + safeNumber(t.popularity),
+        0
+      )
+      return {
+        topTracksCount: tracks.length,
+        avgTrackPopularity: Math.round((totalPop / tracks.length) * 10) / 10,
+      }
+    },
+    { topTracksCount: 0, avgTrackPopularity: 0 },
+    "spotify_top_tracks"
+  )
+
+  const ownedPlaylists = await safe(
+    async () => {
+      const res = await safeFetch(`${BASE}/me/playlists?limit=50`, headers)
+      const data = await res.json()
+      const items = data.items ?? []
+      return items.filter((p: any) => p.owner?.id === userId).length
+    },
+    0,
+    "spotify_playlists"
+  )
+
+  return {
+    diversite_genres: genres,
+    playlists_creees: ownedPlaylists,
+    top_artists_count: topArtistsCount,
+    followers: followersTotal,
+    top_tracks_count: topTracksCount,
+    avg_track_popularity: avgTrackPopularity,
+  }
+}

--- a/services/mastra/src/mastra/signals/strava.ts
+++ b/services/mastra/src/mastra/signals/strava.ts
@@ -1,0 +1,70 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { safeFetch, monthsSince, safeNumber } from "./utils"
+
+const BASE = "https://www.strava.com/api/v3"
+
+export const fetchStravaSignals: SignalFetcher = async (
+  token,
+  _userId,
+  ctx
+): Promise<PlatformMetrics> => {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  const safe = ctx?.safeStep ?? (async (fn, fallback) => {
+    try { return await fn() } catch { return fallback }
+  })
+
+  const athleteRes = await safeFetch(`${BASE}/athlete`, headers)
+  const athlete = await athleteRes.json()
+  const athleteId = athlete.id
+
+  const stats = await safe(
+    async () => {
+      const res = await safeFetch(`${BASE}/athletes/${athleteId}/stats`, headers)
+      return await res.json()
+    },
+    {} as any,
+    "strava_stats"
+  )
+
+  const thirtyDaysAgo = Math.floor(
+    (Date.now() - 30 * 24 * 60 * 60 * 1000) / 1000
+  )
+  const activities = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/athlete/activities?after=${thirtyDaysAgo}&per_page=100`,
+        headers
+      )
+      const data = await res.json()
+      return Array.isArray(data) ? data : []
+    },
+    [] as any[],
+    "strava_activities"
+  )
+
+  const kmMois = activities.reduce(
+    (sum: number, a: any) => sum + safeNumber(a.distance) / 1000,
+    0
+  )
+
+  const totalKm =
+    (safeNumber(stats.all_run_totals?.distance) +
+      safeNumber(stats.all_ride_totals?.distance) +
+      safeNumber(stats.all_swim_totals?.distance)) /
+    1000
+
+  return {
+    activites_mois: activities.length,
+    km_mois: Math.round(kmMois * 10) / 10,
+    total_km: Math.round(totalKm),
+    followers: safeNumber(athlete.follower_count),
+    friend_count: safeNumber(athlete.friend_count),
+    ytd_runs: safeNumber(stats.ytd_run_totals?.count),
+    ytd_rides: safeNumber(stats.ytd_ride_totals?.count),
+    anciennete_mois: athlete.created_at ? monthsSince(athlete.created_at) : 0,
+    is_premium: athlete.premium ? 1 : 0,
+  }
+}

--- a/services/mastra/src/mastra/signals/twitch.ts
+++ b/services/mastra/src/mastra/signals/twitch.ts
@@ -1,0 +1,126 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { safeFetch, monthsSince, safeNumber } from "./utils"
+
+const BASE = "https://api.twitch.tv/helix"
+
+export const fetchTwitchSignals: SignalFetcher = async (
+  token,
+  _userId,
+  ctx
+): Promise<PlatformMetrics> => {
+  const clientId = process.env.TWITCH_CLIENT_ID
+  if (!clientId) {
+    throw new Error("TWITCH_CLIENT_ID not configured")
+  }
+
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "Client-Id": clientId,
+  }
+
+  const userRes = await safeFetch(`${BASE}/users`, headers)
+  const userData = await userRes.json()
+  const user = userData.data?.[0]
+
+  if (!user) {
+    return {
+      heures_stream_mois: 0,
+      followers: 0,
+      follows_count: 0,
+      subs_count: 0,
+      anciennete_mois: 0,
+      is_affiliate: 0,
+      is_partner: 0,
+    }
+  }
+
+  const broadcasterId = user.id
+  const safe = ctx?.safeStep ?? (async (fn, fallback) => {
+    try { return await fn() } catch { return fallback }
+  })
+
+  const followers = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/channels/followers?broadcaster_id=${broadcasterId}&moderator_id=${broadcasterId}&first=1`,
+        headers
+      )
+      const data = await res.json()
+      return safeNumber(data.total)
+    },
+    0,
+    "twitch_followers"
+  )
+
+  const followsCount = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/channels/followed?user_id=${broadcasterId}&first=1`,
+        headers
+      )
+      const data = await res.json()
+      return safeNumber(data.total)
+    },
+    0,
+    "twitch_follows"
+  )
+
+  const subsCount = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/subscriptions?broadcaster_id=${broadcasterId}&first=1`,
+        headers
+      )
+      const data = await res.json()
+      return safeNumber(data.total)
+    },
+    0,
+    "twitch_subs"
+  )
+
+  const streamHours = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/videos?user_id=${broadcasterId}&type=archive&first=100`,
+        headers
+      )
+      const data = await res.json()
+      const videos = data.data ?? []
+
+      const thirtyDaysAgo = new Date()
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+
+      let totalSeconds = 0
+      for (const video of videos) {
+        const createdAt = new Date(video.created_at)
+        if (createdAt < thirtyDaysAgo) continue
+        totalSeconds += parseTwitchDuration(video.duration ?? "0h0m0s")
+      }
+      return Math.round(totalSeconds / 3600)
+    },
+    0,
+    "twitch_stream_hours"
+  )
+
+  return {
+    heures_stream_mois: streamHours,
+    followers,
+    follows_count: followsCount,
+    subs_count: subsCount,
+    anciennete_mois: user.created_at ? monthsSince(user.created_at) : 0,
+    is_affiliate: user.broadcaster_type === "affiliate" ? 1 : 0,
+    is_partner: user.broadcaster_type === "partner" ? 1 : 0,
+  }
+}
+
+/**
+ * Parse Twitch duration format "1h2m3s" into seconds
+ */
+function parseTwitchDuration(duration: string): number {
+  const match = duration.match(/(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?/)
+  if (!match) return 0
+  const hours = parseInt(match[1] ?? "0", 10)
+  const minutes = parseInt(match[2] ?? "0", 10)
+  const seconds = parseInt(match[3] ?? "0", 10)
+  return hours * 3600 + minutes * 60 + seconds
+}

--- a/services/mastra/src/mastra/signals/types.ts
+++ b/services/mastra/src/mastra/signals/types.ts
@@ -1,0 +1,14 @@
+export interface PlatformMetrics {
+  [key: string]: number
+}
+
+export interface FetcherContext {
+  warnings: string[]
+  safeStep: <T>(fn: () => Promise<T>, fallback: T, label: string) => Promise<T>
+}
+
+export type SignalFetcher = (
+  token: string,
+  userId?: string,
+  ctx?: FetcherContext
+) => Promise<PlatformMetrics>

--- a/services/mastra/src/mastra/signals/utils.ts
+++ b/services/mastra/src/mastra/signals/utils.ts
@@ -1,0 +1,132 @@
+/**
+ * Calculate months elapsed since a date string (ISO 8601)
+ */
+export function monthsSince(dateString: string): number {
+  const then = new Date(dateString)
+  const now = new Date()
+  const months =
+    (now.getFullYear() - then.getFullYear()) * 12 +
+    (now.getMonth() - then.getMonth())
+  return Math.max(0, months)
+}
+
+/**
+ * Calculate the longest consecutive-day streak from a list of events.
+ * Events must have a `created_at` ISO date field.
+ */
+export function calculateStreak(
+  events: { created_at: string }[]
+): number {
+  if (events.length === 0) return 0
+
+  const uniqueDays = [
+    ...new Set(events.map((e) => e.created_at.slice(0, 10))),
+  ].sort()
+
+  let maxStreak = 1
+  let current = 1
+
+  for (let i = 1; i < uniqueDays.length; i++) {
+    const prev = new Date(uniqueDays[i - 1])
+    const curr = new Date(uniqueDays[i])
+    const diffMs = curr.getTime() - prev.getTime()
+    const diffDays = diffMs / (1000 * 60 * 60 * 24)
+
+    if (diffDays === 1) {
+      current++
+      maxStreak = Math.max(maxStreak, current)
+    } else {
+      current = 1
+    }
+  }
+
+  return maxStreak
+}
+
+/**
+ * Fetch wrapper that throws typed errors for 401/403 (token_expired)
+ */
+export async function safeFetch(
+  url: string,
+  headers: Record<string, string>
+): Promise<Response> {
+  const response = await fetch(url, { headers })
+
+  if (response.status === 401 || response.status === 403) {
+    throw new TokenExpiredError(
+      `API returned ${response.status} — token expired or revoked`
+    )
+  }
+
+  if (!response.ok) {
+    throw new Error(`API returned ${response.status}: ${response.statusText}`)
+  }
+
+  return response
+}
+
+export class TokenExpiredError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "TokenExpiredError"
+  }
+}
+
+/**
+ * Parse a value to a finite number, fallback to 0 if invalid.
+ */
+export function safeNumber(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(n) ? n : 0
+}
+
+/**
+ * Wrap a secondary API call so a single failure doesn't abort the whole fetcher.
+ * Primary fetches (getUser, getRepos, etc.) should NOT use this — they can throw.
+ */
+export async function safeStep<T>(
+  fn: () => Promise<T>,
+  fallback: T,
+  label: string,
+  warnings: string[]
+): Promise<T> {
+  try {
+    return await fn()
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    warnings.push(`${label}:${msg}`)
+    return fallback
+  }
+}
+
+/**
+ * Validate a raw metrics object. Filters out NaN/Infinity, clamps negatives to 0.
+ * Returns sanitized metrics + warnings for invalid entries.
+ */
+export function validateMetrics(raw: unknown): {
+  metrics: Record<string, number>
+  warnings: string[]
+} {
+  const metrics: Record<string, number> = {}
+  const warnings: string[] = []
+
+  if (!raw || typeof raw !== "object") {
+    return { metrics, warnings: ["invalid_metrics_object"] }
+  }
+
+  for (const [k, v] of Object.entries(raw)) {
+    const n = typeof v === "number" ? v : Number(v)
+    if (!Number.isFinite(n)) {
+      warnings.push(`invalid_metric:${k}`)
+      continue
+    }
+    if (n < 0) {
+      warnings.push(`negative_metric:${k}`)
+      metrics[k] = 0
+      continue
+    }
+    metrics[k] = n
+  }
+
+  return { metrics, warnings }
+}

--- a/services/mastra/src/mastra/signals/youtube.ts
+++ b/services/mastra/src/mastra/signals/youtube.ts
@@ -1,0 +1,121 @@
+import type { PlatformMetrics, SignalFetcher } from "./types"
+import { safeFetch, monthsSince, safeNumber } from "./utils"
+
+const BASE = "https://www.googleapis.com/youtube/v3"
+
+export const fetchYoutubeSignals: SignalFetcher = async (
+  token,
+  _userId,
+  ctx
+): Promise<PlatformMetrics> => {
+  const headers = { Authorization: `Bearer ${token}` }
+  const safe = ctx?.safeStep ?? (async (fn, fallback) => {
+    try { return await fn() } catch { return fallback }
+  })
+
+  const channelRes = await safeFetch(
+    `${BASE}/channels?part=statistics,snippet&mine=true`,
+    headers
+  )
+  const channelData = await channelRes.json()
+  const channel = channelData.items?.[0]
+
+  if (!channel) {
+    return {
+      videos_postees: 0,
+      vues_totales: 0,
+      subscribers: 0,
+      subscribers_hidden: 0,
+      videos_recentes_90j: 0,
+      anciennete_mois: 0,
+      avg_views_per_video: 0,
+      avg_likes_per_video: 0,
+      avg_comments_per_video: 0,
+      playlists_count: 0,
+    }
+  }
+
+  const stats = channel.statistics ?? {}
+  const publishedAt = channel.snippet?.publishedAt
+  const hiddenSubs = stats.hiddenSubscriberCount === true
+
+  const ninetyDaysAgo = new Date()
+  ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90)
+  const after = ninetyDaysAgo.toISOString()
+
+  const { recentVideoIds, recentCount } = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/search?forMine=true&type=video&order=date&publishedAfter=${after}&maxResults=50&part=id`,
+        headers
+      )
+      const data = await res.json()
+      const ids: string[] = (data.items ?? [])
+        .map((it: any) => it.id?.videoId)
+        .filter(Boolean)
+      return {
+        recentVideoIds: ids,
+        recentCount: safeNumber(data.pageInfo?.totalResults),
+      }
+    },
+    { recentVideoIds: [] as string[], recentCount: 0 },
+    "youtube_recent_search"
+  )
+
+  const perVideo = await safe(
+    async () => {
+      if (recentVideoIds.length === 0) {
+        return { avgViews: 0, avgLikes: 0, avgComments: 0 }
+      }
+      const ids = recentVideoIds.slice(0, 50).join(",")
+      const res = await safeFetch(
+        `${BASE}/videos?id=${ids}&part=statistics`,
+        headers
+      )
+      const data = await res.json()
+      const videos = data.items ?? []
+      if (videos.length === 0) {
+        return { avgViews: 0, avgLikes: 0, avgComments: 0 }
+      }
+      let views = 0, likes = 0, comments = 0
+      for (const v of videos) {
+        views += safeNumber(v.statistics?.viewCount)
+        likes += safeNumber(v.statistics?.likeCount)
+        comments += safeNumber(v.statistics?.commentCount)
+      }
+      return {
+        avgViews: Math.round(views / videos.length),
+        avgLikes: Math.round(likes / videos.length),
+        avgComments: Math.round(comments / videos.length),
+      }
+    },
+    { avgViews: 0, avgLikes: 0, avgComments: 0 },
+    "youtube_per_video_stats"
+  )
+
+  const playlistsCount = await safe(
+    async () => {
+      const res = await safeFetch(
+        `${BASE}/playlists?mine=true&maxResults=50&part=id`,
+        headers
+      )
+      const data = await res.json()
+      return safeNumber(data.pageInfo?.totalResults)
+    },
+    0,
+    "youtube_playlists"
+  )
+
+  return {
+    videos_postees: safeNumber(stats.videoCount),
+    vues_totales: safeNumber(stats.viewCount),
+    subscribers: hiddenSubs ? 0 : safeNumber(stats.subscriberCount),
+    subscribers_hidden: hiddenSubs ? 1 : 0,
+    videos_recentes_90j: recentCount,
+    anciennete_mois: publishedAt ? monthsSince(publishedAt) : 0,
+    avg_views_per_video: perVideo.avgViews,
+    avg_likes_per_video: perVideo.avgLikes,
+    avg_comments_per_video: perVideo.avgComments,
+    playlists_count: playlistsCount,
+  }
+}

--- a/services/mastra/src/mastra/workflows/link-social-workflow.ts
+++ b/services/mastra/src/mastra/workflows/link-social-workflow.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import { createPublicClient, createWalletClient, http, stringToHex, encodeFunctionData } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
+import { storeToken } from '../db/tokens';
+import { verifyAndGetUserId, type Platform } from '../oauth/verify';
 import { intuitionMainnet, RPC_URL } from '../config/chain';
 import {
   MULTIVAULT_ADDRESS,
@@ -14,12 +16,11 @@ import {
 } from '../config/constants';
 import { MultiVaultAbi } from '../config/abi';
 
-// Intuition GraphQL endpoint for pinning
 const INTUITION_GRAPHQL_ENDPOINT = 'https://mainnet.intuition.sh/v1/graphql';
 
 /**
- * Pin data to IPFS via Intuition's pinThing mutation
- * Returns the IPFS URI that will be used as the atom data
+ * Pin data to IPFS via Intuition's pinThing mutation.
+ * Returns the IPFS URI used as the atom data.
  */
 async function pinToIPFS(name: string, description: string): Promise<string> {
   const mutation = `
@@ -32,20 +33,13 @@ async function pinToIPFS(name: string, description: string): Promise<string> {
 
   const response = await fetch(INTUITION_GRAPHQL_ENDPOINT, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       query: mutation,
       variables: {
-        thing: {
-          name,
-          description,
-          image: '',
-          url: ''
-        }
-      }
-    })
+        thing: { name, description, image: '', url: '' },
+      },
+    }),
   });
 
   if (!response.ok) {
@@ -66,11 +60,7 @@ async function pinToIPFS(name: string, description: string): Promise<string> {
   return uri;
 }
 
-// Platform type
-type Platform = 'discord' | 'youtube' | 'spotify' | 'twitch' | 'twitter';
-
-// Predicate names for each platform (for logging)
-const PREDICATE_NAMES: Record<Platform, string> = {
+const PREDICATE_NAMES: Record<string, string> = {
   discord: 'has verified discord id',
   youtube: 'has verified youtube id',
   spotify: 'has verified spotify id',
@@ -78,8 +68,16 @@ const PREDICATE_NAMES: Record<Platform, string> = {
   twitter: 'has verified twitter id',
 };
 
-// Pre-existing predicate term IDs for each platform (already on-chain)
-const PREDICATE_TERM_IDS: Record<Platform, `0x${string}`> = {
+/**
+ * Pre-existing predicate term IDs already on-chain. Platforms NOT listed here
+ * will get their token stored and verified, but the on-chain triple creation
+ * is skipped (it would fail without a predicate atom).
+ *
+ * To enable on-chain linking for a new platform: create the
+ * "has verified <platform> id" atom on the Intuition contract, then add the
+ * resulting term_id to ../config/constants.ts and reference it here.
+ */
+const PREDICATE_TERM_IDS: Partial<Record<Platform, `0x${string}`>> = {
   youtube: TERM_ID_HAS_VERIFIED_YOUTUBE,
   discord: TERM_ID_HAS_VERIFIED_DISCORD,
   spotify: TERM_ID_HAS_VERIFIED_SPOTIFY,
@@ -87,14 +85,28 @@ const PREDICATE_TERM_IDS: Record<Platform, `0x${string}`> = {
   twitter: TERM_ID_HAS_VERIFIED_TWITTER,
 };
 
-// Input schema
 const inputSchema = z.object({
   walletAddress: z.string().describe('User wallet address'),
-  platform: z.enum(['discord', 'youtube', 'spotify', 'twitch', 'twitter']).describe('Social platform'),
+  platform: z
+    .enum([
+      'discord',
+      'youtube',
+      'spotify',
+      'twitch',
+      'twitter',
+      'github',
+      'reddit',
+      'strava',
+      'soundcloud',
+      'mixcloud',
+      'producthunt',
+      'orcid',
+      'coinbase',
+    ])
+    .describe('Social platform'),
   oauthToken: z.string().describe('OAuth access token'),
 });
 
-// Output schema
 const outputSchema = z.object({
   success: z.boolean(),
   platform: z.string().optional(),
@@ -105,137 +117,23 @@ const outputSchema = z.object({
   walletAtomCreated: z.boolean().optional(),
   predicateAtomCreated: z.boolean().optional(),
   socialAtomCreated: z.boolean().optional(),
+  onchainSkipped: z.boolean().optional(),
   error: z.string().optional(),
 });
-
-// OAuth verification result
-interface OAuthVerificationResult {
-  valid: boolean;
-  userId?: string;
-  username?: string;
-  error?: string;
-}
-
-// OAuth endpoints configuration
-const OAUTH_ENDPOINTS = {
-  youtube: {
-    url: 'https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true',
-    authHeader: (token: string) => `Bearer ${token}`,
-  },
-  spotify: {
-    url: 'https://api.spotify.com/v1/me',
-    authHeader: (token: string) => `Bearer ${token}`,
-  },
-  discord: {
-    url: 'https://discord.com/api/users/@me',
-    authHeader: (token: string) => `Bearer ${token}`,
-  },
-  twitch: {
-    url: 'https://api.twitch.tv/helix/users',
-    authHeader: (token: string) => `Bearer ${token}`,
-    requiresClientId: true,
-  },
-  twitter: {
-    url: 'https://api.twitter.com/2/users/me',
-    authHeader: (token: string) => `Bearer ${token}`,
-  },
-} as const;
-
-/**
- * Verify OAuth token and retrieve user ID
- */
-async function verifyAndGetUserId(
-  platform: Platform,
-  token: string,
-  clientId?: string
-): Promise<OAuthVerificationResult> {
-  const endpoint = OAUTH_ENDPOINTS[platform];
-
-  try {
-    const headers: Record<string, string> = {
-      Authorization: endpoint.authHeader(token),
-    };
-
-    if (platform === 'twitch') {
-      const twitchClientId = clientId || process.env.TWITCH_CLIENT_ID;
-      if (!twitchClientId) {
-        return { valid: false, error: 'Twitch Client ID required' };
-      }
-      headers['Client-Id'] = twitchClientId;
-    }
-
-    const response = await fetch(endpoint.url, { headers });
-
-    if (!response.ok) {
-      return { valid: false, error: `API returned ${response.status}` };
-    }
-
-    const data = await response.json();
-
-    console.log(`[LinkSocialWorkflow] ${platform} API response:`, JSON.stringify(data).substring(0, 500));
-
-    // Extract userId based on platform
-    let userId: string | undefined;
-    let username: string | undefined;
-
-    switch (platform) {
-      case 'discord':
-        // Discord: { id: "123456789", username: "user" }
-        userId = data.id ? String(data.id) : undefined;
-        username = data.username ? String(data.username) : undefined;
-        break;
-      case 'youtube':
-        // YouTube: { items: [{ id: "UCxxxxx", snippet: { title: "Channel Name" } }] }
-        userId = data.items?.[0]?.id ? String(data.items[0].id) : undefined;
-        username = data.items?.[0]?.snippet?.title ? String(data.items[0].snippet.title) : undefined;
-        break;
-      case 'spotify':
-        // Spotify: { id: "user123", display_name: "User Name" }
-        userId = data.id ? String(data.id) : undefined;
-        username = data.display_name ? String(data.display_name) : undefined;
-        break;
-      case 'twitch':
-        // Twitch: { data: [{ id: "123456", login: "username" }] }
-        userId = data.data?.[0]?.id ? String(data.data[0].id) : undefined;
-        username = data.data?.[0]?.login ? String(data.data[0].login) : undefined;
-        break;
-      case 'twitter':
-        // Twitter: { data: { id: "123456789", username: "user" } }
-        userId = data.data?.id ? String(data.data.id) : undefined;
-        username = data.data?.username ? String(data.data.username) : undefined;
-        break;
-    }
-
-    console.log(`[LinkSocialWorkflow] ${platform} extracted userId: ${userId}, username: ${username}`);
-
-    if (!userId) {
-      return { valid: false, error: `Could not extract user ID from ${platform} response` };
-    }
-
-    return { valid: true, userId, username };
-  } catch (error) {
-    console.error(`[LinkSocialWorkflow] ${platform}: Verification failed:`, error);
-    return { valid: false, error: error instanceof Error ? error.message : 'Unknown error' };
-  }
-}
 
 /**
  * Link Social Workflow
  *
- * Links a social account to a wallet by creating a triple on-chain:
- * [wallet] [has verified {platform} id] [userId]
+ * Verifies the OAuth token, stores it encrypted, and (when a predicate atom
+ * exists on-chain) creates the triple `[wallet] [has verified {platform} id] [userId]`.
  *
- * Uses pre-existing predicate atoms from PREDICATE_TERM_IDS (already on-chain).
- *
- * Flow:
- * 1. Verify OAuth token and extract userId
- * 2. Create wallet atom if needed
- * 3. Create social atom (userId) if needed
- * 4. Create triple [wallet] [predicate] [userId] using pre-existing predicate term ID
+ * For platforms without an on-chain predicate atom yet, the workflow still
+ * verifies and stores the token — signal fetching works, on-chain proof is
+ * skipped until the predicate atom is created.
  */
 const executeLinkSocial = createStep({
   id: 'execute-link-social',
-  description: 'Verify OAuth token and link social account to wallet on-chain',
+  description: 'Verify OAuth token, store it, and link the platform on-chain when possible',
   inputSchema,
   outputSchema,
   execute: async ({ inputData }) => {
@@ -264,9 +162,39 @@ const executeLinkSocial = createStep({
       };
     }
 
-    console.log(`[LinkSocialWorkflow] Verified ${platform} user: ${verification.userId} (${verification.username})`);
+    console.log(
+      `[LinkSocialWorkflow] Verified ${platform} user: ${verification.userId} (${verification.username})`,
+    );
 
-    // Check for BOT_PRIVATE_KEY
+    // Step 2: Store the OAuth token (encrypted) — non-blocking
+    try {
+      await storeToken(
+        walletAddress,
+        platform,
+        oauthToken,
+        undefined,
+        verification.userId,
+        verification.username,
+      );
+    } catch (err) {
+      console.warn('[LinkSocialWorkflow] Token storage failed (non-blocking):', err);
+    }
+
+    // Step 3: Check if we have a predicate atom for on-chain link
+    const predicateAtomId = PREDICATE_TERM_IDS[platform];
+    if (!predicateAtomId) {
+      console.log(
+        `[LinkSocialWorkflow] No predicate atom for ${platform} — skipping on-chain link.`,
+      );
+      return {
+        success: true,
+        platform,
+        userId: verification.userId,
+        username: verification.username,
+        onchainSkipped: true,
+      };
+    }
+
     const botPrivateKey = process.env.BOT_PRIVATE_KEY;
     if (!botPrivateKey) {
       return {
@@ -279,7 +207,6 @@ const executeLinkSocial = createStep({
     }
 
     try {
-      // Create viem clients
       const account = privateKeyToAccount(botPrivateKey as `0x${string}`);
       const publicClient = createPublicClient({
         chain: intuitionMainnet,
@@ -293,25 +220,20 @@ const executeLinkSocial = createStep({
 
       console.log(`[LinkSocialWorkflow] Bot address: ${account.address}`);
 
-      // Build atom data
-      // Social atom = pin to IPFS with name = userId, so the label will be the userId
       const userId = verification.userId;
       const socialDescription = `Verified ${platform} account ID`;
 
-      console.log(`[LinkSocialWorkflow] Pinning social atom to IPFS: name=${userId}, description=${socialDescription}`);
+      console.log(
+        `[LinkSocialWorkflow] Pinning social atom to IPFS: name=${userId}, description=${socialDescription}`,
+      );
       const socialIpfsUri = await pinToIPFS(userId, socialDescription);
       console.log(`[LinkSocialWorkflow] Social atom IPFS URI: ${socialIpfsUri}`);
 
       const socialAtomDataHex = stringToHex(socialIpfsUri);
-
-      // Use pre-existing predicate term ID (already on-chain)
       const predicateName = PREDICATE_NAMES[platform];
-      const predicateAtomId = PREDICATE_TERM_IDS[platform];
 
-      console.log(`[LinkSocialWorkflow] Social atom data (IPFS URI): ${socialIpfsUri}`);
       console.log(`[LinkSocialWorkflow] Predicate: ${predicateName} (term_id: ${predicateAtomId})`);
 
-      // Calculate atom IDs (predicate already exists, no need to calculate)
       const walletAtomData = stringToHex(walletAddress);
       const [walletAtomId, socialAtomId] = await Promise.all([
         publicClient.readContract({
@@ -330,9 +252,7 @@ const executeLinkSocial = createStep({
 
       console.log(`[LinkSocialWorkflow] Wallet atom ID: ${walletAtomId}`);
       console.log(`[LinkSocialWorkflow] Social atom ID: ${socialAtomId}`);
-      console.log(`[LinkSocialWorkflow] Predicate atom ID: ${predicateAtomId} (pre-existing)`);
 
-      // Check if atoms exist (predicate already exists on-chain, no need to check)
       const [walletAtomExists, socialAtomExists] = await Promise.all([
         publicClient.readContract({
           address: MULTIVAULT_ADDRESS,
@@ -350,13 +270,8 @@ const executeLinkSocial = createStep({
 
       console.log(`[LinkSocialWorkflow] Wallet atom exists: ${walletAtomExists}`);
       console.log(`[LinkSocialWorkflow] Social atom exists: ${socialAtomExists}`);
-      console.log(`[LinkSocialWorkflow] Predicate atom exists: true (pre-existing)`);
 
-      // Note: We don't check if social atom exists anymore because the same userId
-      // could be used across different platforms. The uniqueness is in the triple itself.
-
-      // Get costs and config from contract
-      const [atomCost, tripleCost, generalConfig] = await Promise.all([
+      const [atomCost, tripleCost] = await Promise.all([
         publicClient.readContract({
           address: MULTIVAULT_ADDRESS,
           abi: MultiVaultAbi,
@@ -367,29 +282,19 @@ const executeLinkSocial = createStep({
           abi: MultiVaultAbi,
           functionName: 'getTripleCost',
         }) as Promise<bigint>,
-        publicClient.readContract({
-          address: MULTIVAULT_ADDRESS,
-          abi: MultiVaultAbi,
-          functionName: 'getGeneralConfig',
-        }) as Promise<{ minDeposit: bigint }>,
       ]);
 
-      const minDeposit = generalConfig.minDeposit;
-      console.log(`[LinkSocialWorkflow] atomCost: ${atomCost}, tripleCost: ${tripleCost}, minDeposit: ${minDeposit}`);
+      console.log(`[LinkSocialWorkflow] atomCost: ${atomCost}, tripleCost: ${tripleCost}`);
 
-      // Deposit amounts
-      const atomDeposit = 500000000000000000n; // 0.5 TRUST for atom creation
-      const tripleExtraDeposit = 500000000000000000n; // 0.5 TRUST extra for triple
+      const atomDeposit = 500000000000000000n; // 0.5 TRUST
+      const tripleExtraDeposit = 500000000000000000n; // 0.5 TRUST extra for fees
 
       let walletAtomCreated = false;
       let socialAtomCreated = false;
 
-      // Step 2: Create wallet atom if needed
       if (!walletAtomExists) {
         console.log(`[LinkSocialWorkflow] Creating wallet atom...`);
-
         const atomTotalValue = atomCost + atomDeposit;
-
         const atomCallData = encodeFunctionData({
           abi: MultiVaultAbi,
           functionName: 'createAtoms',
@@ -420,13 +325,8 @@ const executeLinkSocial = createStep({
         walletAtomCreated = true;
       }
 
-      // Note: Predicate atoms already exist on-chain (pre-created)
-      // No need to create them - using PREDICATE_TERM_IDS directly
-
-      // Step 3: Create social atom (userId) if needed
       if (!socialAtomExists) {
         console.log(`[LinkSocialWorkflow] Creating social atom: ${userId} (IPFS: ${socialIpfsUri})`);
-
         const socialAtomTotalValue = atomCost + atomDeposit;
 
         const socialAtomCallData = encodeFunctionData({
@@ -443,7 +343,9 @@ const executeLinkSocial = createStep({
         });
 
         console.log(`[LinkSocialWorkflow] Social atom TX: ${createSocialAtomHash}`);
-        const socialAtomReceipt = await publicClient.waitForTransactionReceipt({ hash: createSocialAtomHash });
+        const socialAtomReceipt = await publicClient.waitForTransactionReceipt({
+          hash: createSocialAtomHash,
+        });
 
         if (socialAtomReceipt.status !== 'success') {
           return {
@@ -456,12 +358,15 @@ const executeLinkSocial = createStep({
           };
         }
 
-        console.log(`[LinkSocialWorkflow] Social atom created in block ${socialAtomReceipt.blockNumber}`);
+        console.log(
+          `[LinkSocialWorkflow] Social atom created in block ${socialAtomReceipt.blockNumber}`,
+        );
         socialAtomCreated = true;
       }
 
-      // Step 4: Create triple [wallet] [has verified {platform} id] [userId]
-      console.log(`[LinkSocialWorkflow] Creating triple: [${walletAddress}] [${predicateName}] [${userId}]`);
+      console.log(
+        `[LinkSocialWorkflow] Creating triple: [${walletAddress}] [${predicateName}] [${userId}]`,
+      );
 
       const tripleDepositAmount = tripleCost + tripleExtraDeposit;
 
@@ -469,10 +374,10 @@ const executeLinkSocial = createStep({
         abi: MultiVaultAbi,
         functionName: 'createTriples',
         args: [
-          [walletAtomId as `0x${string}`],      // subjectIds - wallet
-          [predicateAtomId as `0x${string}`],   // predicateIds - has verified {platform} id
-          [socialAtomId as `0x${string}`],      // objectIds - userId
-          [tripleDepositAmount],                // assets
+          [walletAtomId as `0x${string}`],
+          [predicateAtomId as `0x${string}`],
+          [socialAtomId as `0x${string}`],
+          [tripleDepositAmount],
         ],
       });
 
@@ -508,7 +413,7 @@ const executeLinkSocial = createStep({
         txHash: tripleTxHash,
         blockNumber: Number(tripleReceipt.blockNumber),
         walletAtomCreated,
-        predicateAtomCreated: false, // Pre-existing, not created
+        predicateAtomCreated: false,
         socialAtomCreated,
       };
     } catch (error) {
@@ -524,7 +429,6 @@ const executeLinkSocial = createStep({
   },
 });
 
-// Create the workflow
 const linkSocialWorkflow = createWorkflow({
   id: 'link-social-workflow',
   inputSchema,

--- a/services/mastra/src/mastra/workflows/signal-fetcher-workflow.ts
+++ b/services/mastra/src/mastra/workflows/signal-fetcher-workflow.ts
@@ -1,0 +1,111 @@
+import { createStep, createWorkflow } from "@mastra/core/workflows"
+import { z } from "zod"
+import { getToken } from "../db/tokens"
+import {
+  SIGNAL_FETCHERS,
+  WALLET_BASED_PLATFORMS,
+  runFetcher,
+} from "../signals/registry"
+import { TokenExpiredError } from "../signals/utils"
+
+const inputSchema = z.object({
+  platform: z.string().describe("Platform to fetch signals from"),
+  walletAddress: z.string().describe("User wallet address"),
+})
+
+const outputSchema = z.object({
+  success: z.boolean(),
+  platformId: z.string().optional(),
+  fetchedAt: z.number().optional(),
+  metrics: z.record(z.string(), z.number()).optional(),
+  warnings: z.array(z.string()).optional(),
+  error: z.string().optional(),
+})
+
+const executeSignalFetch = createStep({
+  id: "execute-signal-fetch",
+  description:
+    "Fetch platform metrics. Token-based for OAuth platforms, walletAddress-based for web3.",
+  inputSchema,
+  outputSchema,
+  execute: async ({ inputData }) => {
+    const { platform, walletAddress } = inputData
+
+    if (!platform || !walletAddress) {
+      return { success: false, error: "platform and walletAddress required" }
+    }
+
+    console.log(
+      `[SignalFetcher] Fetching ${platform} signals for ${walletAddress.slice(0, 8)}...`
+    )
+
+    if (!SIGNAL_FETCHERS[platform]) {
+      return { success: false, platformId: platform, error: "no_fetcher" }
+    }
+
+    const isWalletBased = WALLET_BASED_PLATFORMS.has(platform)
+
+    let credential: string
+    let userIdHint: string | undefined
+
+    if (isWalletBased) {
+      credential = walletAddress
+      userIdHint = walletAddress
+    } else {
+      const tokenRecord = await getToken(walletAddress, platform)
+      if (!tokenRecord) {
+        return { success: false, platformId: platform, error: "no_token" }
+      }
+      credential = tokenRecord.access_token
+      userIdHint = tokenRecord.user_id
+    }
+
+    try {
+      const { metrics, warnings } = await runFetcher(
+        platform,
+        credential,
+        userIdHint
+      )
+
+      console.log(
+        `[SignalFetcher] ${platform} metrics: ${Object.keys(metrics).join(", ")}` +
+          (warnings.length ? ` | warnings: ${warnings.length}` : "")
+      )
+
+      return {
+        success: true,
+        platformId: platform,
+        fetchedAt: Date.now(),
+        metrics,
+        warnings,
+      }
+    } catch (error) {
+      if (error instanceof TokenExpiredError) {
+        console.warn(`[SignalFetcher] ${platform} token expired`)
+        return {
+          success: false,
+          platformId: platform,
+          error: "token_expired",
+        }
+      }
+
+      console.error(`[SignalFetcher] ${platform} fetch error:`, error)
+      return {
+        success: false,
+        platformId: platform,
+        error:
+          error instanceof Error ? error.message : "Unknown fetch error",
+      }
+    }
+  },
+})
+
+const signalFetcherWorkflow = createWorkflow({
+  id: "signal-fetcher-workflow",
+  inputSchema,
+  outputSchema,
+}).then(executeSignalFetch)
+
+signalFetcherWorkflow.commit()
+
+export { signalFetcherWorkflow }


### PR DESCRIPTION
…-phase-1

Brings the OAuth scaffold and 12 signal fetchers from the standalone sofia-mastra branch into the monorepo's services/mastra/. Without this, the Explorer's /oauth/{platformId}/authorize calls 404 and platform "Connect" buttons are dead.

OAuth scaffold (services/mastra/src/mastra/oauth/):
  - config.ts  — provider config for 12 platforms (auth/token URLs, scopes, quirks: Spotify basic auth, Reddit user-agent, Strava comma-separated scopes, GitHub Accept header, Product Hunt GraphQL).
  - exchange.ts — code → access_token, handles per-provider exchange quirks.
  - verify.ts  — verifyAndGetUserId(): hits each provider /me endpoint and extracts userId/username for the on-chain triple.
  - routes.ts  — Hono apiRoutes for GET /oauth/:platform/authorize (302) + POST /oauth/:platform/callback (token exchange + verify).

Encrypted token store (services/mastra/src/mastra/db/tokens.ts):
  - libSQL + AES-256-GCM, key from TOKEN_ENCRYPTION_KEY env (64-char hex).
  - oauth_tokens table created at boot via initTokenTable().
  - Warns silently if key missing — token storage becomes a no-op.

Signal fetchers (services/mastra/src/mastra/signals/):
  - types.ts, utils.ts (TokenExpiredError, safeFetch, monthsSince, calculateStreak, validateMetrics), registry.ts.
  - 12 OAuth fetchers: youtube, spotify, discord, twitch, github, reddit, strava, soundcloud, mixcloud, producthunt, orcid, coinbase.
  - Registry already wires the 10 existing on-chain fetchers (signals/onchain/).

Workflows:
  - signal-fetcher-workflow.ts: loads token from DB → runs fetcher → returns metrics. Wallet-based platforms bypass the token lookup.
  - link-social-workflow.ts: refactored to import verifyAndGetUserId from oauth/verify (instead of inlining ~110 lines), calls storeToken after successful verification, extends Platform enum to 12 platforms, and skips on-chain link gracefully for platforms without a predicate atom yet (returns onchainSkipped: true).

Mastra registration (services/mastra/src/mastra/index.ts):
  - Mounts oauthRoutes via server.apiRoutes, registers signalFetcherWorkflow, fires initTokenTable() at boot.

Misc:
  - Added @libsql/client as direct dep (was transitive via @mastra/libsql).
  - .env.example lists the 13 new env vars (TOKEN_ENCRYPTION_KEY + {provider}_CLIENT_ID/SECRET for 12 providers).
  - 7 docs/*.md ported for credential setup + future phases.
  - .gitignore: removed /docs entry so the docs ship with the package.

Out of scope: the 70+ remaining oauth2 platforms (see docs/plan-oauth-extension.md), token refresh, on-chain predicate atoms for github/reddit/strava/soundcloud/mixcloud/producthunt/orcid/coinbase (currently skipped on link).