### PR TITLE
feat(explorer): wire circle creation through cart drawer

### DIFF
--- a/apps/explorer/src/App.tsx
+++ b/apps/explorer/src/App.tsx
@@ -87,7 +87,7 @@ export default function App() {
     location.pathname.startsWith('/streaks') ||
     location.pathname.startsWith('/leaderboard') ||
     location.pathname.startsWith('/settings')
-  const [cartOpen, setCartOpen] = useState(false)
+  const cartOpen = cart.isOpen
   const [profileDrawerOpen, setProfileDrawerOpen] = useState(false)
   const [weightModalOpen, setWeightModalOpen] = useState(false)
 
@@ -96,15 +96,10 @@ export default function App() {
     setProfileDrawerOpen(false)
   }, [location.pathname])
 
-  // Auto-close cart when it becomes empty
-  useEffect(() => {
-    if (cartOpen && cart.count === 0) setCartOpen(false)
-  }, [cartOpen, cart.count])
-
   const handleCartSubmit = useCallback(() => {
-    setCartOpen(false)
+    cart.close()
     setWeightModalOpen(true)
-  }, [])
+  }, [cart])
 
   const handleDepositSuccess = useCallback(() => {
     cart.clear()
@@ -149,7 +144,7 @@ export default function App() {
         <InterestsHydrationBoundary />
         <WsStatusBadge />
         <NavSidebar
-          onCartClick={() => setCartOpen((o) => !o)}
+          onCartClick={cart.toggle}
           collapsed={navCollapsed}
           onToggleCollapse={toggleNavCollapsed}
         />
@@ -160,7 +155,7 @@ export default function App() {
         <CartDrawer
           items={cart.items}
           isOpen={cartOpen}
-          onClose={() => setCartOpen(false)}
+          onClose={cart.close}
           onRemove={cart.removeItem}
           onClear={cart.clear}
           onSubmit={handleCartSubmit}

--- a/apps/explorer/src/components/WeightModal.tsx
+++ b/apps/explorer/src/components/WeightModal.tsx
@@ -2,16 +2,27 @@ import { useState, useEffect, useMemo, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { usePrivy, useWallets } from '@privy-io/react-auth'
 import { useQueryClient } from '@tanstack/react-query'
+import { usePinThingMutation } from '@0xsofia/graphql'
 import { useDeposit } from '../hooks/useDeposit'
 import { useFeeEstimate } from '../hooks/useFeeEstimate'
+import { useUserAccountAtom } from '../hooks/useUserAccountAtom'
 import type { CartItem } from '../hooks/useCart'
-import { EXPLORER_URL } from '../config'
+import { EXPLORER_URL, PREDICATE_IDS } from '../config'
+import {
+  HAS_TAG_PREDICATE_ID,
+  TOPIC_ATOM_IDS,
+} from '../config/atomIds'
 import { intentionBadgeStyle } from '../config/intentions'
 import {
   executeCreateTriplesBatch,
   type BatchCreateTripleItem,
   type CreateTripleResult,
 } from '../services/tripleCreationService'
+import {
+  executeCreateAtomsBatch,
+  type AtomIPFSPayload,
+  type PinThingFn,
+} from '../services/atomCreationService'
 import SofiaLoader from './ui/SofiaLoader'
 import './styles/weight-modal.css'
 
@@ -47,6 +58,22 @@ export default function WeightModal({
   const { authenticated } = usePrivy()
   const { wallets } = useWallets()
   const qc = useQueryClient()
+  // Resolve the wallet's Account atom term_id — required as the subject
+  // of any membership triple we mint when items[].kind === 'create-circle'.
+  const userAccountAtom = useUserAccountAtom(wallets[0]?.address)
+  // Static fetcher exposed alongside the React Query mutation hook —
+  // we use it here to keep the create flow fully callable from a sync
+  // event handler without needing a separate `mutate` callback.
+  const pinThing: PinThingFn = useCallback(
+    (vars) =>
+      usePinThingMutation.fetcher({
+        name: vars.name,
+        description: vars.description,
+        image: vars.image,
+        url: vars.url,
+      })(),
+    [],
+  )
 
   useEffect(() => {
     if (isOpen && items.length > 0) {
@@ -102,13 +129,18 @@ export default function WeightModal({
     })
   }
 
-  // Cart items split by kind so we route to the right contract call.
-  // create-triple items go through `executeCreateTriplesBatch` (mints
-  // the new triple + initial deposit), classic deposit items keep
-  // using `useDeposit.depositBatch`.
+  // Cart items split by kind so we route to the right contract call:
+  //   - 'deposit'        → useDeposit.depositBatch
+  //   - 'create-triple'  → executeCreateTriplesBatch
+  //   - 'create-circle'  → executeCreateAtomsBatch THEN executeCreateTriplesBatch
+  //                        (the membership + has_tag triples reference the
+  //                        atom ids returned by the atom batch)
   const handleSubmit = useCallback(async () => {
     const depositItems: { termId: string; amountTrust: number }[] = []
     const createItems: BatchCreateTripleItem[] = []
+    /** Indices of items[] that are 'create-circle', kept in order so
+     *  we can map them back to their amounts after the atom batch. */
+    const circleIndices: number[] = []
     items.forEach((item, i) => {
       const amount = getAmount(i)
       if (
@@ -123,6 +155,8 @@ export default function WeightModal({
           objectId: item.objectId,
           signalTrust: amount,
         })
+      } else if (item.kind === 'create-circle' && item.circleDraft) {
+        circleIndices.push(i)
       } else {
         depositItems.push({ termId: item.termId, amountTrust: amount })
       }
@@ -135,6 +169,95 @@ export default function WeightModal({
       if (!r.success) allOk = false
     }
 
+    // Phase A — mint every queued circle atom in one tx, then derive
+    // the membership + has_tag triples that reference the new atom ids.
+    if (circleIndices.length > 0) {
+      if (!authenticated || wallets.length === 0) {
+        setCreateTripleResult({ success: false, error: 'No wallet connected' })
+        return
+      }
+      if (!userAccountAtom.exists || !userAccountAtom.termId) {
+        setCreateTripleResult({
+          success: false,
+          error:
+            'Your Account atom is not yet on-chain. Make any deposit or certification first, then retry.',
+        })
+        return
+      }
+
+      setCreateTripleProcessing(true)
+      setCreateTripleResult(null)
+      try {
+        const payloads: AtomIPFSPayload[] = circleIndices.map((idx) => {
+          const draft = items[idx].circleDraft!
+          return {
+            name: draft.name,
+            description: draft.description,
+            image: '',
+            // Sentinel URL — the protocol uses this string for atom
+            // dedupe. `circle:<name>` keeps it human-readable in the
+            // indexer and avoids collisions with content URLs.
+            url: `circle:${draft.name}`,
+          }
+        })
+
+        const atomBatch = await executeCreateAtomsBatch(
+          wallets[0],
+          payloads,
+          pinThing,
+        )
+        if (!atomBatch.success) {
+          setCreateTripleResult({
+            success: false,
+            error: atomBatch.error ?? 'Circle atom creation failed',
+          })
+          return
+        }
+
+        // For each circle atom, push membership + has_tag triples into
+        // the existing createItems batch — single triple-batch tx mints
+        // them all together (1 + N per circle).
+        const userAtomId = userAccountAtom.termId
+        circleIndices.forEach((idx, i) => {
+          const result = atomBatch.results[i]
+          const atomId = result?.atomId
+          if (!atomId) return
+          const item = items[idx]
+          const draft = item.circleDraft!
+          const amount = getAmount(idx)
+
+          // Membership: account → MEMBER_OF → circle
+          createItems.push({
+            subjectId: userAtomId,
+            predicateId: PREDICATE_IDS.MEMBER_OF,
+            objectId: atomId,
+            signalTrust: amount,
+          })
+
+          // Topic tags: circle → has_tag → topic (one per selected topic)
+          for (const topicSlug of draft.topicIds) {
+            const topicAtomId = TOPIC_ATOM_IDS[topicSlug]
+            if (!topicAtomId) continue
+            createItems.push({
+              subjectId: atomId,
+              predicateId: HAS_TAG_PREDICATE_ID,
+              objectId: topicAtomId,
+              signalTrust: amount,
+            })
+          }
+        })
+      } catch (err) {
+        setCreateTripleResult({
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        setCreateTripleProcessing(false)
+        return
+      }
+    }
+
+    // Phase B — single triple-batch tx (covers both pre-existing
+    // create-triple items and newly-derived circle triples).
     if (createItems.length > 0) {
       if (!authenticated || wallets.length === 0) {
         setCreateTripleResult({
@@ -172,6 +295,9 @@ export default function WeightModal({
     wallets,
     qc,
     onSuccess,
+    userAccountAtom.exists,
+    userAccountAtom.termId,
+    pinThing,
   ])
 
   const handleClose = () => {

--- a/apps/explorer/src/components/circles/CreateCircleDrawer.tsx
+++ b/apps/explorer/src/components/circles/CreateCircleDrawer.tsx
@@ -1,14 +1,16 @@
 /**
  * CreateCircleDrawer — slide-in form for creating a new circle.
  * Mirrors AllMembersPanel's drawer chrome (backdrop + right-side aside)
- * so the two share visual language. The submit handler is a no-op
- * pending the on-chain primitive — see CreateCircleCard's TODO.
+ * so the two share visual language. On submit we queue a
+ * `kind: 'create-circle'` cart item — WeightModal expands it into a
+ * circle atom + membership triple + N has_tag triples at submit time.
  */
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ArrowUpRight, ChevronDown, Search, X } from 'lucide-react'
 import { type AccountAtom, useSearchAccounts } from '@/hooks/useSearchAccounts'
 import { SOFIA_TOPICS } from '@/config/taxonomy'
+import { useCart, type CircleDraft } from '@/hooks/useCart'
 
 const TOPIC_PREVIEW_COUNT = 6
 
@@ -28,7 +30,9 @@ interface DraftCircle {
   name: string
   description: string
   actionsPerMonth: number
-  topicId: string | null
+  /** Multi-select — each selected topic produces one (circle, has_tag,
+   *  topic) triple alongside the membership triple at submit. */
+  topicIds: string[]
   members: DraftMember[]
 }
 
@@ -36,7 +40,7 @@ const EMPTY_DRAFT: DraftCircle = {
   name: '',
   description: '',
   actionsPerMonth: 30,
-  topicId: null,
+  topicIds: [],
   members: [],
 }
 
@@ -47,6 +51,7 @@ export default function CreateCircleDrawer({
   onClose,
 }: CreateCircleDrawerProps) {
   const navigate = useNavigate()
+  const cart = useCart()
   const [draft, setDraft] = useState<DraftCircle>(EMPTY_DRAFT)
   const [topicQuery, setTopicQuery] = useState('')
   const [topicsExpanded, setTopicsExpanded] = useState(false)
@@ -79,44 +84,55 @@ export default function CreateCircleDrawer({
     [],
   )
 
-  // Filter by query (case-insensitive); always keep the active topic visible
-  // even if it doesn't match, so the user can see their current selection.
+  // Filter by query (case-insensitive); always keep selected topics
+  // visible even if they don't match, so the user can see their picks.
   const filteredTopics = useMemo(() => {
     const q = topicQuery.trim().toLowerCase()
+    const selected = new Set(draft.topicIds)
     if (!q) return topicOptions
     return topicOptions.filter(
-      (t) => t.label.toLowerCase().includes(q) || t.id === draft.topicId,
+      (t) => t.label.toLowerCase().includes(q) || selected.has(t.id),
     )
-  }, [topicOptions, topicQuery, draft.topicId])
+  }, [topicOptions, topicQuery, draft.topicIds])
 
-  // Collapsed view shows only the first N — but keep the selected topic in
-  // the visible slice so the user always sees what they picked.
+  // Collapsed view shows only the first N — but lift every selected
+  // topic into the visible slice so the user always sees their picks.
   const visibleTopics = useMemo(() => {
     if (topicsExpanded || filteredTopics.length <= TOPIC_PREVIEW_COUNT) {
       return filteredTopics
     }
-    const head = filteredTopics.slice(0, TOPIC_PREVIEW_COUNT)
-    if (
-      draft.topicId &&
-      !head.some((t) => t.id === draft.topicId) &&
-      filteredTopics.some((t) => t.id === draft.topicId)
-    ) {
-      const sel = filteredTopics.find((t) => t.id === draft.topicId)!
-      return [sel, ...head.slice(0, TOPIC_PREVIEW_COUNT - 1)]
-    }
-    return head
-  }, [filteredTopics, topicsExpanded, draft.topicId])
+    const selected = filteredTopics.filter((t) => draft.topicIds.includes(t.id))
+    const unselected = filteredTopics.filter(
+      (t) => !draft.topicIds.includes(t.id),
+    )
+    const remaining = Math.max(0, TOPIC_PREVIEW_COUNT - selected.length)
+    return [...selected, ...unselected.slice(0, remaining)]
+  }, [filteredTopics, topicsExpanded, draft.topicIds])
 
   const hiddenTopicCount = Math.max(
     0,
     filteredTopics.length - visibleTopics.length,
   )
 
-  const canSubmit =
-    draft.name.trim().length >= 3 &&
-    draft.description.trim().length >= 10 &&
-    draft.actionsPerMonth > 0 &&
-    draft.topicId !== null
+  // Per-rule validation. We surface the first failing reason under the
+  // submit button so the user isn't left guessing why it's disabled.
+  const validationError = (() => {
+    if (draft.name.trim().length < 3) return 'Name must be at least 3 characters'
+    if (draft.description.trim().length < 10)
+      return `Description must be at least 10 characters (${draft.description.trim().length}/10)`
+    if (draft.actionsPerMonth <= 0) return 'Pick a positive actions/month value'
+    if (draft.topicIds.length < 1) return 'Select at least one theme'
+    return null
+  })()
+  const canSubmit = validationError === null
+
+  const toggleTopic = (id: string) => {
+    setDraft((d) =>
+      d.topicIds.includes(id)
+        ? { ...d, topicIds: d.topicIds.filter((t) => t !== id) }
+        : { ...d, topicIds: [...d.topicIds, id] },
+    )
+  }
 
   const addMember = (account: AccountAtom) => {
     if (!account.data) return
@@ -152,9 +168,33 @@ export default function CreateCircleDrawer({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!canSubmit) return
-    // TODO: replace with on-chain create-circle call once available.
-    // eslint-disable-next-line no-console
-    console.log('[circles] draft circle', draft)
+
+    const circleDraft: CircleDraft = {
+      name: draft.name.trim(),
+      description: draft.description.trim(),
+      topicIds: draft.topicIds,
+    }
+
+    // Pick the first selected topic's color for the cart item border —
+    // visual cue that ties the queued circle to its primary theme.
+    const primaryColor =
+      topicOptions.find((t) => t.id === draft.topicIds[0])?.color ??
+      'var(--foreground)'
+
+    cart.addItem({
+      id: `create-circle-${Date.now()}`,
+      side: 'support',
+      // Sentinel termId — no on-chain id known until WeightModal mints
+      // the circle atom. The draft name keeps it unique within the cart.
+      termId: `pending-circle:${circleDraft.name}`,
+      kind: 'create-circle',
+      intention: 'Circle',
+      title: circleDraft.name,
+      favicon: '',
+      intentionColor: primaryColor,
+      circleDraft,
+    })
+    cart.open()
     onClose()
   }
 
@@ -268,7 +308,12 @@ export default function CreateCircleDrawer({
           </div>
 
           <fieldset className="cc-field cc-field-fieldset">
-            <legend className="cc-label">Theme</legend>
+            <legend className="cc-label">
+              Themes
+              <span className="cc-help" style={{ marginLeft: 8 }}>
+                {draft.topicIds.length} selected — at least 1 required
+              </span>
+            </legend>
             <div className="cc-search">
               <Search className="cc-search-icon h-4 w-4" />
               <input
@@ -303,7 +348,7 @@ export default function CreateCircleDrawer({
                 </span>
               )}
               {visibleTopics.map((t) => {
-                const active = draft.topicId === t.id
+                const active = draft.topicIds.includes(t.id)
                 return (
                   <button
                     type="button"
@@ -316,7 +361,7 @@ export default function CreateCircleDrawer({
                           } as React.CSSProperties)
                         : undefined
                     }
-                    onClick={() => setDraft((d) => ({ ...d, topicId: t.id }))}
+                    onClick={() => toggleTopic(t.id)}
                     aria-pressed={active}
                   >
                     <span
@@ -461,10 +506,19 @@ export default function CreateCircleDrawer({
               type="submit"
               className="cc-btn cc-btn-primary"
               disabled={!canSubmit}
+              title={validationError ?? undefined}
             >
-              Create circle
+              Add to cart
             </button>
           </div>
+          {validationError && (
+            <p
+              className="cc-help"
+              style={{ textAlign: 'right', marginTop: 4 }}
+            >
+              {validationError}
+            </p>
+          )}
         </form>
       </aside>
     </>

--- a/apps/explorer/src/hooks/useCart.ts
+++ b/apps/explorer/src/hooks/useCart.ts
@@ -1,38 +1,62 @@
 import {
   createContext,
   useContext,
+  useEffect,
   useState,
   useCallback,
   createElement,
 } from 'react'
 import type { ReactNode } from 'react'
 
+/** Draft payload carried by a `kind: 'create-circle'` cart item. The
+ *  drawer collects this; WeightModal expands it into a circle atom +
+ *  membership triple + N has_tag triples at submit time. */
+export interface CircleDraft {
+  name: string
+  description: string
+  /** Topic atom slugs (keys of TOPIC_ATOM_IDS) — one has_tag triple per
+   *  entry is minted alongside the membership triple. */
+  topicIds: string[]
+}
+
 export interface CartItem {
   id: string
   side: 'support' | 'oppose'
-  /** Existing-triple termId for deposits, or the deterministic tripleId
-   *  (calculated client-side via SofiaFeeProxy.calculateTripleId) for
-   *  brand-new create-triple items. Used as the dedupe key in the cart. */
+  /** Existing-triple termId for deposits, the deterministic tripleId
+   *  for `kind: 'create-triple'`, or a `pending:<draftKey>` sentinel
+   *  for `kind: 'create-circle'` (no on-chain id known until submit).
+   *  Used as the dedupe key in the cart. */
   termId: string
   intention: string
   title: string
   favicon: string
   intentionColor: string
-  /** When 'create-triple', WeightModal mints the triple via
-   *  SofiaFeeProxy.createTriples instead of depositing on an existing
-   *  termId. Defaults to 'deposit' for back-compat with existing
-   *  callers (Support/Oppose, Interest, Trust). */
-  kind?: 'deposit' | 'create-triple'
+  /** Routing tag — WeightModal partitions items by `kind`:
+   *   - 'deposit'        → SofiaFeeProxy.deposit / depositBatch
+   *   - 'create-triple'  → SofiaFeeProxy.createTriples (atoms must exist)
+   *   - 'create-circle'  → atomCreationService + createTriples (mints
+   *                        circle atom + membership + has_tag triples)
+   *  Defaults to 'deposit' for back-compat with existing callers. */
+  kind?: 'deposit' | 'create-triple' | 'create-circle'
   /** Required when `kind === 'create-triple'`. The atom term_ids that
    *  identify the new triple's subject / predicate / object. */
   subjectId?: string
   predicateId?: string
   objectId?: string
+  /** Required when `kind === 'create-circle'`. */
+  circleDraft?: CircleDraft
 }
 
 interface CartContextValue {
   items: CartItem[]
   count: number
+  /** True when the cart drawer is currently visible. Components that
+   *  add items can call `open()` to surface the drawer immediately so
+   *  the user sees their pending action queued up. */
+  isOpen: boolean
+  open: () => void
+  close: () => void
+  toggle: () => void
   addItem: (item: CartItem) => void
   addItems: (items: CartItem[]) => void
   removeItem: (id: string) => void
@@ -43,6 +67,7 @@ const CartContext = createContext<CartContextValue | null>(null)
 
 export function CartProvider({ children }: { children: ReactNode }) {
   const [items, setItems] = useState<CartItem[]>([])
+  const [isOpen, setIsOpen] = useState(false)
 
   const addItem = useCallback((item: CartItem) => {
     setItems((prev) => {
@@ -71,6 +96,15 @@ export function CartProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const clear = useCallback(() => setItems([]), [])
+  const open = useCallback(() => setIsOpen(true), [])
+  const close = useCallback(() => setIsOpen(false), [])
+  const toggle = useCallback(() => setIsOpen((o) => !o), [])
+
+  // Auto-close when the cart becomes empty so the slot frees up for
+  // the right-rail content. Mirrors the pre-context behavior in App.tsx.
+  useEffect(() => {
+    if (isOpen && items.length === 0) setIsOpen(false)
+  }, [isOpen, items.length])
 
   return createElement(
     CartContext.Provider,
@@ -78,6 +112,10 @@ export function CartProvider({ children }: { children: ReactNode }) {
       value: {
         items,
         count: items.length,
+        isOpen,
+        open,
+        close,
+        toggle,
         addItem,
         addItems,
         removeItem,

--- a/apps/explorer/src/lib/contracts/sofiaFeeProxy.ts
+++ b/apps/explorer/src/lib/contracts/sofiaFeeProxy.ts
@@ -1,6 +1,42 @@
-/** SofiaFeeProxy ABI — deposits + triple creation. Redeems go through
- *  MultiVault directly. */
+/** SofiaFeeProxy ABI — atom creation, triple creation, deposits.
+ *  Redeems go through MultiVault directly. */
 export const SofiaFeeProxyAbi = [
+  // createAtoms(receiver, data[], assets[], curveId) payable → atomIds[]
+  // Mints brand-new atoms from raw bytes payloads (typically IPFS URIs
+  // returned by the pinThing mutation). Each entry's `assets[i]` is an
+  // optional initial deposit on the new atom's positive vault.
+  {
+    inputs: [
+      { internalType: 'address', name: 'receiver', type: 'address' },
+      { internalType: 'bytes[]', name: 'data', type: 'bytes[]' },
+      { internalType: 'uint256[]', name: 'assets', type: 'uint256[]' },
+      { internalType: 'uint256', name: 'curveId', type: 'uint256' },
+    ],
+    name: 'createAtoms',
+    outputs: [
+      { internalType: 'bytes32[]', name: 'atomIds', type: 'bytes32[]' },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  // getAtomCost() view → cost (full creation cost for a single atom)
+  {
+    inputs: [],
+    name: 'getAtomCost',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  // calculateAtomId(data) pure → atomId
+  // Pre-image of the deterministic atom hash, used to know the term_id
+  // before submitting the create-atoms transaction.
+  {
+    inputs: [{ internalType: 'bytes', name: 'data', type: 'bytes' }],
+    name: 'calculateAtomId',
+    outputs: [{ internalType: 'bytes32', name: '', type: 'bytes32' }],
+    stateMutability: 'pure',
+    type: 'function',
+  },
   // createTriples(receiver, subjectIds[], predicateIds[], objectIds[], assets[], curveId)
   // payable → tripleIds[]
   // Used to mint a brand-new triple (subject/predicate/object atom term_ids

--- a/apps/explorer/src/pages/ComposePage.tsx
+++ b/apps/explorer/src/pages/ComposePage.tsx
@@ -19,6 +19,7 @@ import { ArrowUpRight, Search } from 'lucide-react'
 import { useLinkedWallets } from '@/hooks/useLinkedWallets'
 import { useTrustCircle } from '@/hooks/useTrustCircle'
 import { useTaxonomy } from '@/hooks/useTaxonomy'
+import { useGroups } from '@/hooks/useGroups'
 import { getTopicEmoji } from '@/config/topicEmoji'
 import MemberAvatar from '@/components/circles/MemberAvatar'
 import CompileActionButton from '@/components/CompileActionButton'
@@ -67,6 +68,7 @@ export default function ComposePage() {
   const { addresses } = useLinkedWallets()
   const { accounts: trustMembers } = useTrustCircle(addresses)
   const { topics } = useTaxonomy()
+  const { groups } = useGroups()
   // Pre-fill from `?circles=&topics=` — lets PerspectivePage round-trip the
   // selection via the "Edit" button.
   const [selectedCircles, setSelectedCircles] = useState<Set<string>>(
@@ -88,17 +90,51 @@ export default function ComposePage() {
   const matchesQuery = (label: string) =>
     q.length === 0 || label.toLowerCase().includes(q)
 
-  const circles = useMemo(
-    () => [
+  // Trust Circle stays in pole position (local identity construct), then
+  // every on-chain group surfaced by useGroups (sorted by member count).
+  // For each group we pull the first 4 member atoms with a wallet so the
+  // avatar stack matches the Trust Circle UI without an extra query.
+  const circles = useMemo(() => {
+    type Member = (typeof trustMembers)[number]
+    const onChain = groups.map((g) => {
+      const seen = new Set<string>()
+      const members: Member[] = []
+      for (const m of g.memberships) {
+        if (members.length >= 4) break
+        if (!m.member.walletAddress) continue
+        if (seen.has(m.member.termId)) continue
+        seen.add(m.member.termId)
+        // MemberAvatar only reads termId/label/image. Fill the remaining
+        // TrustCircleAccount fields with neutral placeholders so the
+        // shared type checks but no consumer drifts onto stale data.
+        members.push({
+          id: m.member.termId,
+          termId: m.member.termId,
+          tripleId: m.tripleTermId,
+          label: m.member.label,
+          image: m.member.image,
+          walletAddress: m.member.walletAddress,
+          trustAmount: 0,
+          createdAt: 0,
+        } as Member)
+      }
+      return {
+        id: g.termId,
+        name: g.label,
+        size: g.memberCount,
+        members,
+      }
+    })
+    return [
       {
         id: TRUST_CIRCLE_ID,
         name: 'Trust Circle',
         size: trustMembers.length,
         members: trustMembers.slice(0, 4),
       },
-    ],
-    [trustMembers],
-  )
+      ...onChain,
+    ]
+  }, [trustMembers, groups])
 
   const visibleCircles = circles.filter((c) => matchesQuery(c.name))
   const visibleTopics = topics.filter((t) => matchesQuery(t.label))
@@ -216,7 +252,7 @@ export default function ComposePage() {
                         className="cmp-card-view"
                         onClick={(e) => {
                           e.stopPropagation()
-                          navigate('/circles/trust')
+                          navigate(`/circles/${c.id}`)
                         }}
                       >
                         <ArrowUpRight className="h-3 w-3" />

--- a/apps/explorer/src/pages/PerspectivePage.tsx
+++ b/apps/explorer/src/pages/PerspectivePage.tsx
@@ -14,6 +14,7 @@ import { Link, Navigate, useParams, useSearchParams } from 'react-router-dom'
 import { ArrowLeft, PenSquare } from 'lucide-react'
 import { PageHero } from '@0xsofia/design-system'
 import { useTaxonomy } from '@/hooks/useTaxonomy'
+import { useGroups } from '@/hooks/useGroups'
 import { getTopicEmoji } from '@/config/topicEmoji'
 import type { CompareMode } from '@/lib/compileActionAnims'
 import '@/components/styles/pages.css'
@@ -48,9 +49,10 @@ const MODE_META: Record<CompareMode, ModeMeta> = {
   },
 }
 
-// Human-readable name for each circle id. Real metadata will come from
-// a `useCircleById` hook once circle creation ships on-chain.
-const CIRCLE_NAMES: Record<string, string> = {
+// Hardcoded names for synthetic circles (Trust Circle is local, not
+// indexed on-chain). On-chain circles fall through to `useGroups()`
+// resolution below.
+const SYNTHETIC_CIRCLE_NAMES: Record<string, string> = {
   trust: 'Trust Circle',
 }
 
@@ -64,6 +66,7 @@ export default function PerspectivePage() {
   const { mode } = useParams<{ mode: string }>()
   const [searchParams] = useSearchParams()
   const { topicById } = useTaxonomy()
+  const { groups } = useGroups()
 
   if (!isCompareMode(mode)) {
     return <Navigate to="/compose" replace />
@@ -89,6 +92,19 @@ export default function PerspectivePage() {
   const editHref =
     `/compose?circles=${encodeURIComponent(circleIds.join(','))}` +
     `&topics=${encodeURIComponent(topicIds.join(','))}`
+
+  // term_id → label resolver. Falls back to a truncated id so the chip
+  // never renders a 64-char bytes32 string.
+  const groupLabelById = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const g of groups) map.set(g.termId, g.label)
+    return map
+  }, [groups])
+
+  const resolveCircleName = (id: string): string =>
+    SYNTHETIC_CIRCLE_NAMES[id] ??
+    groupLabelById.get(id) ??
+    `${id.slice(0, 6)}…${id.slice(-4)}`
 
   return (
     <div className="page-content page-enter perspective-page">
@@ -122,7 +138,7 @@ export default function PerspectivePage() {
             ) : (
               circleIds.map((id) => (
                 <span key={id} className="psp-chip psp-chip--circle">
-                  {CIRCLE_NAMES[id] ?? id}
+                  {resolveCircleName(id)}
                 </span>
               ))
             )}

--- a/apps/explorer/src/services/atomCreationService.ts
+++ b/apps/explorer/src/services/atomCreationService.ts
@@ -1,0 +1,322 @@
+/**
+ * atomCreationService — single source of truth for minting new atoms
+ * from the explorer.
+ *
+ * Mirrors `tripleCreationService` but calls `SofiaFeeProxy.createAtoms`,
+ * which atomically:
+ *   1. mints one or more atoms from raw `bytes` payloads
+ *   2. (optionally) deposits an initial stake on each new atom's positive vault
+ *
+ * The atom payload is typically an IPFS URI returned by the `pinThing`
+ * GraphQL mutation. The deterministic atom term_id is pre-computed via
+ * `calculateAtomId` so callers can route/cache before the receipt lands
+ * and stay idempotent across indexer lag.
+ */
+
+import { createPublicClient, http, stringToHex } from 'viem'
+import {
+  INTUITION_RPC_URL,
+  PROXY_ADDRESS,
+  SofiaFeeProxyAbi,
+} from '../lib/contracts'
+import { buildWalletClient, type WalletDescriptor } from './depositService'
+
+const CREATION_CURVE_ID = 1n
+
+/** Atoms can be minted with zero stake — the protocol only charges the
+ *  fixed creation cost (`getAtomCost()`). Triples require a non-zero
+ *  signal deposit (`MIN_SIGNAL_TRUST` in tripleCreationService). */
+const MIN_ATOM_DEPOSIT = 0n
+
+const publicClient = createPublicClient({
+  transport: http(INTUITION_RPC_URL),
+})
+
+/** Payload accepted by the `pinThing` GraphQL mutation. The `image` and
+ *  `description` fields are optional but kept as required strings ("")
+ *  to match the codegen's nullable signature without leaking undefined
+ *  through the wire. */
+export interface AtomIPFSPayload {
+  name: string
+  description: string
+  image: string
+  url: string
+}
+
+/** Function shape expected for the IPFS pinning side-effect. Provided by
+ *  the caller (typically `usePinThingMutation()` from `@0xsofia/graphql`)
+ *  so the service stays free of React-Query coupling. */
+export type PinThingFn = (
+  vars: AtomIPFSPayload,
+) => Promise<{ pinThing?: { uri?: string | null } | null }>
+
+export interface CreateAtomResult {
+  success: boolean
+  /** Deterministic term_id of the atom (newly created or pre-existing). */
+  atomId?: string
+  txHash?: string
+  /** True when the atom was already on-chain and we skipped minting it.
+   *  UI surfaces this as a no-op rather than a "you created an atom". */
+  alreadyExisted?: boolean
+  error?: string
+}
+
+export interface BatchCreateAtomResult {
+  success: boolean
+  /** One entry per input payload, in the same order. */
+  results: CreateAtomResult[]
+  /** Hash of the single tx that minted every NEW atom in the batch.
+   *  Undefined when every payload was already on-chain. */
+  txHash?: string
+  error?: string
+}
+
+// ── Internal helpers ────────────────────────────────────────────────
+
+/** Pin the payload to IPFS and return the encoded bytes the contract
+ *  expects. Errors propagate so the calling tx aborts before any value
+ *  leaves the wallet. */
+async function pinAtomToIPFS(
+  payload: AtomIPFSPayload,
+  pinThing: PinThingFn,
+): Promise<{ ipfsUri: string; encodedData: `0x${string}` }> {
+  const result = await pinThing(payload)
+  const ipfsUri = result.pinThing?.uri
+  if (!ipfsUri) {
+    throw new Error(`Failed to pin atom "${payload.name}" to IPFS`)
+  }
+  return { ipfsUri, encodedData: stringToHex(ipfsUri) }
+}
+
+/** Read-only check via `calculateAtomId` + a simulation probe. The
+ *  contract has no `getAtom` selector; instead we attempt a 1-element
+ *  `createAtoms` simulation and treat `MultiVault_AtomExists` as the
+ *  "already on-chain" signal. */
+async function atomExistsOnChain(
+  encodedData: `0x${string}`,
+  receiver: `0x${string}`,
+  atomCost: bigint,
+): Promise<boolean> {
+  try {
+    await publicClient.simulateContract({
+      address: PROXY_ADDRESS,
+      abi: SofiaFeeProxyAbi,
+      functionName: 'createAtoms',
+      args: [receiver, [encodedData], [MIN_ATOM_DEPOSIT], CREATION_CURVE_ID],
+      value: atomCost,
+      account: receiver,
+    })
+    return false
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return /AtomExists/.test(msg)
+  }
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/**
+ * Pin one payload to IPFS and mint the resulting atom on-chain in a
+ * single tx. Idempotent — if the atom already exists we return its
+ * deterministic term_id without sending a transaction.
+ */
+export async function executeCreateAtom(
+  wallet: WalletDescriptor,
+  payload: AtomIPFSPayload,
+  pinThing: PinThingFn,
+): Promise<CreateAtomResult> {
+  try {
+    const { address, client } = await buildWalletClient(wallet)
+    const { encodedData } = await pinAtomToIPFS(payload, pinThing)
+
+    // Pre-compute the deterministic atom term_id so callers can route
+    // before the receipt lands.
+    const atomId = (await publicClient.readContract({
+      address: PROXY_ADDRESS,
+      abi: SofiaFeeProxyAbi,
+      functionName: 'calculateAtomId',
+      args: [encodedData],
+      authorizationList: undefined,
+    })) as `0x${string}`
+
+    const atomCost = (await publicClient.readContract({
+      address: PROXY_ADDRESS,
+      abi: SofiaFeeProxyAbi,
+      functionName: 'getAtomCost',
+      authorizationList: undefined,
+    })) as bigint
+
+    // Idempotent path — atom already on-chain.
+    if (await atomExistsOnChain(encodedData, address, atomCost)) {
+      return { success: true, atomId, alreadyExisted: true }
+    }
+
+    // Total creation cost = MultiVault atom cost + Sofia fees. We let
+    // the proxy compute the canonical total.
+    const totalCost = (await publicClient.readContract({
+      address: PROXY_ADDRESS,
+      abi: SofiaFeeProxyAbi,
+      functionName: 'getTotalCreationCost',
+      args: [0n, MIN_ATOM_DEPOSIT, atomCost],
+      authorizationList: undefined,
+    })) as bigint
+
+    const args = [
+      address,
+      [encodedData],
+      [MIN_ATOM_DEPOSIT],
+      CREATION_CURVE_ID,
+    ] as const
+
+    await publicClient.simulateContract({
+      address: PROXY_ADDRESS,
+      abi: SofiaFeeProxyAbi,
+      functionName: 'createAtoms',
+      args,
+      value: totalCost,
+      account: address,
+    })
+
+    const hash = await client.writeContract({
+      address: PROXY_ADDRESS,
+      abi: SofiaFeeProxyAbi,
+      functionName: 'createAtoms',
+      args,
+      value: totalCost,
+      chain: undefined,
+      account: address,
+    })
+
+    const receipt = await publicClient.waitForTransactionReceipt({ hash })
+    return receipt.status === 'success'
+      ? { success: true, atomId, txHash: hash }
+      : { success: false, error: 'Transaction reverted', atomId }
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+/**
+ * Batch atom creation — pins every payload, partitions into "needs
+ * creation" vs "already exists", mints the new ones in a single tx,
+ * and returns one result per input in the original order.
+ */
+export async function executeCreateAtomsBatch(
+  wallet: WalletDescriptor,
+  payloads: AtomIPFSPayload[],
+  pinThing: PinThingFn,
+): Promise<BatchCreateAtomResult> {
+  if (payloads.length === 0) {
+    return { success: true, results: [] }
+  }
+
+  try {
+    const { address, client } = await buildWalletClient(wallet)
+
+    // Pin every payload in parallel — pinning is the slowest step, so
+    // overlapping I/O matters more than for the on-chain reads below.
+    const pinned = await Promise.all(
+      payloads.map(async (payload) => {
+        const { encodedData } = await pinAtomToIPFS(payload, pinThing)
+        return { payload, encodedData }
+      }),
+    )
+
+    const atomCost = (await publicClient.readContract({
+      address: PROXY_ADDRESS,
+      abi: SofiaFeeProxyAbi,
+      functionName: 'getAtomCost',
+      authorizationList: undefined,
+    })) as bigint
+
+    // Pre-compute every atomId + existence flag.
+    const calculated = await Promise.all(
+      pinned.map(async ({ payload, encodedData }) => {
+        const atomId = (await publicClient.readContract({
+          address: PROXY_ADDRESS,
+          abi: SofiaFeeProxyAbi,
+          functionName: 'calculateAtomId',
+          args: [encodedData],
+          authorizationList: undefined,
+        })) as `0x${string}`
+        const exists = await atomExistsOnChain(encodedData, address, atomCost)
+        return { payload, encodedData, atomId, exists }
+      }),
+    )
+
+    const toCreate = calculated.filter((c) => !c.exists)
+    const results: CreateAtomResult[] = calculated.map((c) =>
+      c.exists
+        ? { success: true, atomId: c.atomId, alreadyExisted: true }
+        : { success: false, atomId: c.atomId, error: 'pending' },
+    )
+
+    if (toCreate.length === 0) {
+      return { success: true, results }
+    }
+
+    const dataArray = toCreate.map((c) => c.encodedData)
+    const assetsArray = toCreate.map(() => MIN_ATOM_DEPOSIT)
+    const totalDeposit = MIN_ATOM_DEPOSIT * BigInt(toCreate.length)
+    const multiVaultCost = atomCost * BigInt(toCreate.length) + totalDeposit
+    const totalCost = (await publicClient.readContract({
+      address: PROXY_ADDRESS,
+      abi: SofiaFeeProxyAbi,
+      functionName: 'getTotalCreationCost',
+      args: [0n, totalDeposit, multiVaultCost],
+      authorizationList: undefined,
+    })) as bigint
+
+    const args = [address, dataArray, assetsArray, CREATION_CURVE_ID] as const
+
+    await publicClient.simulateContract({
+      address: PROXY_ADDRESS,
+      abi: SofiaFeeProxyAbi,
+      functionName: 'createAtoms',
+      args,
+      value: totalCost,
+      account: address,
+    })
+
+    const hash = await client.writeContract({
+      address: PROXY_ADDRESS,
+      abi: SofiaFeeProxyAbi,
+      functionName: 'createAtoms',
+      args,
+      value: totalCost,
+      chain: undefined,
+      account: address,
+    })
+
+    const receipt = await publicClient.waitForTransactionReceipt({ hash })
+    if (receipt.status !== 'success') {
+      return {
+        success: false,
+        results,
+        error: 'createAtoms batch reverted',
+      }
+    }
+
+    // Promote every "pending" entry to success in the original order.
+    for (let i = 0; i < calculated.length; i++) {
+      if (!calculated[i].exists) {
+        results[i] = {
+          success: true,
+          atomId: calculated[i].atomId,
+          txHash: hash,
+        }
+      }
+    }
+
+    return { success: true, results, txHash: hash }
+  } catch (err) {
+    return {
+      success: false,
+      results: [],
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}


### PR DESCRIPTION
Mints a circle as 1 atom (createAtoms) + N+1 triples in a single batch (createTriples): account→is_member_of→circle plus circle→has_tag→topic per selected theme. The creator's first deposit on the membership triple proves they are the founding member. All transactions go through the cart drawer — CreateCircleDrawer queues a 'create-circle' item, WeightModal partitions cart items by kind and routes circles through atomCreationService → tripleCreationService.

CreateCircleDrawer accepts multi-topic selection, surfaces validation errors under the submit button, and opens the cart on add. ComposePage and PerspectivePage now read on-chain circles via useGroups instead of the hardcoded Trust Circle stub.