### PR TITLE
feat(explorer): Circles-first refonte — nav, engagement, design

### DIFF
--- a/apps/explorer/src/components/NavSidebar.tsx
+++ b/apps/explorer/src/components/NavSidebar.tsx
@@ -124,10 +124,10 @@ export function NavSidebar({
     label: string
     public: boolean
   }[] = [
-    { to: '/feed', icon: Home, label: 'Home', public: true },
-    { to: '/profile', icon: User, label: 'My Profile', public: false },
     { to: '/circles', icon: Users, label: 'Circles', public: false },
+    { to: '/feed', icon: Home, label: 'Home', public: true },
     { to: '/compose', icon: Layers, label: 'Compose', public: false },
+    { to: '/profile', icon: User, label: 'My Profile', public: false },
   ]
 
   const quickLinks: {

--- a/apps/explorer/src/components/circles/CircleDetailHero.tsx
+++ b/apps/explorer/src/components/circles/CircleDetailHero.tsx
@@ -9,6 +9,7 @@
  */
 import type { ReactNode } from 'react'
 import { Zap } from 'lucide-react'
+import type { CircleStats } from '@/services/circleStats'
 
 interface CircleDetailHeroProps {
   name: string
@@ -25,6 +26,15 @@ interface CircleDetailHeroProps {
    *  actions-budget panel. Used today by non-member groups to surface
    *  the Join CTA without taking a row of its own below the hero. */
   cta?: ReactNode
+  /** Aggregate metrics rendered above the Actions Budget block — posts,
+   *  votes, and 7-day active members. Omit for locked / non-member
+   *  views so the page doesn't leak cumulative volume. */
+  stats?: CircleStats
+}
+
+function formatCount(n: number): string {
+  if (n >= 1000) return (n / 1000).toFixed(1) + 'k'
+  return String(n)
 }
 
 export default function CircleDetailHero({
@@ -37,6 +47,7 @@ export default function CircleDetailHero({
   onColorChange,
   colorOptions,
   cta,
+  stats,
 }: CircleDetailHeroProps) {
   const total = sponsorClaimsLeft + 2000
   const pct = Math.min(100, Math.round((sponsorClaimsLeft / total) * 100))
@@ -109,6 +120,33 @@ export default function CircleDetailHero({
       {cta && <div className="crd-hero-cta">{cta}</div>}
 
       <div className="crd-hero-right">
+        {stats && (
+          <div
+            className="crd-hero-stats"
+            role="group"
+            aria-label="Circle activity"
+          >
+            <div className="crd-hero-stat">
+              <span className="crd-hero-stat__num">
+                {formatCount(stats.postCount)}
+              </span>
+              <span className="crd-hero-stat__label">posts</span>
+            </div>
+            <div className="crd-hero-stat">
+              <span className="crd-hero-stat__num">
+                {formatCount(stats.voteCount)}
+              </span>
+              <span className="crd-hero-stat__label">votes</span>
+            </div>
+            <div className="crd-hero-stat">
+              <span className="crd-hero-stat__num">
+                {stats.activeMemberCount}
+                <span className="crd-hero-stat__pulse" aria-hidden="true" />
+              </span>
+              <span className="crd-hero-stat__label">live</span>
+            </div>
+          </div>
+        )}
         <div className="crd-hero-actions">
           <div className="cr-section-head">Actions budget</div>
           <div className="crd-actions-big">

--- a/apps/explorer/src/components/circles/CircleDetailView.tsx
+++ b/apps/explorer/src/components/circles/CircleDetailView.tsx
@@ -19,16 +19,12 @@ import { ArrowLeft } from 'lucide-react'
 import { useTopicSelection } from '@/hooks/useDomainSelection'
 import { useCircleFeed } from '@/hooks/useCircleFeed'
 import { useCircleTopicCounts } from '@/hooks/useCircleTopicCounts'
-import {
-  computeCircleStats,
-  computeTopEngaged,
-} from '@/services/circleStats'
+import { computeCircleStats } from '@/services/circleStats'
 import CircleDetailHero from './CircleDetailHero'
 import CircleMembersCard from './CircleMembersCard'
 import CircleMostActiveCard from './CircleMostActiveCard'
 import CircleTopTopicsCard from './CircleTopTopicsCard'
 import CircleFeedSection from './CircleFeedSection'
-import CircleTopEngagedStrip from './CircleTopEngagedStrip'
 import AllMembersPanel from './AllMembersPanel'
 import CircleJoinOverlay from './CircleJoinOverlay'
 import type { CircleData } from '@/types/circle'
@@ -80,10 +76,6 @@ export default function CircleDetailView({
     topTopicSlugs,
   )
   const stats = useMemo(() => computeCircleStats(feedItems), [feedItems])
-  const topEngaged = useMemo(
-    () => computeTopEngaged(feedItems, 4),
-    [feedItems],
-  )
   const [allMembersOpen, setAllMembersOpen] = useState(false)
 
   const effectiveColor = colorOverride ?? circle.color
@@ -149,7 +141,6 @@ export default function CircleDetailView({
         className={locked ? 'crd-feed-locked' : undefined}
         aria-hidden={locked}
       >
-        {!locked && <CircleTopEngagedStrip items={topEngaged} />}
         <CircleFeedSection
           addresses={circle.addresses}
           circleName={circle.name}

--- a/apps/explorer/src/components/circles/CircleDetailView.tsx
+++ b/apps/explorer/src/components/circles/CircleDetailView.tsx
@@ -19,10 +19,16 @@ import { ArrowLeft } from 'lucide-react'
 import { useTopicSelection } from '@/hooks/useDomainSelection'
 import { useCircleFeed } from '@/hooks/useCircleFeed'
 import { useCircleTopicCounts } from '@/hooks/useCircleTopicCounts'
+import {
+  computeCircleStats,
+  computeTopEngaged,
+} from '@/services/circleStats'
 import CircleDetailHero from './CircleDetailHero'
 import CircleMembersCard from './CircleMembersCard'
 import CircleTopTopicsCard from './CircleTopTopicsCard'
 import CircleFeedSection from './CircleFeedSection'
+import CircleStatsStrip from './CircleStatsStrip'
+import CircleTopEngagedStrip from './CircleTopEngagedStrip'
 import AllMembersPanel from './AllMembersPanel'
 import CircleJoinOverlay from './CircleJoinOverlay'
 import type { CircleData } from '@/types/circle'
@@ -73,6 +79,11 @@ export default function CircleDetailView({
     circle.addresses,
     topTopicSlugs,
   )
+  const stats = useMemo(() => computeCircleStats(feedItems), [feedItems])
+  const topEngaged = useMemo(
+    () => computeTopEngaged(feedItems, 4),
+    [feedItems],
+  )
   const [allMembersOpen, setAllMembersOpen] = useState(false)
 
   const effectiveColor = colorOverride ?? circle.color
@@ -112,6 +123,12 @@ export default function CircleDetailView({
         }
       />
 
+      {/* Stats strip — aggregate signals/endorsements/active count.
+          Sits between the hero and the members/topics row so the page
+          reads as a live dashboard for the circle. Locked groups hide
+          it so non-members don't see the cumulative volume. */}
+      {!locked && <CircleStatsStrip stats={stats} />}
+
       {/* Members card + Top Topics stay fully accessible — even for
           non-members. They surface enough of the circle's identity
           (who's in, which topics are hot) to inform the Join decision
@@ -136,6 +153,7 @@ export default function CircleDetailView({
         className={locked ? 'crd-feed-locked' : undefined}
         aria-hidden={locked}
       >
+        {!locked && <CircleTopEngagedStrip items={topEngaged} />}
         <CircleFeedSection
           addresses={circle.addresses}
           circleName={circle.name}

--- a/apps/explorer/src/components/circles/CircleDetailView.tsx
+++ b/apps/explorer/src/components/circles/CircleDetailView.tsx
@@ -27,7 +27,6 @@ import CircleDetailHero from './CircleDetailHero'
 import CircleMembersCard from './CircleMembersCard'
 import CircleTopTopicsCard from './CircleTopTopicsCard'
 import CircleFeedSection from './CircleFeedSection'
-import CircleStatsStrip from './CircleStatsStrip'
 import CircleTopEngagedStrip from './CircleTopEngagedStrip'
 import AllMembersPanel from './AllMembersPanel'
 import CircleJoinOverlay from './CircleJoinOverlay'
@@ -106,6 +105,7 @@ export default function CircleDetailView({
         memberCount={Math.max(1, circle.members.length)}
         onColorChange={onColorChange}
         colorOptions={colorOptions}
+        stats={!locked ? stats : undefined}
         // Non-member CTA lives inside the hero's middle slot so the
         // page doesn't grow a separate banner row above the activity
         // feed. The hero is the only thing the user reads first; the
@@ -122,12 +122,6 @@ export default function CircleDetailView({
           ) : undefined
         }
       />
-
-      {/* Stats strip — aggregate signals/endorsements/active count.
-          Sits between the hero and the members/topics row so the page
-          reads as a live dashboard for the circle. Locked groups hide
-          it so non-members don't see the cumulative volume. */}
-      {!locked && <CircleStatsStrip stats={stats} />}
 
       {/* Members card + Top Topics stay fully accessible — even for
           non-members. They surface enough of the circle's identity

--- a/apps/explorer/src/components/circles/CircleDetailView.tsx
+++ b/apps/explorer/src/components/circles/CircleDetailView.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/services/circleStats'
 import CircleDetailHero from './CircleDetailHero'
 import CircleMembersCard from './CircleMembersCard'
+import CircleMostActiveCard from './CircleMostActiveCard'
 import CircleTopTopicsCard from './CircleTopTopicsCard'
 import CircleFeedSection from './CircleFeedSection'
 import CircleTopEngagedStrip from './CircleTopEngagedStrip'
@@ -123,15 +124,16 @@ export default function CircleDetailView({
         }
       />
 
-      {/* Members card + Top Topics stay fully accessible — even for
-          non-members. They surface enough of the circle's identity
-          (who's in, which topics are hot) to inform the Join decision
-          without giving away the activity feed. */}
+      {/* Members card + Most Active + Top Topics — 3-col info strip.
+          Members and Most Active share the available oxygen (1.1fr
+          each); Top Topics rétrécit (0.8fr). All three stay accessible
+          for non-members so the circle's identity reads at a glance. */}
       <div className="crd-info-row">
         <CircleMembersCard
           members={circle.members}
           onViewAll={() => setAllMembersOpen(true)}
         />
+        <CircleMostActiveCard items={feedItems} members={circle.members} />
         <CircleTopTopicsCard
           topicIds={topTopicSlugs}
           circleColor={effectiveColor}

--- a/apps/explorer/src/components/circles/CircleFeedCard.tsx
+++ b/apps/explorer/src/components/circles/CircleFeedCard.tsx
@@ -15,6 +15,7 @@ import type { MouseEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Star, ThumbsUp, ThumbsDown } from 'lucide-react'
 import type { CircleItem } from '@/services/circleService'
+import { computeStars, starTier } from '@/services/circleFeedSort'
 import {
   displayLabelToIntentionType,
   INTENTION_CONFIG,
@@ -48,29 +49,12 @@ const VERB_CLASS_BY_LABEL: Record<string, string> = Object.fromEntries(
   Object.values(INTENTION_CONFIG).map((v) => [v.label, v.cssClass]),
 )
 
-/** Proto `computeStars(supports)` — buckets 1..5. */
-function computeStars(supports: number): number {
-  if (supports >= 20) return 5
-  if (supports >= 14) return 4
-  if (supports >= 9) return 3
-  if (supports >= 5) return 2
-  return 1
-}
 function starLabel(stars: number): string {
   if (stars >= 5) return 'Highly recommended'
   if (stars >= 4) return 'Recommended'
   if (stars >= 3) return 'Moderate'
   if (stars >= 2) return 'Low engagement'
   return 'New'
-}
-/** Tier color per slot — gold for 1..3, orange for 4, red for 5.
- *  Slots above `stars` render muted so the bar still reads as a fixed
- *  5-step scale. */
-function starTier(slot: number, stars: number): 'gold' | 'orange' | 'red' | 'muted' {
-  if (slot > stars) return 'muted'
-  if (slot <= 3) return 'gold'
-  if (slot === 4) return 'orange'
-  return 'red'
 }
 
 export default function CircleFeedCard({

--- a/apps/explorer/src/components/circles/CircleFeedCard.tsx
+++ b/apps/explorer/src/components/circles/CircleFeedCard.tsx
@@ -135,7 +135,7 @@ export default function CircleFeedCard({
           ))}
         </div>
         <div className="fc-star-tip">
-          <strong>{starLabel(stars)}</strong> · {totalVotes} endorsed
+          <strong>{starLabel(stars)}</strong> · {totalVotes} votes
         </div>
       </div>
 

--- a/apps/explorer/src/components/circles/CircleFeedCard.tsx
+++ b/apps/explorer/src/components/circles/CircleFeedCard.tsx
@@ -63,6 +63,15 @@ function starLabel(stars: number): string {
   if (stars >= 2) return 'Low engagement'
   return 'New'
 }
+/** Tier color per slot — gold for 1..3, orange for 4, red for 5.
+ *  Slots above `stars` render muted so the bar still reads as a fixed
+ *  5-step scale. */
+function starTier(slot: number, stars: number): 'gold' | 'orange' | 'red' | 'muted' {
+  if (slot > stars) return 'muted'
+  if (slot <= 3) return 'gold'
+  if (slot === 4) return 'orange'
+  return 'red'
+}
 
 export default function CircleFeedCard({
   item,
@@ -130,8 +139,17 @@ export default function CircleFeedCard({
       rel="noopener noreferrer"
     >
       <div className="fc-star-badge" title={starLabel(stars)}>
-        <Star size={14} fill="currentColor" strokeWidth={0} />
-        <span className="fc-star-num">{stars}</span>
+        <div className="fc-star-row" aria-label={`${stars} out of 5`}>
+          {[1, 2, 3, 4, 5].map((slot) => (
+            <Star
+              key={slot}
+              size={11}
+              fill="currentColor"
+              strokeWidth={0}
+              className={`fc-star fc-star--${starTier(slot, stars)}`}
+            />
+          ))}
+        </div>
         <div className="fc-star-tip">
           <strong>{starLabel(stars)}</strong> · {totalVotes} endorsed
         </div>

--- a/apps/explorer/src/components/circles/CircleFeedSection.tsx
+++ b/apps/explorer/src/components/circles/CircleFeedSection.tsx
@@ -23,6 +23,7 @@ import {
   INTENTION_COLORS,
 } from '@/config/intentions'
 import type { CircleItem } from '@/services/circleService'
+import { sortFeed, type FeedSortId } from '@/services/circleFeedSort'
 import type { TrustCircleAccount } from '@/services/trustCircleService'
 import {
   Select,
@@ -39,6 +40,7 @@ import CircleVerbFilter, { type VerbFilterId } from './CircleVerbFilter'
 import CircleTopicFilter, {
   type TopicFilterId,
 } from './CircleTopicFilter'
+import CircleFeedSort from './CircleFeedSort'
 import '@/components/styles/feed-card.css'
 
 interface CircleFeedSectionProps {
@@ -58,6 +60,7 @@ export default function CircleFeedSection({
   const [verb, setVerb] = useState<VerbFilterId>('all')
   const [topic, setTopic] = useState<TopicFilterId>('all')
   const [memberFilter, setMemberFilter] = useState<string>('all')
+  const [sort, setSort] = useState<FeedSortId>('engagement')
 
   const { authenticated } = usePrivy()
   const cart = useCart()
@@ -128,7 +131,7 @@ export default function CircleFeedSection({
   )
 
   const filtered = useMemo(() => {
-    return items
+    const base = items
       .filter((item) => {
         if (verb === 'all') return true
         return item.intentions.some(
@@ -146,7 +149,8 @@ export default function CircleFeedSection({
           memberFilter.toLowerCase()
         )
       })
-  }, [items, verb, topic, memberFilter])
+    return sortFeed(base, sort)
+  }, [items, verb, topic, memberFilter, sort])
 
   const shown = filtered.slice(0, MAX_SHOWN)
 
@@ -168,6 +172,8 @@ export default function CircleFeedSection({
         <CircleVerbFilter active={verb} onChange={setVerb} />
         <div className="crd-feed-filters-divider" aria-hidden="true" />
         <CircleTopicFilter active={topic} onChange={setTopic} />
+        <div className="crd-feed-filters-divider" aria-hidden="true" />
+        <CircleFeedSort active={sort} onChange={setSort} />
         <div className="crd-feed-filters-divider" aria-hidden="true" />
         <div className="crd-user-filter">
           <label className="crd-user-filter-label" htmlFor="crd-user-filter">

--- a/apps/explorer/src/components/circles/CircleFeedSection.tsx
+++ b/apps/explorer/src/components/circles/CircleFeedSection.tsx
@@ -25,21 +25,17 @@ import {
 import type { CircleItem } from '@/services/circleService'
 import { sortFeed, type FeedSortId } from '@/services/circleFeedSort'
 import type { TrustCircleAccount } from '@/services/trustCircleService'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import PredicatePicker from '@/components/PredicatePicker'
 import { EmptyFeedState } from '@/components/EmptyFeedState'
 import { FeedCardSkeleton } from '@/components/FeedCardSkeleton'
 import CircleFeedCard from './CircleFeedCard'
-import CircleVerbFilter, { type VerbFilterId } from './CircleVerbFilter'
-import CircleTopicFilter, {
+import CircleVerbFilterDropdown, {
+  type VerbFilterId,
+} from './CircleVerbFilterDropdown'
+import CircleTopicFilterDropdown, {
   type TopicFilterId,
-} from './CircleTopicFilter'
+} from './CircleTopicFilterDropdown'
+import CircleMemberFilterDropdown from './CircleMemberFilterDropdown'
 import CircleFeedSort from './CircleFeedSort'
 import '@/components/styles/feed-card.css'
 
@@ -169,34 +165,14 @@ export default function CircleFeedSection({
       <h2 className="crd-feed-title">Certified by {circleName}</h2>
 
       <div className="crd-feed-filters">
-        <CircleVerbFilter active={verb} onChange={setVerb} />
-        <div className="crd-feed-filters-divider" aria-hidden="true" />
-        <CircleTopicFilter active={topic} onChange={setTopic} />
-        <div className="crd-feed-filters-divider" aria-hidden="true" />
+        <CircleVerbFilterDropdown active={verb} onChange={setVerb} />
+        <CircleTopicFilterDropdown active={topic} onChange={setTopic} />
+        <CircleMemberFilterDropdown
+          active={memberFilter}
+          onChange={setMemberFilter}
+          members={members}
+        />
         <CircleFeedSort active={sort} onChange={setSort} />
-        <div className="crd-feed-filters-divider" aria-hidden="true" />
-        <div className="crd-user-filter">
-          <label className="crd-user-filter-label" htmlFor="crd-user-filter">
-            Member
-          </label>
-          <Select value={memberFilter} onValueChange={setMemberFilter}>
-            <SelectTrigger
-              id="crd-user-filter"
-              className="crd-user-filter-select"
-              aria-label="Filter by member"
-            >
-              <SelectValue placeholder="All members" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All members</SelectItem>
-              {members.map((m) => (
-                <SelectItem key={m.termId} value={m.walletAddress ?? m.termId}>
-                  {m.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
       </div>
 
       {loading ? (

--- a/apps/explorer/src/components/circles/CircleFeedSection.tsx
+++ b/apps/explorer/src/components/circles/CircleFeedSection.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/config/intentions'
 import type { CircleItem } from '@/services/circleService'
 import { sortFeed, type FeedSortId } from '@/services/circleFeedSort'
+import { computeTopEngaged } from '@/services/circleStats'
 import type { TrustCircleAccount } from '@/services/trustCircleService'
 import PredicatePicker from '@/components/PredicatePicker'
 import { EmptyFeedState } from '@/components/EmptyFeedState'
@@ -37,6 +38,7 @@ import CircleTopicFilterDropdown, {
 } from './CircleTopicFilterDropdown'
 import CircleMemberFilterDropdown from './CircleMemberFilterDropdown'
 import CircleFeedSort from './CircleFeedSort'
+import CircleTopEngagedStrip from './CircleTopEngagedStrip'
 import '@/components/styles/feed-card.css'
 
 interface CircleFeedSectionProps {
@@ -126,6 +128,8 @@ export default function CircleFeedSection({
     [predicatePicker, cart],
   )
 
+  const topEngaged = useMemo(() => computeTopEngaged(items, 4), [items])
+
   const filtered = useMemo(() => {
     const base = items
       .filter((item) => {
@@ -174,6 +178,8 @@ export default function CircleFeedSection({
         />
         <CircleFeedSort active={sort} onChange={setSort} />
       </div>
+
+      <CircleTopEngagedStrip items={topEngaged} />
 
       {loading ? (
         <EmptyFeedState

--- a/apps/explorer/src/components/circles/CircleFeedSort.tsx
+++ b/apps/explorer/src/components/circles/CircleFeedSort.tsx
@@ -1,0 +1,38 @@
+/**
+ * CircleFeedSort — segmented toggle that picks the sort key for the
+ * circles feed. Sits in the `.crd-feed-filters` row next to the verb /
+ * topic / member filters. Reuses the `.vf-chip` chrome so the bar reads
+ * as a single horizontal control surface.
+ */
+import type { FeedSortId } from '@/services/circleFeedSort'
+
+interface CircleFeedSortProps {
+  active: FeedSortId
+  onChange: (id: FeedSortId) => void
+}
+
+const SORTS: { id: FeedSortId; label: string }[] = [
+  { id: 'engagement', label: 'Top engagement' },
+  { id: 'recent', label: 'Recent' },
+]
+
+export default function CircleFeedSort({
+  active,
+  onChange,
+}: CircleFeedSortProps) {
+  return (
+    <div className="cfs-bar" role="toolbar" aria-label="Sort feed">
+      <span className="cfs-label">Sort</span>
+      {SORTS.map((s) => (
+        <button
+          key={s.id}
+          type="button"
+          className={`vf-chip${active === s.id ? ' active' : ''}`}
+          onClick={() => onChange(s.id)}
+        >
+          {s.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/explorer/src/components/circles/CircleMemberFilterDropdown.tsx
+++ b/apps/explorer/src/components/circles/CircleMemberFilterDropdown.tsx
@@ -1,0 +1,122 @@
+/**
+ * CircleMemberFilterDropdown — Popover-driven member filter for the
+ * circles feed. Mirrors CircleVerbFilterDropdown / CircleTopicFilterDropdown
+ * so all three filters share the same trigger + cell chrome. The active
+ * dot uses `avatarColor(label)` so the trigger picks up the selected
+ * member's identity color at a glance.
+ */
+import { useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover'
+import type { TrustCircleAccount } from '@/services/trustCircleService'
+import { avatarColor } from '@/utils/avatarColor'
+
+interface CircleMemberFilterDropdownProps {
+  /** `'all'` or the member's `walletAddress ?? termId`. */
+  active: string
+  onChange: (id: string) => void
+  members: TrustCircleAccount[]
+}
+
+export default function CircleMemberFilterDropdown({
+  active,
+  onChange,
+  members,
+}: CircleMemberFilterDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const activeMember =
+    active === 'all'
+      ? null
+      : members.find(
+          (m) => (m.walletAddress ?? m.termId).toLowerCase() ===
+            active.toLowerCase(),
+        )
+  const activeLabel = activeMember ? activeMember.label : 'All members'
+  const dotColor = activeMember
+    ? avatarColor(activeMember.label)
+    : 'var(--ds-muted, #888)'
+
+  const handleSelect = (id: string) => {
+    onChange(id)
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="crd-filter-trigger crd-filter-trigger--wide"
+          aria-label="Filter by member"
+        >
+          <span
+            className="crd-filter-trigger__dot"
+            style={{ background: dotColor }}
+            aria-hidden="true"
+          />
+          <span className="crd-filter-trigger__label">Member</span>
+          <span className="crd-filter-trigger__value">{activeLabel}</span>
+          <ChevronDown size={12} className="crd-filter-trigger__chev" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="crd-filter-pop crd-filter-pop--topics"
+        align="start"
+        sideOffset={6}
+      >
+        <div className="crd-filter-pop__grid">
+          <button
+            type="button"
+            className={`crd-filter-pop__cell${
+              active === 'all' ? ' is-active' : ''
+            }`}
+            onClick={() => handleSelect('all')}
+          >
+            <span
+              className="crd-filter-pop__dot"
+              style={{ background: 'var(--ds-muted, #888)' }}
+              aria-hidden="true"
+            />
+            All members
+          </button>
+          {members.map((m) => {
+            const value = m.walletAddress ?? m.termId
+            return (
+              <button
+                key={m.termId}
+                type="button"
+                className={`crd-filter-pop__cell${
+                  active.toLowerCase() === value.toLowerCase()
+                    ? ' is-active'
+                    : ''
+                }`}
+                onClick={() => handleSelect(value)}
+                title={m.label}
+              >
+                <span
+                  className="crd-filter-pop__dot"
+                  style={{ background: avatarColor(m.label) }}
+                  aria-hidden="true"
+                />
+                {m.label}
+              </button>
+            )
+          })}
+        </div>
+        {active !== 'all' && (
+          <button
+            type="button"
+            className="crd-filter-pop__reset"
+            onClick={() => handleSelect('all')}
+          >
+            Reset
+          </button>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/explorer/src/components/circles/CircleMembersCard.tsx
+++ b/apps/explorer/src/components/circles/CircleMembersCard.tsx
@@ -12,7 +12,7 @@ interface CircleMembersCardProps {
   onViewAll?: () => void
 }
 
-const MAX_STACK = 5
+const MAX_STACK = 10
 
 export default function CircleMembersCard({
   members,

--- a/apps/explorer/src/components/circles/CircleMostActiveCard.tsx
+++ b/apps/explorer/src/components/circles/CircleMostActiveCard.tsx
@@ -1,0 +1,113 @@
+/**
+ * CircleMostActiveCard — leaderboard of the circle's most active
+ * members inside a configurable time window (7d / 30d / all). Renders
+ * 4 rows with a Fraunces-serif rank, an avatar, the member label and
+ * a pixel bar (▮▮▮) whose length scales with the count. Sits next to
+ * the Members card in the 3-col info row.
+ */
+import { useMemo, useState } from 'react'
+import type { CircleItem } from '@/services/circleService'
+import type { TrustCircleAccount } from '@/services/trustCircleService'
+import {
+  computeMostActive,
+  type ActivityWindow,
+} from '@/services/circleStats'
+import MemberAvatar from './MemberAvatar'
+
+interface CircleMostActiveCardProps {
+  items: CircleItem[]
+  members: TrustCircleAccount[]
+}
+
+const WINDOWS: { id: ActivityWindow; label: string }[] = [
+  { id: '7d', label: '7d' },
+  { id: '30d', label: '30d' },
+  { id: 'all', label: 'All' },
+]
+
+const MAX_BARS = 6
+
+export default function CircleMostActiveCard({
+  items,
+  members,
+}: CircleMostActiveCardProps) {
+  const [window, setWindow] = useState<ActivityWindow>('7d')
+
+  const ranked = useMemo(
+    () => computeMostActive(items, members, window, 4),
+    [items, members, window],
+  )
+  const max = ranked.reduce((m, r) => Math.max(m, r.count), 0) || 1
+
+  return (
+    <div className="crd-active-card">
+      <div className="crd-active-head">
+        <span className="crd-active-label">Most active</span>
+        <div className="crd-active-tabs" role="tablist" aria-label="Window">
+          {WINDOWS.map((w) => (
+            <button
+              key={w.id}
+              type="button"
+              role="tab"
+              aria-selected={window === w.id}
+              className={`crd-active-tab${window === w.id ? ' is-active' : ''}`}
+              onClick={() => setWindow(w.id)}
+            >
+              {w.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {ranked.length === 0 ? (
+        <div className="crd-active-empty">
+          No activity{' '}
+          {window === '7d'
+            ? 'this week'
+            : window === '30d'
+              ? 'this month'
+              : 'yet'}
+          {window !== 'all' && (
+            <>
+              {' '}
+              ·{' '}
+              <button
+                type="button"
+                className="crd-active-empty-cta"
+                onClick={() => setWindow(window === '7d' ? '30d' : 'all')}
+              >
+                check {window === '7d' ? '30d' : 'all'} ↗
+              </button>
+            </>
+          )}
+        </div>
+      ) : (
+        <div className="crd-active-list">
+          {ranked.map((r, idx) => {
+            const bars = Math.max(1, Math.round((r.count / max) * MAX_BARS))
+            return (
+              <div key={r.member.termId} className="crd-active-row">
+                <span className="crd-active-rank">{idx + 1}</span>
+                <MemberAvatar member={r.member} linkable />
+                <span className="crd-active-name" title={r.member.label}>
+                  {r.member.label}
+                </span>
+                <span className="crd-active-count">{r.count}</span>
+                <span
+                  className="crd-active-bar"
+                  aria-hidden="true"
+                  title={`${r.count} signal${r.count === 1 ? '' : 's'}`}
+                >
+                  {'▮'.repeat(bars)}
+                  <span className="crd-active-bar-rest">
+                    {'▯'.repeat(MAX_BARS - bars)}
+                  </span>
+                </span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/explorer/src/components/circles/CircleStatsStrip.tsx
+++ b/apps/explorer/src/components/circles/CircleStatsStrip.tsx
@@ -30,9 +30,9 @@ export default function CircleStatsStrip({ stats }: CircleStatsStripProps) {
       <div className="crd-stat-divider" aria-hidden="true" />
       <div className="crd-stat">
         <span className="crd-stat-value">
-          {formatCount(stats.endorsementCount)}
+          {formatCount(stats.voteCount)}
         </span>
-        <span className="crd-stat-label">Endorsements</span>
+        <span className="crd-stat-label">Votes</span>
       </div>
       <div className="crd-stat-divider" aria-hidden="true" />
       <div className="crd-stat">

--- a/apps/explorer/src/components/circles/CircleStatsStrip.tsx
+++ b/apps/explorer/src/components/circles/CircleStatsStrip.tsx
@@ -1,0 +1,47 @@
+/**
+ * CircleStatsStrip — compact ribbon of aggregate metrics under the
+ * circle hero. Posts / Endorsements / Active members (7d). The active
+ * dot animates so the strip reads as a "live dashboard" rather than a
+ * static count row.
+ */
+import type { CircleStats } from '@/services/circleStats'
+
+interface CircleStatsStripProps {
+  stats: CircleStats
+}
+
+function formatCount(n: number): string {
+  if (n >= 10_000) return (n / 1000).toFixed(1) + 'k'
+  if (n >= 1000) return (n / 1000).toFixed(1) + 'k'
+  return String(n)
+}
+
+export default function CircleStatsStrip({ stats }: CircleStatsStripProps) {
+  return (
+    <div
+      className="crd-stats-strip"
+      role="group"
+      aria-label="Circle activity stats"
+    >
+      <div className="crd-stat">
+        <span className="crd-stat-value">{formatCount(stats.postCount)}</span>
+        <span className="crd-stat-label">Posts</span>
+      </div>
+      <div className="crd-stat-divider" aria-hidden="true" />
+      <div className="crd-stat">
+        <span className="crd-stat-value">
+          {formatCount(stats.endorsementCount)}
+        </span>
+        <span className="crd-stat-label">Endorsements</span>
+      </div>
+      <div className="crd-stat-divider" aria-hidden="true" />
+      <div className="crd-stat">
+        <span className="crd-stat-value">
+          {stats.activeMemberCount}
+          <span className="crd-stat-pulse" aria-hidden="true" />
+        </span>
+        <span className="crd-stat-label">Active · 7d</span>
+      </div>
+    </div>
+  )
+}

--- a/apps/explorer/src/components/circles/CircleTopEngagedStrip.tsx
+++ b/apps/explorer/src/components/circles/CircleTopEngagedStrip.tsx
@@ -1,8 +1,10 @@
 /**
- * CircleTopEngagedStrip — horizontal strip of the top 4 URLs in the
- * circle by engagement score. Sits between the stats ribbon and the
- * full feed. Cards reuse the same star-tier palette as `CircleFeedCard`
- * so the visual scale is consistent across the page.
+ * CircleTopEngagedStrip — "Hot picks" strip of the top 4 URLs in the
+ * circle by engagement score. Rendered inside CircleFeedSection just
+ * below the filter row so it reads as the curated header of the feed
+ * rather than a separate band. Cards reuse the same star-tier palette
+ * as `CircleFeedCard` so the visual scale is consistent across the
+ * page.
  */
 import { Star } from 'lucide-react'
 import type { CircleItem } from '@/services/circleService'
@@ -34,7 +36,10 @@ export default function CircleTopEngagedStrip({
 
   return (
     <section className="crd-top-engaged">
-      <h3 className="crd-top-engaged-title">Hot this week</h3>
+      <div className="crd-top-engaged-head">
+        <h3 className="crd-top-engaged-title">Hot picks</h3>
+        <div className="crd-top-engaged-rule" aria-hidden="true" />
+      </div>
       <div className="crd-top-engaged-strip">
         {items.map((item, idx) => {
           const { supports, opposes } = aggregateCounts(item)

--- a/apps/explorer/src/components/circles/CircleTopEngagedStrip.tsx
+++ b/apps/explorer/src/components/circles/CircleTopEngagedStrip.tsx
@@ -1,0 +1,86 @@
+/**
+ * CircleTopEngagedStrip — horizontal strip of the top 4 URLs in the
+ * circle by engagement score. Sits between the stats ribbon and the
+ * full feed. Cards reuse the same star-tier palette as `CircleFeedCard`
+ * so the visual scale is consistent across the page.
+ */
+import { Star } from 'lucide-react'
+import type { CircleItem } from '@/services/circleService'
+import { computeStars, starTier } from '@/services/circleFeedSort'
+import { UrlPreview } from '@/components/UrlPreview'
+import { extractDomain } from '@/utils/formatting'
+
+interface CircleTopEngagedStripProps {
+  items: CircleItem[]
+}
+
+function aggregateCounts(item: CircleItem): {
+  supports: number
+  opposes: number
+} {
+  let supports = 0
+  let opposes = 0
+  for (const v of Object.values(item.intentionVaults)) {
+    supports += v.supportCount
+    opposes += v.opposeCount
+  }
+  return { supports, opposes }
+}
+
+export default function CircleTopEngagedStrip({
+  items,
+}: CircleTopEngagedStripProps) {
+  if (items.length === 0) return null
+
+  return (
+    <section className="crd-top-engaged">
+      <h3 className="crd-top-engaged-title">Hot this week</h3>
+      <div className="crd-top-engaged-strip">
+        {items.map((item, idx) => {
+          const { supports, opposes } = aggregateCounts(item)
+          const stars = computeStars(supports)
+          const host = item.domain || (item.url ? extractDomain(item.url) : '')
+          const href =
+            item.url && item.url.startsWith('http') ? item.url : '#'
+          return (
+            <a
+              key={item.id}
+              className="crd-te-card"
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={item.title || host}
+            >
+              <span className="crd-te-rank">#{idx + 1}</span>
+              <UrlPreview
+                variant="card"
+                url={item.url}
+                domain={host}
+                className="crd-te-thumb"
+                alt={item.title || host}
+              />
+              <p className="crd-te-title">{item.title || host}</p>
+              <div className="crd-te-meta">
+                <div
+                  className="crd-te-stars"
+                  aria-label={`${stars} out of 5`}
+                >
+                  {[1, 2, 3, 4, 5].map((slot) => (
+                    <Star
+                      key={slot}
+                      size={9}
+                      fill="currentColor"
+                      strokeWidth={0}
+                      className={`fc-star fc-star--${starTier(slot, stars)}`}
+                    />
+                  ))}
+                </div>
+                <span className="crd-te-count">{supports + opposes}</span>
+              </div>
+            </a>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/apps/explorer/src/components/circles/CircleTopTopicsCard.tsx
+++ b/apps/explorer/src/components/circles/CircleTopTopicsCard.tsx
@@ -73,6 +73,12 @@ export default function CircleTopTopicsCard({
   // so a circle with fewer signals still gets readable proportions.
   const max = rows.reduce((m, r) => Math.max(m, r.count), 0) || 1
 
+  // `circleColor` and `max` are no longer used now that the bar visual
+  // is gone — kept in the props signature for backward compat with
+  // callers (CircleDetailView still passes them).
+  void max
+  void circleColor
+
   return (
     <div className="crd-topics-section">
       <div className="cr-section-head">Top topics</div>
@@ -82,20 +88,11 @@ export default function CircleTopTopicsCard({
             <TopicBadge
               topicId={r.id}
               color={r.color}
-              size={20}
+              size={16}
               title={r.label}
             />
             <span className="cr-topics-label">{r.label}</span>
             <span className="cr-topics-num">{r.count}</span>
-            <div className="cr-topics-bar">
-              <div
-                className="cr-topics-fill"
-                style={{
-                  width: `${(r.count / max) * 100}%`,
-                  background: circleColor,
-                }}
-              />
-            </div>
           </div>
         ))}
         {rows.length === 0 && (

--- a/apps/explorer/src/components/circles/CircleTopTopicsCard.tsx
+++ b/apps/explorer/src/components/circles/CircleTopTopicsCard.tsx
@@ -88,7 +88,7 @@ export default function CircleTopTopicsCard({
             <TopicBadge
               topicId={r.id}
               color={r.color}
-              size={16}
+              size={22}
               title={r.label}
             />
             <span className="cr-topics-label">{r.label}</span>

--- a/apps/explorer/src/components/circles/CircleTopicFilterDropdown.tsx
+++ b/apps/explorer/src/components/circles/CircleTopicFilterDropdown.tsx
@@ -1,0 +1,108 @@
+/**
+ * CircleTopicFilterDropdown — Popover-driven topic filter for the
+ * circles feed. Twin of CircleVerbFilterDropdown but renders the 14
+ * SOFIA topics with their TopicBadge so the palette stays consistent
+ * with the rest of the explorer (profile interests, top topics card).
+ */
+import { useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover'
+import { SOFIA_TOPICS } from '@/config/taxonomy'
+import TopicBadge from '@/components/profile/TopicBadge'
+
+export type TopicFilterId = 'all' | string
+
+interface CircleTopicFilterDropdownProps {
+  active: TopicFilterId
+  onChange: (id: TopicFilterId) => void
+}
+
+export default function CircleTopicFilterDropdown({
+  active,
+  onChange,
+}: CircleTopicFilterDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const activeTopic =
+    active === 'all' ? null : SOFIA_TOPICS.find((t) => t.id === active)
+  const activeLabel = activeTopic ? activeTopic.label : 'All'
+  const dotColor = activeTopic ? activeTopic.color : 'var(--ds-muted, #888)'
+
+  const handleSelect = (id: TopicFilterId) => {
+    onChange(id)
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="crd-filter-trigger crd-filter-trigger--wide"
+          aria-label="Filter by topic"
+        >
+          <span
+            className="crd-filter-trigger__dot"
+            style={{ background: dotColor }}
+            aria-hidden="true"
+          />
+          <span className="crd-filter-trigger__label">Topics</span>
+          <span className="crd-filter-trigger__value">{activeLabel}</span>
+          <ChevronDown size={12} className="crd-filter-trigger__chev" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="crd-filter-pop crd-filter-pop--topics"
+        align="start"
+        sideOffset={6}
+      >
+        <div className="crd-filter-pop__grid">
+          <button
+            type="button"
+            className={`crd-filter-pop__cell${
+              active === 'all' ? ' is-active' : ''
+            }`}
+            onClick={() => handleSelect('all')}
+          >
+            <span
+              className="crd-filter-pop__dot"
+              style={{ background: 'var(--ds-muted, #888)' }}
+              aria-hidden="true"
+            />
+            All
+          </button>
+          {SOFIA_TOPICS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              className={`crd-filter-pop__cell${
+                active === t.id ? ' is-active' : ''
+              }`}
+              onClick={() => handleSelect(t.id)}
+            >
+              <TopicBadge
+                topicId={t.id}
+                color={t.color}
+                size={12}
+                title={t.label}
+              />
+              {t.label}
+            </button>
+          ))}
+        </div>
+        {active !== 'all' && (
+          <button
+            type="button"
+            className="crd-filter-pop__reset"
+            onClick={() => handleSelect('all')}
+          >
+            Reset
+          </button>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/explorer/src/components/circles/CircleVerbFilterDropdown.tsx
+++ b/apps/explorer/src/components/circles/CircleVerbFilterDropdown.tsx
@@ -1,0 +1,139 @@
+/**
+ * CircleVerbFilterDropdown — Popover-driven verb filter for the circles
+ * feed. Replaces the inline 8-chip bar that crowded the filter row.
+ * Trigger reads as `[dot] VERBS · <active label> ▾` so the active state
+ * stays visible at rest.
+ */
+import { useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@/components/ui/popover'
+import { INTENTION_CONFIG, type IntentionType } from '@/config/intentions'
+
+export type VerbFilterId = 'all' | IntentionType
+
+const VERBS: { id: IntentionType; label: string; color: string }[] = [
+  {
+    id: 'trusted',
+    label: INTENTION_CONFIG.trusted.label,
+    color: INTENTION_CONFIG.trusted.color,
+  },
+  {
+    id: 'work',
+    label: INTENTION_CONFIG.work.label,
+    color: INTENTION_CONFIG.work.color,
+  },
+  {
+    id: 'learning',
+    label: INTENTION_CONFIG.learning.label,
+    color: INTENTION_CONFIG.learning.color,
+  },
+  {
+    id: 'inspiration',
+    label: INTENTION_CONFIG.inspiration.label,
+    color: INTENTION_CONFIG.inspiration.color,
+  },
+  {
+    id: 'fun',
+    label: INTENTION_CONFIG.fun.label,
+    color: INTENTION_CONFIG.fun.color,
+  },
+  {
+    id: 'buying',
+    label: INTENTION_CONFIG.buying.label,
+    color: INTENTION_CONFIG.buying.color,
+  },
+  {
+    id: 'music',
+    label: INTENTION_CONFIG.music.label,
+    color: INTENTION_CONFIG.music.color,
+  },
+]
+
+interface CircleVerbFilterDropdownProps {
+  active: VerbFilterId
+  onChange: (id: VerbFilterId) => void
+}
+
+export default function CircleVerbFilterDropdown({
+  active,
+  onChange,
+}: CircleVerbFilterDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const activeVerb = active === 'all' ? null : VERBS.find((v) => v.id === active)
+  const activeLabel = activeVerb ? activeVerb.label : 'All'
+  const dotColor = activeVerb ? activeVerb.color : 'var(--ds-muted, #888)'
+
+  const handleSelect = (id: VerbFilterId) => {
+    onChange(id)
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="crd-filter-trigger"
+          aria-label="Filter by verb"
+        >
+          <span
+            className="crd-filter-trigger__dot"
+            style={{ background: dotColor }}
+            aria-hidden="true"
+          />
+          <span className="crd-filter-trigger__label">Verbs</span>
+          <span className="crd-filter-trigger__value">{activeLabel}</span>
+          <ChevronDown size={12} className="crd-filter-trigger__chev" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="crd-filter-pop" align="start" sideOffset={6}>
+        <div className="crd-filter-pop__grid">
+          <button
+            type="button"
+            className={`crd-filter-pop__cell${
+              active === 'all' ? ' is-active' : ''
+            }`}
+            onClick={() => handleSelect('all')}
+          >
+            <span
+              className="crd-filter-pop__dot"
+              style={{ background: 'var(--ds-muted, #888)' }}
+              aria-hidden="true"
+            />
+            All
+          </button>
+          {VERBS.map((v) => (
+            <button
+              key={v.id}
+              type="button"
+              className={`crd-filter-pop__cell${
+                active === v.id ? ' is-active' : ''
+              }`}
+              onClick={() => handleSelect(v.id)}
+            >
+              <span
+                className="crd-filter-pop__dot"
+                style={{ background: v.color }}
+                aria-hidden="true"
+              />
+              {v.label}
+            </button>
+          ))}
+        </div>
+        {active !== 'all' && (
+          <button
+            type="button"
+            className="crd-filter-pop__reset"
+            onClick={() => handleSelect('all')}
+          >
+            Reset
+          </button>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -856,7 +856,7 @@
   display: grid;
   grid-template-columns: 1.1fr 1.1fr 0.8fr;
   gap: 22px;
-  align-items: start;
+  align-items: stretch;
   margin: 0 0 22px;
 }
 @media (max-width: 1100px) {
@@ -1091,7 +1091,7 @@
   border-color: var(--ds-ink);
 }
 .crd-view-all {
-  margin-top: 12px;
+  margin-top: auto;
   width: 100%;
   justify-content: center;
   padding: 7px 14px;

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -854,14 +854,25 @@
 /* Info row: members card + top topics */
 .crd-info-row {
   display: grid;
-  grid-template-columns: 360px 1fr;
+  grid-template-columns: 1.1fr 1.1fr 0.8fr;
   gap: 22px;
   align-items: start;
   margin: 0 0 22px;
 }
-@media (max-width: 900px) {
+@media (max-width: 1100px) {
+  .crd-info-row {
+    grid-template-columns: 1fr 1fr;
+  }
+  .crd-info-row > :last-child {
+    grid-column: 1 / -1;
+  }
+}
+@media (max-width: 720px) {
   .crd-info-row {
     grid-template-columns: 1fr;
+  }
+  .crd-info-row > :last-child {
+    grid-column: auto;
   }
 }
 
@@ -894,18 +905,20 @@
   gap: 10px;
 }
 .crd-members-stack {
-  display: inline-flex;
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  gap: 6px;
 }
 .crd-members-stack .mav {
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   font-family: 'JetBrains Mono', monospace;
   font-size: 11px;
   font-weight: 700;
   color: #02000e;
-  margin-left: -10px;
-  border: 2px solid var(--ds-card);
+  margin-left: 0;
+  border: 1px solid var(--ds-card);
   border-radius: 50%;
   flex-shrink: 0;
   display: inline-flex;
@@ -914,9 +927,151 @@
   overflow: hidden;
   box-sizing: border-box;
 }
-.crd-members-stack .mav:first-child {
-  margin-left: 0;
+/* ── CircleMostActiveCard ───────────────────────────────────────────
+   Mini leaderboard next to Members. Rank is in Fraunces serif so it
+   reads as a "ledger" column rather than a chart axis. Pixel bars
+   (▮▯) keep the visual pixel-art-ish without gradients. */
+.crd-active-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border-radius: 14px;
+  background: var(--ds-card);
+  border: 1px solid var(--ds-border);
 }
+.crd-active-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.crd-active-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ds-muted);
+  font-weight: 600;
+}
+.crd-active-tabs {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 999px;
+  background: var(--ds-bg-subtle);
+  border: 1px solid var(--ds-border-soft);
+}
+.crd-active-tab {
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: none;
+  background: transparent;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--ds-muted);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  letter-spacing: 0.04em;
+}
+.crd-active-tab:hover {
+  color: var(--ds-ink);
+}
+.crd-active-tab.is-active {
+  background: var(--ds-ink);
+  color: var(--ds-card);
+}
+.crd-active-empty {
+  font-family: 'Fraunces', serif;
+  font-style: italic;
+  font-size: 13px;
+  color: var(--ds-muted);
+  padding: 8px 0;
+}
+.crd-active-empty-cta {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--ds-ink);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  cursor: pointer;
+}
+.crd-active-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.crd-active-row {
+  display: grid;
+  grid-template-columns: 22px 34px 1fr auto;
+  grid-template-rows: auto auto;
+  gap: 2px 10px;
+  align-items: center;
+}
+.crd-active-rank {
+  grid-row: 1 / span 2;
+  font-family: 'Fraunces', serif;
+  font-weight: 800;
+  font-size: 18px;
+  color: var(--ds-muted);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  font-variation-settings:
+    'SOFT' 30,
+    'opsz' 144;
+}
+.crd-active-row .mav {
+  grid-row: 1 / span 2;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 1px solid var(--ds-card);
+  overflow: hidden;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 700;
+  color: #02000e;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.crd-active-name {
+  grid-column: 3;
+  grid-row: 1;
+  font-family: 'Geist', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ds-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.crd-active-count {
+  grid-column: 4;
+  grid-row: 1;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--ds-ink);
+  font-variant-numeric: tabular-nums;
+}
+.crd-active-bar {
+  grid-column: 3 / span 2;
+  grid-row: 2;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 1px;
+  color: var(--circle-color, var(--ds-accent));
+  line-height: 1;
+}
+.crd-active-bar-rest {
+  color: var(--ds-border);
+}
+
 .crd-members-more {
   padding: 6px 12px;
   font-family: 'JetBrains Mono', monospace;

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -531,6 +531,10 @@
   align-items: stretch;
   gap: 32px;
   border-left: 4px solid var(--circle-color, var(--ds-accent));
+  /* Subtle inset top accent in the circle color — anti-flat detail
+     that ties the card to its circle without screaming. */
+  box-shadow: inset 0 1px 0
+    color-mix(in srgb, var(--circle-color, var(--ds-accent)) 18%, transparent);
 }
 .crd-hero-left {
   flex: 1;
@@ -696,6 +700,71 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+
+/* ── Hero stats (absorbed from CircleStatsStrip) ────────────────────
+   Three numbers in a 3-col grid above the actions panel. Uniform size
+   + uniform alignment so the labels sit on the same baseline. The
+   "live" count has a pulsing dot to read as a real-time indicator
+   rather than a frozen counter. */
+.crd-hero-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 0;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--ds-border);
+}
+.crd-hero-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  align-items: flex-start;
+}
+.crd-hero-stat:nth-child(2) {
+  align-items: center;
+}
+.crd-hero-stat:last-child {
+  align-items: flex-end;
+}
+.crd-hero-stat__num {
+  font-family: 'Fraunces', serif;
+  font-weight: 800;
+  color: var(--ds-ink);
+  line-height: 1;
+  font-variation-settings:
+    'SOFT' 30,
+    'opsz' 144;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  letter-spacing: -0.01em;
+  font-size: 26px;
+}
+.crd-hero-stat__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ds-muted);
+  font-weight: 600;
+}
+.crd-hero-stat__pulse {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--trusted, #6dd4a0);
+  animation: crd-hero-pulse 1.8s ease-in-out infinite;
+}
+@keyframes crd-hero-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--trusted, #6dd4a0) 0%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 6px
+      color-mix(in srgb, var(--trusted, #6dd4a0) 25%, transparent);
+  }
 }
 .crd-actions-head {
   display: flex;

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -1120,6 +1120,16 @@
   flex-direction: column;
   gap: 14px;
 }
+/* Zero out the cr-section-head margins inherited from the Discover
+   groups rule (line 148) — the card already provides its own padding
+   + gap so the inherited 32/12 push the label down inside the card. */
+.crd-topics-section > .cr-section-head {
+  margin: 0;
+}
+/* Same scoping for the Actions budget label inside the hero. */
+.crd-hero-actions > .cr-section-head {
+  margin: 0;
+}
 /* Distribute rows vertically when the stretched card has extra height
    so the bottom doesn't feel like a void below a top-pinned label.
    space-between pushes rows to fill the full height — first stays at

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -1120,19 +1120,26 @@
   flex-direction: column;
   gap: 14px;
 }
+/* Distribute rows vertically when the stretched card has extra height
+   so the bottom doesn't feel like a void below a top-pinned label.
+   space-between pushes rows to fill the full height — first stays at
+   the top, last at the bottom, the rest spread evenly. */
 .cr-topics-list {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  flex: 1;
+  justify-content: space-between;
 }
 .cr-topics-row {
   display: grid;
   grid-template-columns: auto 1fr auto;
-  gap: 10px;
+  gap: 12px;
   align-items: center;
+  padding: 4px 0;
 }
 .cr-topics-label {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
   color: var(--ds-ink);
   overflow: hidden;

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -1153,6 +1153,145 @@
   margin-right: 2px;
 }
 
+/* ── Filter dropdowns (verb + topic) ────────────────────────────── */
+.crd-filter-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--ds-card);
+  border: 1px solid var(--ds-border);
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+  min-width: 180px;
+  font-family: inherit;
+}
+.crd-filter-trigger--wide {
+  min-width: 210px;
+}
+.crd-filter-trigger:hover {
+  border-color: var(--ds-ink-soft);
+}
+.crd-filter-trigger[data-state='open'] {
+  border-color: var(--ds-ink);
+  background: var(--ds-bg-subtle);
+}
+.crd-filter-trigger__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  transform: translateY(-1px);
+  transition: opacity 0.2s ease;
+}
+.crd-filter-trigger:hover .crd-filter-trigger__dot {
+  opacity: 0.65;
+}
+.crd-filter-trigger__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ds-muted);
+  font-weight: 600;
+}
+.crd-filter-trigger__value {
+  font-family: 'Geist', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ds-ink);
+  flex: 1;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.crd-filter-trigger__chev {
+  color: var(--ds-muted);
+  transition: transform 0.15s ease;
+  flex-shrink: 0;
+}
+.crd-filter-trigger[data-state='open'] .crd-filter-trigger__chev {
+  transform: rotate(180deg);
+}
+
+/* Popover content — override radix default w-72 + p-4 with our own. */
+.crd-filter-pop {
+  width: 320px !important;
+  padding: 12px !important;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--ds-card);
+  border-color: var(--ds-border) !important;
+  transform-origin: top left;
+}
+.crd-filter-pop--topics {
+  width: 360px !important;
+}
+.crd-filter-pop__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 4px;
+  max-height: 300px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+.crd-filter-pop__cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  font-family: 'Geist', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ds-ink);
+  text-align: left;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+.crd-filter-pop__cell:hover {
+  background: var(--ds-bg-subtle);
+}
+.crd-filter-pop__cell.is-active {
+  background: var(--ds-bg-subtle);
+  border-color: var(--ds-border);
+}
+.crd-filter-pop__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.crd-filter-pop__reset {
+  align-self: flex-end;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--ds-border);
+  border-radius: 999px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ds-muted);
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+.crd-filter-pop__reset:hover {
+  color: var(--ds-ink);
+  border-color: var(--ds-ink);
+}
+
 /* ── CircleStatsStrip ───────────────────────────────────────────── */
 .crd-stats-strip {
   display: flex;

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -968,35 +968,31 @@
 .cr-topics-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 .cr-topics-row {
   display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 4px 10px;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
   align-items: center;
 }
 .cr-topics-label {
   font-size: 12px;
   font-weight: 600;
   color: var(--ds-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .cr-topics-num {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
+  font-size: 12px;
   color: var(--ds-muted);
   font-weight: 600;
-}
-.cr-topics-bar {
-  grid-column: 1 / -1;
-  height: 3px;
-  background: var(--ds-border-soft);
-  border-radius: 999px;
-  overflow: hidden;
-}
-.cr-topics-fill {
-  height: 100%;
-  border-radius: 999px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+  text-align: right;
+  min-width: 24px;
 }
 
 /* All-members slide-in panel.

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -1580,16 +1580,30 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin-bottom: 22px;
+  margin: 4px 0 14px;
+}
+.crd-top-engaged-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
 }
 .crd-top-engaged-title {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--ds-muted);
-  font-weight: 700;
+  font-family: 'Fraunces', serif;
+  font-style: italic;
+  font-size: 14px;
+  color: var(--ds-ink);
+  font-weight: 500;
   margin: 0;
+  flex-shrink: 0;
+  font-variation-settings:
+    'SOFT' 30,
+    'opsz' 144;
+  letter-spacing: -0.01em;
+}
+.crd-top-engaged-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--ds-border);
 }
 .crd-top-engaged-strip {
   display: flex;
@@ -1618,7 +1632,7 @@
   color: inherit;
 }
 .crd-te-card:hover {
-  transform: translateY(-2px);
+  transform: translateY(-2px) rotate(-0.4deg);
   border-color: var(--ds-border);
   box-shadow: 0 10px 24px -12px color-mix(in srgb, var(--ds-ink) 30%, transparent);
 }

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -1137,6 +1137,21 @@
   gap: 8px;
   flex-shrink: 0;
 }
+.cfs-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.cfs-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ds-muted);
+  font-weight: 600;
+  margin-right: 2px;
+}
 .crd-user-filter-label {
   font-family: 'JetBrains Mono', monospace;
   font-size: 10px;

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -1152,6 +1152,168 @@
   font-weight: 600;
   margin-right: 2px;
 }
+
+/* ── CircleStatsStrip ───────────────────────────────────────────── */
+.crd-stats-strip {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  padding: 14px 20px;
+  border-radius: 14px;
+  background: var(--ds-bg-subtle);
+  border: 1px solid var(--ds-border-soft);
+  border-left: 4px solid var(--circle-color, var(--ds-accent));
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+.crd-stat {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+}
+.crd-stat-value {
+  font-family: 'Fraunces', serif;
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--ds-ink);
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-variation-settings:
+    'SOFT' 30,
+    'opsz' 144;
+}
+.crd-stat-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--trusted, #6dd4a0);
+  animation: crd-stat-pulse 1.8s ease-in-out infinite;
+}
+@keyframes crd-stat-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--trusted, #6dd4a0) 0%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--trusted, #6dd4a0) 25%, transparent);
+  }
+}
+.crd-stat-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ds-muted);
+  font-weight: 600;
+}
+.crd-stat-divider {
+  width: 1px;
+  height: 34px;
+  background: var(--ds-border);
+  flex-shrink: 0;
+}
+
+/* ── CircleTopEngagedStrip ──────────────────────────────────────── */
+.crd-top-engaged {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 22px;
+}
+.crd-top-engaged-title {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ds-muted);
+  font-weight: 700;
+  margin: 0;
+}
+.crd-top-engaged-strip {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  padding: 2px 2px 8px;
+  scrollbar-width: thin;
+}
+.crd-te-card {
+  flex: 0 0 168px;
+  width: 168px;
+  padding: 10px;
+  background: var(--ds-card);
+  border: 1px solid var(--ds-border-soft);
+  border-radius: 12px;
+  text-decoration: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  cursor: pointer;
+  transition:
+    transform 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+  position: relative;
+  color: inherit;
+}
+.crd-te-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--ds-border);
+  box-shadow: 0 10px 24px -12px color-mix(in srgb, var(--ds-ink) 30%, transparent);
+}
+.crd-te-rank {
+  position: absolute;
+  top: 14px;
+  left: 14px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 3px 7px;
+  border-radius: 6px;
+  background: var(--ds-ink);
+  color: var(--ds-bg);
+  z-index: 2;
+}
+.crd-te-thumb {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--ds-bg-subtle);
+}
+.crd-te-title {
+  font-family: 'Geist', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ds-ink);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.3;
+  min-height: 32px;
+}
+.crd-te-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+.crd-te-stars {
+  display: inline-flex;
+  gap: 1px;
+  line-height: 0;
+}
+.crd-te-count {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ds-muted);
+  font-weight: 600;
+}
 .crd-user-filter-label {
   font-family: 'JetBrains Mono', monospace;
   font-size: 10px;

--- a/apps/explorer/src/components/styles/feed-card.css
+++ b/apps/explorer/src/components/styles/feed-card.css
@@ -455,25 +455,29 @@
 }
 
 /* Masonry column layout (CSS columns — no JS needed). */
+/* Row-major grid (was CSS-columns masonry). Items flow left-to-right
+   so the engagement sort reads as 1 2 3 / 4 5 6 instead of the
+   column-first 1 3 5 / 2 4 6 you get with `column-count`. The class
+   name is kept for backward compat with the existing selectors. */
 .masonry-grid {
-  column-count: 3;
-  column-gap: 14px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
   width: 100%;
 }
 .masonry-grid > * {
-  break-inside: avoid;
-  margin-bottom: 14px;
   display: flex;
   overflow: visible;
+  min-width: 0;
 }
 @media (max-width: 1200px) {
   .masonry-grid {
-    column-count: 2;
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 @media (max-width: 720px) {
   .masonry-grid {
-    column-count: 1;
+    grid-template-columns: 1fr;
   }
 }
 

--- a/apps/explorer/src/components/styles/feed-card.css
+++ b/apps/explorer/src/components/styles/feed-card.css
@@ -306,7 +306,9 @@
   background: #ff5722;
 }
 
-/* Star badge (top-right of the card). Mock until real ratings ship. */
+/* Star badge (top-right of the card). 5-tier scale: gold (1..3),
+   orange (4), red (5). Slots above the current score render muted so
+   the bar reads as a fixed 5-step scale at a glance. */
 .fc-star-badge {
   position: absolute;
   top: 12px;
@@ -327,15 +329,27 @@
 .fc-star-badge:hover {
   transform: scale(1.08);
 }
-.fc-star-badge svg {
-  color: var(--ds-accent);
+.fc-star-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  line-height: 0;
 }
-.fc-star-num {
-  font-family: 'Fraunces', serif;
-  font-size: 14px;
-  font-weight: 800;
-  color: var(--ds-ink);
-  line-height: 1;
+.fc-star {
+  flex-shrink: 0;
+  transition: color 0.15s ease;
+}
+.fc-star--gold {
+  color: var(--fun, #e4b95a);
+}
+.fc-star--orange {
+  color: var(--music, #e0896a);
+}
+.fc-star--red {
+  color: var(--distrusted, #e87c7c);
+}
+.fc-star--muted {
+  color: color-mix(in srgb, var(--ds-border) 70%, transparent);
 }
 /* Tooltip sits BELOW the badge so it stays inside the card bounds — CSS
    column layouts (.masonry-grid) clip children that overflow a column,

--- a/apps/explorer/src/hooks/useCircleTopicCounts.ts
+++ b/apps/explorer/src/hooks/useCircleTopicCounts.ts
@@ -47,8 +47,18 @@ export function useCircleTopicCounts(
     refetchOnWindowFocus: false,
   })
 
+  // PersistQueryClient JSON-serializes the cache, so a Map rehydrates as
+  // a plain object and loses `.get`. Normalize back to Map on every read
+  // so consumers can keep relying on the Map interface.
+  const counts: CircleTopicCounts =
+    data instanceof Map
+      ? data
+      : data && typeof data === 'object'
+        ? new Map(Object.entries(data as Record<string, number>))
+        : EMPTY
+
   return {
-    counts: data ?? EMPTY,
+    counts,
     isLoading: enabled && isLoading,
     error: error
       ? error instanceof Error

--- a/apps/explorer/src/services/circleFeedSort.ts
+++ b/apps/explorer/src/services/circleFeedSort.ts
@@ -37,3 +37,26 @@ export function sortFeed(
   }
   return [...items].sort((a, b) => engagementScore(b) - engagementScore(a))
 }
+
+/** Bucket a raw support count into the 1..5 star scale used by feed
+ *  cards, the top-engaged strip, and any other star renderer that
+ *  wants to read off the same thresholds. */
+export function computeStars(supports: number): number {
+  if (supports >= 20) return 5
+  if (supports >= 14) return 4
+  if (supports >= 9) return 3
+  if (supports >= 5) return 2
+  return 1
+}
+
+/** Tier color for slot `n` of a star bar at level `stars`.
+ *  gold for 1..3, orange for 4, red for 5; muted for unreached slots. */
+export function starTier(
+  slot: number,
+  stars: number,
+): 'gold' | 'orange' | 'red' | 'muted' {
+  if (slot > stars) return 'muted'
+  if (slot <= 3) return 'gold'
+  if (slot === 4) return 'orange'
+  return 'red'
+}

--- a/apps/explorer/src/services/circleFeedSort.ts
+++ b/apps/explorer/src/services/circleFeedSort.ts
@@ -1,0 +1,39 @@
+/**
+ * Sort utilities for the circles feed.
+ *
+ * Two modes:
+ *   - `engagement`: raw position count across both sides of every intention
+ *     vault (support + oppose), plus a recency bonus on a 7-day half-life.
+ *     Surfaces what the circle is actively staking on, while still letting
+ *     a fresh post overtake a cold top-scorer.
+ *   - `recent`: pure timestamp DESC. Keeps the legacy chronological view.
+ */
+import type { CircleItem } from './circleService'
+
+export type FeedSortId = 'engagement' | 'recent'
+
+const RECENCY_HALF_LIFE_MS = 7 * 24 * 60 * 60 * 1000
+
+export function engagementScore(item: CircleItem): number {
+  const raw = Object.values(item.intentionVaults).reduce(
+    (acc, v) => acc + v.supportCount + v.opposeCount,
+    0,
+  )
+  const ts = new Date(item.timestamp).getTime()
+  const ageMs = Math.max(0, Date.now() - ts)
+  const decay = Math.pow(0.5, ageMs / RECENCY_HALF_LIFE_MS)
+  return raw + decay
+}
+
+export function sortFeed(
+  items: CircleItem[],
+  sort: FeedSortId,
+): CircleItem[] {
+  if (sort === 'recent') {
+    return [...items].sort(
+      (a, b) =>
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    )
+  }
+  return [...items].sort((a, b) => engagementScore(b) - engagementScore(a))
+}

--- a/apps/explorer/src/services/circleStats.ts
+++ b/apps/explorer/src/services/circleStats.ts
@@ -10,18 +10,18 @@ const ACTIVE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
 
 export interface CircleStats {
   postCount: number
-  endorsementCount: number
+  voteCount: number
   activeMemberCount: number
 }
 
 export function computeCircleStats(items: CircleItem[]): CircleStats {
   const cutoff = Date.now() - ACTIVE_WINDOW_MS
   const activeCertifiers = new Set<string>()
-  let endorsementCount = 0
+  let voteCount = 0
 
   for (const item of items) {
     for (const v of Object.values(item.intentionVaults)) {
-      endorsementCount += v.supportCount + v.opposeCount
+      voteCount += v.supportCount + v.opposeCount
     }
     if (
       new Date(item.timestamp).getTime() >= cutoff &&
@@ -33,7 +33,7 @@ export function computeCircleStats(items: CircleItem[]): CircleStats {
 
   return {
     postCount: items.length,
-    endorsementCount,
+    voteCount,
     activeMemberCount: activeCertifiers.size,
   }
 }

--- a/apps/explorer/src/services/circleStats.ts
+++ b/apps/explorer/src/services/circleStats.ts
@@ -4,9 +4,17 @@
  * functions over `CircleItem[]`, no side effects.
  */
 import type { CircleItem } from './circleService'
+import type { TrustCircleAccount } from './trustCircleService'
 import { engagementScore } from './circleFeedSort'
 
 const ACTIVE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
+
+export type ActivityWindow = '7d' | '30d' | 'all'
+
+export interface MemberActivity {
+  member: TrustCircleAccount
+  count: number
+}
 
 export interface CircleStats {
   postCount: number
@@ -45,4 +53,41 @@ export function computeTopEngaged(
   return [...items]
     .sort((a, b) => engagementScore(b) - engagementScore(a))
     .slice(0, n)
+}
+
+/** Rank the circle's members by their signal count inside a time window.
+ *  Falls back to all-time when `window === 'all'`. Returns the top N
+ *  members whose `walletAddress` matches a certifier in the feed. */
+export function computeMostActive(
+  items: CircleItem[],
+  members: TrustCircleAccount[],
+  window: ActivityWindow = '7d',
+  topN: number = 4,
+): MemberActivity[] {
+  const cutoff =
+    window === '7d'
+      ? Date.now() - 7 * 24 * 60 * 60 * 1000
+      : window === '30d'
+        ? Date.now() - 30 * 24 * 60 * 60 * 1000
+        : 0
+
+  const counts = new Map<string, number>()
+  for (const item of items) {
+    if (new Date(item.timestamp).getTime() < cutoff) continue
+    if (!item.certifierAddress) continue
+    const key = item.certifierAddress.toLowerCase()
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+
+  const byWallet = new Map<string, TrustCircleAccount>()
+  for (const m of members) {
+    if (m.walletAddress) byWallet.set(m.walletAddress.toLowerCase(), m)
+  }
+
+  const result: MemberActivity[] = []
+  for (const [addr, count] of counts) {
+    const member = byWallet.get(addr)
+    if (member) result.push({ member, count })
+  }
+  return result.sort((a, b) => b.count - a.count).slice(0, topN)
 }

--- a/apps/explorer/src/services/circleStats.ts
+++ b/apps/explorer/src/services/circleStats.ts
@@ -1,0 +1,48 @@
+/**
+ * Aggregate metrics for a circle's feed — feeds the stats strip under
+ * the hero and the top-engaged strip above the activity feed. Pure
+ * functions over `CircleItem[]`, no side effects.
+ */
+import type { CircleItem } from './circleService'
+import { engagementScore } from './circleFeedSort'
+
+const ACTIVE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
+
+export interface CircleStats {
+  postCount: number
+  endorsementCount: number
+  activeMemberCount: number
+}
+
+export function computeCircleStats(items: CircleItem[]): CircleStats {
+  const cutoff = Date.now() - ACTIVE_WINDOW_MS
+  const activeCertifiers = new Set<string>()
+  let endorsementCount = 0
+
+  for (const item of items) {
+    for (const v of Object.values(item.intentionVaults)) {
+      endorsementCount += v.supportCount + v.opposeCount
+    }
+    if (
+      new Date(item.timestamp).getTime() >= cutoff &&
+      item.certifierAddress
+    ) {
+      activeCertifiers.add(item.certifierAddress.toLowerCase())
+    }
+  }
+
+  return {
+    postCount: items.length,
+    endorsementCount,
+    activeMemberCount: activeCertifiers.size,
+  }
+}
+
+export function computeTopEngaged(
+  items: CircleItem[],
+  n: number = 4,
+): CircleItem[] {
+  return [...items]
+    .sort((a, b) => engagementScore(b) - engagementScore(a))
+    .slice(0, n)
+}


### PR DESCRIPTION
## Summary

Re-pitch the explorer around Circles as the primary surface and rebuild the circle detail page so engagement reads at a glance.

- **Nav** — Circles takes the top spot above Home / Compose / Profile (NavSidebar swap).
- **Feed** — engagement sort with a Top engaged / Recent toggle, 5-tier star rating (gold 1–3 / orange 4 / red 5), filters consolidated into popovers (Verbs · Topics · Member share the same chrome), masonry switched to a CSS grid so the sort reads left-to-right.
- **Hero** — three live stats (posts / votes / live · 7d) folded into the right rail, posts→votes rename, subtle circle-color inset accent.
- **Info row** — 3-column layout (Members · Most Active · Top Topics) sharing the available oxygen, all cards bottom-aligned via \`align-items: stretch\`.
- **Most Active** — new mini-leaderboard with rank in Fraunces serif + pixel bars, time-window toggle 7d / 30d / All, auto-fallback when the window is empty.
- **Top Topics** — bars dropped, single-line rows with tabular-nums.
- **Hot picks** — renamed (was \"Hot this week\"), moved inside CircleFeedSection under the filters, magazine-style separator + -0.4deg tilt on hover.
- **Fixes** — Map rehydration for CircleTopicCounts under \`PersistQueryClient\` JSON cache; scoped out an inherited \`cr-section-head\` 32px margin that was pushing the Top Topics + Actions Budget labels down.

## Test plan

- [ ] \`/circles/trust\` renders without crash, three info-row cards end at the same y
- [ ] Verbs · Topics · Member popovers open, select, close, reset
- [ ] Sort toggle: Top engagement is default, switching to Recent reorders the feed
- [ ] Hot picks strip shows top 4, tilt on hover
- [ ] Stars: 1–3 gold, 4 orange, 5 red, off slots muted
- [ ] Most Active: 7d / 30d / All toggle changes the ranking; empty state suggests a wider window
- [ ] Feed cards lay out 1 2 3 / 4 5 6 (row-major), not 1 4 / 2 5 / 3 6
- [ ] Hero stats row: posts left · votes centered · live right, all on the same baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)