### PR TITLE
feat(explorer): My Impact section, public circles, Discover CTA

### DIFF
--- a/apps/explorer/src/App.tsx
+++ b/apps/explorer/src/App.tsx
@@ -303,14 +303,11 @@ export default function App() {
                     </ProtectedRoute>
                   }
                 />
-                <Route
-                  path="/circles"
-                  element={
-                    <ProtectedRoute>
-                      <CirclesPage />
-                    </ProtectedRoute>
-                  }
-                />
+                {/* Circles routes are PUBLIC — a visitor can browse the
+                    on-chain groups and their members without connecting.
+                    Join + create actions surface a Connect CTA via the
+                    locked overlay when no wallet is linked. */}
+                <Route path="/circles" element={<CirclesPage />} />
                 {/* Legacy redirect — older share links pointed to
                     `/circles/group/:termId`. The unified detail page
                     lives at `/circles/:id` now. */}
@@ -318,14 +315,7 @@ export default function App() {
                   path="/circles/group/:id"
                   element={<LegacyGroupRedirect />}
                 />
-                <Route
-                  path="/circles/:id"
-                  element={
-                    <ProtectedRoute>
-                      <CirclesPage />
-                    </ProtectedRoute>
-                  }
-                />
+                <Route path="/circles/:id" element={<CirclesPage />} />
                 <Route
                   path="/compose"
                   element={

--- a/apps/explorer/src/components/profile/CircleImpactSection.tsx
+++ b/apps/explorer/src/components/profile/CircleImpactSection.tsx
@@ -63,9 +63,12 @@ export default function CircleImpactSection({
           <span className="pp-impact-num">{formatCount(positions.size)}</span>
           <span className="pp-impact-label">Votes</span>
         </div>
-        <div className="pp-impact-stat pp-impact-stat--coming">
+        <div
+          className="pp-impact-stat pp-impact-stat--coming"
+          title="Gold sponsored — lands with the Boost feature"
+        >
           <span className="pp-impact-num">—</span>
-          <span className="pp-impact-label">Gold sponsored</span>
+          <span className="pp-impact-label">Gold</span>
           <span className="pp-impact-soon">soon</span>
         </div>
       </div>

--- a/apps/explorer/src/components/profile/CircleImpactSection.tsx
+++ b/apps/explorer/src/components/profile/CircleImpactSection.tsx
@@ -1,0 +1,74 @@
+/**
+ * CircleImpactSection — "My Impact in Circles" stats row rendered at
+ * the top of the profile page so the user's circle footprint reads
+ * before any other content. Four metrics: how many circles you're in
+ * (Trust Circle + on-chain groups you've joined), how many URLs you've
+ * certified, how many positions you've taken across all triples, and
+ * a placeholder for the Gold-sponsored count that lands with the Boost
+ * chantier.
+ */
+import { useMemo } from 'react'
+import { useGroups } from '@/hooks/useGroups'
+import { useUserPositionTermIds } from '@/hooks/useUserPositionTermIds'
+
+interface CircleImpactSectionProps {
+  /** The user's linked wallet addresses. */
+  addresses: string[]
+  /** Number of URLs the user has certified — comes pre-computed from
+   *  `useUserOnChainProfile` in ProfilePage so we don't re-fetch. */
+  certsCount: number
+}
+
+function formatCount(n: number): string {
+  if (n >= 1000) return (n / 1000).toFixed(1) + 'k'
+  return String(n)
+}
+
+export default function CircleImpactSection({
+  addresses,
+  certsCount,
+}: CircleImpactSectionProps) {
+  const { groups } = useGroups()
+  const positions = useUserPositionTermIds(addresses)
+
+  const circlesCount = useMemo(() => {
+    if (addresses.length === 0) return 1
+    const userWallets = new Set(addresses.map((a) => a.toLowerCase()))
+    const joined = groups.filter((g) =>
+      g.memberships.some((m) => {
+        const w = m.member.walletAddress?.toLowerCase()
+        return w !== undefined && userWallets.has(w)
+      }),
+    )
+    // +1 for the Trust Circle which every user has by default.
+    return 1 + joined.length
+  }, [groups, addresses])
+
+  return (
+    <section className="pp-section pp-impact">
+      <div
+        className="pp-impact-grid"
+        role="group"
+        aria-label="My impact in circles"
+      >
+        <div className="pp-impact-stat">
+          <span className="pp-impact-num">{circlesCount}</span>
+          <span className="pp-impact-label">Circles</span>
+        </div>
+        <div className="pp-impact-stat">
+          <span className="pp-impact-num">{formatCount(certsCount)}</span>
+          <span className="pp-impact-label">Posts</span>
+        </div>
+        <div className="pp-impact-stat">
+          <span className="pp-impact-num">{formatCount(positions.size)}</span>
+          <span className="pp-impact-label">Votes</span>
+        </div>
+        <div className="pp-impact-stat pp-impact-stat--coming">
+          <span className="pp-impact-num">—</span>
+          <span className="pp-impact-label">Gold sponsored</span>
+          <span className="pp-impact-soon">soon</span>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/explorer/src/components/styles/landing.css
+++ b/apps/explorer/src/components/styles/landing.css
@@ -249,6 +249,42 @@
   border-style: solid;
 }
 
+/* Live count badge inside the Discover Circles button. Sits between
+   the label and the arrow, reads as a real-time indicator (dot pulses
+   green) so the CTA doesn't look like a static link. */
+.lp-btn-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  margin-left: 4px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  opacity: 0.85;
+}
+.lp-btn-badge-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #6dd4a0;
+  box-shadow: 0 0 0 0 rgba(109, 212, 160, 0.6);
+  animation: lp-badge-pulse 1.8s ease-in-out infinite;
+}
+@keyframes lp-badge-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(109, 212, 160, 0);
+  }
+  50% {
+    box-shadow: 0 0 0 5px rgba(109, 212, 160, 0.25);
+  }
+}
+
 /* divider */
 
 .lp-divider {

--- a/apps/explorer/src/components/styles/profile-sections.css
+++ b/apps/explorer/src/components/styles/profile-sections.css
@@ -44,32 +44,42 @@
   gap: 14px;
 }
 
-/* ── My Impact in Circles — top profile stats row ────────────────── */
+/* ── My Impact in Circles — compact stats strip ─────────────────── */
+.pp-impact {
+  align-items: center;
+}
 .pp-impact-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0;
-  padding: 18px 24px;
-  border-radius: 14px;
+  grid-template-columns: repeat(4, auto);
+  justify-content: center;
+  align-items: center;
+  gap: 28px;
+  padding: 12px 24px;
+  border-radius: 999px;
   background: var(--ds-card);
   border: 1px solid var(--ds-border);
-  align-items: stretch;
+  max-width: fit-content;
 }
 .pp-impact-stat {
   display: flex;
-  flex-direction: column;
+  align-items: baseline;
   gap: 8px;
-  align-items: flex-start;
   position: relative;
-  padding: 0 12px;
 }
-.pp-impact-stat:not(:first-child) {
-  border-left: 1px solid var(--ds-border-soft);
+.pp-impact-stat:not(:first-child)::before {
+  content: '';
+  position: absolute;
+  left: -14px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1px;
+  height: 18px;
+  background: var(--ds-border-soft);
 }
 .pp-impact-num {
   font-family: 'Fraunces', serif;
   font-weight: 800;
-  font-size: 32px;
+  font-size: 22px;
   color: var(--ds-ink);
   line-height: 1;
   font-variation-settings:
@@ -79,7 +89,7 @@
 }
 .pp-impact-label {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
+  font-size: 9px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--ds-muted);
@@ -96,21 +106,19 @@
   color: var(--ds-muted);
   font-weight: 600;
   border: 1px solid var(--ds-border);
-  padding: 2px 6px;
+  padding: 1px 6px;
   border-radius: 999px;
-  align-self: flex-start;
-  margin-top: 2px;
 }
 @media (max-width: 720px) {
   .pp-impact-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
+    grid-template-columns: repeat(2, auto);
+    gap: 14px 24px;
+    border-radius: 14px;
+    padding: 14px 20px;
   }
-  .pp-impact-stat:not(:first-child) {
-    border-left: none;
-  }
-  .pp-impact-stat:nth-child(odd) {
-    padding-left: 0;
+  .pp-impact-stat:nth-child(odd):not(:first-child)::before,
+  .pp-impact-stat:nth-child(2)::before {
+    display: none;
   }
 }
 

--- a/apps/explorer/src/components/styles/profile-sections.css
+++ b/apps/explorer/src/components/styles/profile-sections.css
@@ -44,6 +44,76 @@
   gap: 14px;
 }
 
+/* ── My Impact in Circles — top profile stats row ────────────────── */
+.pp-impact-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  padding: 18px 24px;
+  border-radius: 14px;
+  background: var(--ds-card);
+  border: 1px solid var(--ds-border);
+  align-items: stretch;
+}
+.pp-impact-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+  position: relative;
+  padding: 0 12px;
+}
+.pp-impact-stat:not(:first-child) {
+  border-left: 1px solid var(--ds-border-soft);
+}
+.pp-impact-num {
+  font-family: 'Fraunces', serif;
+  font-weight: 800;
+  font-size: 32px;
+  color: var(--ds-ink);
+  line-height: 1;
+  font-variation-settings:
+    'SOFT' 30,
+    'opsz' 144;
+  letter-spacing: -0.015em;
+}
+.pp-impact-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ds-muted);
+  font-weight: 600;
+}
+.pp-impact-stat--coming .pp-impact-num {
+  color: var(--ds-muted);
+}
+.pp-impact-soon {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 8px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ds-muted);
+  font-weight: 600;
+  border: 1px solid var(--ds-border);
+  padding: 2px 6px;
+  border-radius: 999px;
+  align-self: flex-start;
+  margin-top: 2px;
+}
+@media (max-width: 720px) {
+  .pp-impact-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+  .pp-impact-stat:not(:first-child) {
+    border-left: none;
+  }
+  .pp-impact-stat:nth-child(odd) {
+    padding-left: 0;
+  }
+}
+
 /* ── Public profile stats ── */
 .pub-stats-grid {
   display: grid;

--- a/apps/explorer/src/pages/CirclesPage.tsx
+++ b/apps/explorer/src/pages/CirclesPage.tsx
@@ -8,6 +8,7 @@
  */
 import { useEffect, useMemo, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router-dom'
+import { usePrivy } from '@privy-io/react-auth'
 import { ArrowLeft } from 'lucide-react'
 import { INTENTION_PASTEL, PageHero } from '@0xsofia/design-system'
 import { useTrustCircle } from '@/hooks/useTrustCircle'
@@ -40,6 +41,7 @@ export default function CirclesPage() {
 // ── List view ────────────────────────────────────────────────────────
 
 function CirclesListSection() {
+  const { authenticated } = usePrivy()
   const { addresses } = useLinkedWallets()
   const { accounts: trustMembers, loading: trustLoading } =
     useTrustCircle(addresses)
@@ -69,18 +71,24 @@ function CirclesListSection() {
     <div className="pf-view cr-page">
       <PageHero
         title="Circles"
-        description="Explore the circles whose signals shape your feed and dive into yours."
+        description={
+          authenticated
+            ? 'Explore the circles whose signals shape your feed and dive into yours.'
+            : 'Discover the circles shaping signal on Sofia — connect to join, create, or dive in.'
+        }
       />
 
       <CirclesFilters />
 
-      <div className="cr-grid">
-        <CreateCircleCard onClick={() => setCreateOpen(true)} />
-        <TrustCircleCard members={trustMembers} loading={trustLoading} />
-        {joinedGroups.map((g) => (
-          <GroupCard key={g.termId} group={g} />
-        ))}
-      </div>
+      {authenticated && (
+        <div className="cr-grid">
+          <CreateCircleCard onClick={() => setCreateOpen(true)} />
+          <TrustCircleCard members={trustMembers} loading={trustLoading} />
+          {joinedGroups.map((g) => (
+            <GroupCard key={g.termId} group={g} />
+          ))}
+        </div>
+      )}
 
       <DiscoverGroupsSection
         groups={discoverGroups}

--- a/apps/explorer/src/pages/LandingPage.tsx
+++ b/apps/explorer/src/pages/LandingPage.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router-dom'
 import { usePrivy, useLogin } from '@privy-io/react-auth'
 import { TopicsIntentions } from '@/components/TopicsIntentions'
 import { HexSplit } from '@/components/HexSplit'
+import { useGroups } from '@/hooks/useGroups'
 import '@/components/styles/landing.css'
 
 export default function LandingPage() {
@@ -20,6 +21,11 @@ export default function LandingPage() {
   const { login } = useLogin({
     onComplete: () => navigate('/profile'),
   })
+  // Live on-chain group count — feeds the "Discover Circles" badge so
+  // the CTA reads as a real, populated network rather than a static
+  // pitch button. Falls back gracefully if the fetch is in-flight.
+  const { groups } = useGroups()
+  const circleCount = groups.length
 
   useEffect(() => {
     if (ready && authenticated) {
@@ -136,6 +142,33 @@ export default function LandingPage() {
                 <span className="lp-arrow">→</span>
               </button>
 
+              <button
+                type="button"
+                className="lp-btn lp-btn-quiet"
+                onClick={() => navigate('/circles')}
+              >
+                <span className="lp-icon" aria-hidden>
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <circle cx="12" cy="12" r="9" />
+                    <circle cx="12" cy="12" r="4.5" />
+                  </svg>
+                </span>
+                Discover Circles
+                {circleCount > 0 && (
+                  <span className="lp-btn-badge">
+                    <span className="lp-btn-badge-dot" aria-hidden />
+                    {circleCount} live
+                  </span>
+                )}
+                <span className="lp-arrow">→</span>
+              </button>
               <button
                 type="button"
                 className="lp-btn lp-btn-quiet"

--- a/apps/explorer/src/pages/ProfilePage.tsx
+++ b/apps/explorer/src/pages/ProfilePage.tsx
@@ -17,6 +17,7 @@ import InterestsGrid, {
   MAX_INTERESTS,
 } from '../components/profile/InterestsGrid'
 import ProfileCharts from '../components/profile/ProfileCharts'
+import CircleImpactSection from '../components/profile/CircleImpactSection'
 import { useUntaggedCerts } from '../hooks/useUntaggedCerts'
 import { Card } from '../components/ui/card'
 import { Button } from '../components/ui/button'
@@ -187,6 +188,17 @@ export default function ProfilePage() {
       )}
 
       <div className="pp-sections">
+        {/* My impact in Circles — top of the page so the circle footprint
+            reads before anything else. Hidden in view-as mode since the
+            data shape (positions, joined groups) is wired to the current
+            user's wallets, not the wallet being inspected. */}
+        {!isViewingAs && (
+          <CircleImpactSection
+            addresses={myAddresses}
+            certsCount={profile.certs.length}
+          />
+        )}
+
         {/* Interests */}
         <section className="pp-section">
           <SectionH2>{isViewingAs ? 'Interests' : 'My Interests'}</SectionH2>


### PR DESCRIPTION
## Summary

Extends the Circles-first work — symmetrize the vision on the profile page and open the Circles list to non-authenticated visitors.

- **D — My Impact in Circles** (ProfilePage) — compact centered pill at the top of \`pp-sections\` with four metrics: Circles (Trust + joined on-chain groups), Posts (own certifications), Votes (positions held), Gold sponsored (placeholder, lands with the Boost chantier). Inline baseline-aligned numbers, 1px pseudo-divider between stats, pill shape (\`border-radius: 999px\`), hidden in view-as mode.
- **G.1 — Public /circles** — Drop the ProtectedRoute on \`/circles\` and \`/circles/:id\`. Visitors can browse the on-chain groups grid + members + topics without connecting; the activity feed stays gated behind the existing locked overlay. Trust Circle and Create cards hidden for non-auth. Hero copy adapts.
- **G.2 — Discover Circles CTA** — New quiet-style button on LandingPage (between auth options and \"Explore as guest\") with a live badge showing the on-chain group count + a pulsing green dot. Links to the now-public /circles.

## Test plan

- [ ] \`/profile\` (logged in): impact pill visible at the top, four stats baseline-aligned
- [ ] \`/profile\` mobile: pill wraps to 2×2 grid
- [ ] \`/profile/0x...\` (view-as another wallet): impact pill is hidden
- [ ] \`/circles\` (logged out): grid renders without crash, Trust Circle and Create cards hidden, hero copy reads \"Discover the circles…\"
- [ ] \`/circles/:id\` (logged out): hero + members + topics visible, activity feed locked with a Connect/Join CTA
- [ ] \`/\` (logged out): \"Discover Circles · N LIVE\" button appears between Email and Explore as guest, dot pulses green
- [ ] Click \"Discover Circles\" on \`/\` → lands on public \`/circles\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)