### PR TITLE
feat(explorer): emit trust signals from the AllMembers drawer

### DIFF
--- a/apps/explorer/src/components/circles/AllMembersPanel.tsx
+++ b/apps/explorer/src/components/circles/AllMembersPanel.tsx
@@ -11,6 +11,7 @@ import { useEnsNames } from '@/hooks/useEnsNames'
 import type { Address } from 'viem'
 import { UserPlus } from 'lucide-react'
 import MemberAvatar from './MemberAvatar'
+import TrustMemberButton from './TrustMemberButton'
 
 const shortAddress = (addr: string) => `${addr.slice(0, 6)}…${addr.slice(-4)}`
 
@@ -97,7 +98,7 @@ export default function AllMembersPanel({
                 ? shortAddress(m.walletAddress)
                 : ''
               const displayName = ens && ens !== shortAddr ? ens : m.label
-              const inner = (
+              const info = (
                 <>
                   <MemberAvatar member={m} />
                   <div className="crd-member-info">
@@ -108,20 +109,22 @@ export default function AllMembersPanel({
                   </div>
                 </>
               )
-              // Whole row navigates to the member's public profile when
-              // we have a resolved wallet. Members without one render as
-              // a plain <div> — clicking nothing is the right default.
-              return m.walletAddress ? (
-                <Link
-                  key={m.termId}
-                  to={`/profile/${m.walletAddress}`}
-                  className="crd-member-row crd-member-row--link"
-                >
-                  {inner}
-                </Link>
-              ) : (
+              // Outer div hosts the nav target + the action button as
+              // siblings so the Trust action doesn't get swallowed by
+              // the row-wide profile link.
+              return (
                 <div key={m.termId} className="crd-member-row">
-                  {inner}
+                  {m.walletAddress ? (
+                    <Link
+                      to={`/profile/${m.walletAddress}`}
+                      className="crd-member-row__main crd-member-row--link"
+                    >
+                      {info}
+                    </Link>
+                  ) : (
+                    <div className="crd-member-row__main">{info}</div>
+                  )}
+                  <TrustMemberButton member={m} />
                 </div>
               )
             })

--- a/apps/explorer/src/components/circles/TrustMemberButton.tsx
+++ b/apps/explorer/src/components/circles/TrustMemberButton.tsx
@@ -1,0 +1,42 @@
+/**
+ * TrustMemberButton — small pill action attached to each row in
+ * `AllMembersPanel`. Wraps `useTrustMember` so the button shows the
+ * right state at every step: idle / queued / disabled with reason.
+ * Click stops propagation so the surrounding row link still navigates
+ * to the public profile when clicked elsewhere.
+ */
+import type { MouseEvent } from 'react'
+import { ShieldCheck } from 'lucide-react'
+import { useTrustMember } from '@/hooks/useTrustMember'
+import type { TrustCircleAccount } from '@/services/trustCircleService'
+
+interface TrustMemberButtonProps {
+  member: TrustCircleAccount
+}
+
+export default function TrustMemberButton({ member }: TrustMemberButtonProps) {
+  const { trust, inCart, disabledReason, disabledHint } = useTrustMember(member)
+
+  const handleClick = (e: MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    trust()
+  }
+
+  const label = inCart ? 'Queued' : 'Trust'
+  const title = disabledHint ?? (inCart ? 'In cart — submit to emit' : 'Trust this member')
+
+  return (
+    <button
+      type="button"
+      className={`crd-trust-btn${inCart ? ' is-queued' : ''}`}
+      onClick={handleClick}
+      disabled={!!disabledReason}
+      aria-label={title}
+      title={title}
+    >
+      <ShieldCheck className="h-3 w-3" aria-hidden="true" />
+      <span>{label}</span>
+    </button>
+  )
+}

--- a/apps/explorer/src/components/circles/TrustMemberButton.tsx
+++ b/apps/explorer/src/components/circles/TrustMemberButton.tsx
@@ -6,7 +6,7 @@
  * to the public profile when clicked elsewhere.
  */
 import type { MouseEvent } from 'react'
-import { ShieldCheck } from 'lucide-react'
+import { ShieldCheck, Check } from 'lucide-react'
 import { useTrustMember } from '@/hooks/useTrustMember'
 import type { TrustCircleAccount } from '@/services/trustCircleService'
 
@@ -15,7 +15,8 @@ interface TrustMemberButtonProps {
 }
 
 export default function TrustMemberButton({ member }: TrustMemberButtonProps) {
-  const { trust, inCart, disabledReason, disabledHint } = useTrustMember(member)
+  const { trust, inCart, alreadyTrusted, disabledReason, disabledHint } =
+    useTrustMember(member)
 
   const handleClick = (e: MouseEvent) => {
     e.preventDefault()
@@ -23,8 +24,27 @@ export default function TrustMemberButton({ member }: TrustMemberButtonProps) {
     trust()
   }
 
+  // Trusted on-chain — solid green badge, no interaction. Read-only
+  // confirmation that the user already emitted the triple in the past.
+  if (alreadyTrusted) {
+    return (
+      <button
+        type="button"
+        className="crd-trust-btn is-trusted"
+        disabled
+        aria-label="You trust this member"
+        title="You trust this member on-chain"
+      >
+        <Check className="h-3 w-3" aria-hidden="true" />
+        <span>Trusted</span>
+      </button>
+    )
+  }
+
   const label = inCart ? 'Queued' : 'Trust'
-  const title = disabledHint ?? (inCart ? 'In cart — submit to emit' : 'Trust this member')
+  const title =
+    disabledHint ??
+    (inCart ? 'In cart — submit to emit' : 'Trust this member')
 
   return (
     <button

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -1286,12 +1286,23 @@
 .crd-member-row {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 8px;
+  gap: 10px;
+  padding: 6px 4px;
   border-radius: 8px;
+}
+.crd-member-row__main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  min-width: 0;
+  text-decoration: none;
+  color: inherit;
   transition: background 0.15s ease;
 }
-.crd-member-row:hover {
+.crd-member-row__main.crd-member-row--link:hover {
   background: var(--ds-bg-subtle);
 }
 .crd-member-row .mav {
@@ -1301,6 +1312,45 @@
   margin: 0;
   border: none;
   flex-shrink: 0;
+}
+/* Trust this member — small pill action sitting at the end of each
+   row in AllMembersPanel. Stays subtle by default (--trusted color at
+   low intensity) and flips to a "queued" muted look once the intent
+   is in the cart. */
+.crd-trust-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--trusted, #6dd4a0) 50%, transparent);
+  background: color-mix(in srgb, var(--trusted, #6dd4a0) 10%, transparent);
+  color: var(--trusted, #6dd4a0);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
+}
+.crd-trust-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--trusted, #6dd4a0) 22%, transparent);
+  border-color: var(--trusted, #6dd4a0);
+}
+.crd-trust-btn.is-queued {
+  color: var(--ds-muted);
+  border-color: var(--ds-border);
+  background: transparent;
+}
+.crd-trust-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 .crd-member-info {
   display: flex;

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -1314,18 +1314,18 @@
   flex-shrink: 0;
 }
 /* Trust this member — small pill action sitting at the end of each
-   row in AllMembersPanel. Stays subtle by default (--trusted color at
-   low intensity) and flips to a "queued" muted look once the intent
-   is in the cart. */
+   row in AllMembersPanel. Neutral by default so the "Trusted"
+   state (solid green) keeps the on-chain confirmation visually
+   distinctive. */
 .crd-trust-btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
   padding: 4px 10px;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--trusted, #6dd4a0) 50%, transparent);
-  background: color-mix(in srgb, var(--trusted, #6dd4a0) 10%, transparent);
-  color: var(--trusted, #6dd4a0);
+  border: 1px solid var(--ds-border);
+  background: transparent;
+  color: var(--ds-ink-soft);
   font-family: 'JetBrains Mono', monospace;
   font-size: 10px;
   letter-spacing: 0.08em;
@@ -1340,8 +1340,9 @@
     opacity 0.15s ease;
 }
 .crd-trust-btn:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--trusted, #6dd4a0) 22%, transparent);
-  border-color: var(--trusted, #6dd4a0);
+  background: var(--ds-bg-subtle);
+  border-color: var(--ds-ink-soft);
+  color: var(--ds-ink);
 }
 .crd-trust-btn.is-queued {
   color: var(--ds-muted);

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -1348,7 +1348,20 @@
   border-color: var(--ds-border);
   background: transparent;
 }
-.crd-trust-btn:disabled {
+/* On-chain confirmation — solid green pill, read-only. Overrides the
+   generic disabled opacity so the "Trusted" state stays visually
+   strong instead of fading out. */
+.crd-trust-btn.is-trusted {
+  background: var(--trusted, #6dd4a0);
+  border-color: var(--trusted, #6dd4a0);
+  color: #02000e;
+  cursor: default;
+}
+.crd-trust-btn.is-trusted:disabled {
+  opacity: 1;
+  cursor: default;
+}
+.crd-trust-btn:disabled:not(.is-trusted) {
   opacity: 0.4;
   cursor: not-allowed;
 }

--- a/apps/explorer/src/hooks/useTrustMember.ts
+++ b/apps/explorer/src/hooks/useTrustMember.ts
@@ -13,6 +13,8 @@ import { useCallback, useMemo } from 'react'
 import { usePrivy } from '@privy-io/react-auth'
 import { useUserAccountAtom } from './useUserAccountAtom'
 import { useCart } from './useCart'
+import { useLinkedWallets } from './useLinkedWallets'
+import { useTrustCircle } from './useTrustCircle'
 import {
   buildTrustCartItem,
   trustCartId,
@@ -28,6 +30,10 @@ export interface UseTrustMemberResult {
   /** True when an item with the same `trustCartId(termId)` is already
    *  queued — the button swaps its label for a "queued" hint. */
   inCart: boolean
+  /** True when the member is already in the user's on-chain trust ring
+   *  (their wallet appears in `useTrustCircle`). The button switches to
+   *  a solid "Trusted" state and the click is a no-op. */
+  alreadyTrusted: boolean
   /** Reason the trust button must be disabled, if any. */
   disabledReason: TrustBlockedReason | null
   /** Pre-mapped UX string for `disabledReason`. */
@@ -52,6 +58,11 @@ export function useTrustMember(
     isLoading: accountAtomLoading,
   } = useUserAccountAtom(userWallet)
   const cart = useCart()
+  // User's existing trust ring — used to flip the button to "Trusted"
+  // once the member is already an anchor. Shares the same useTrustCircle
+  // cache as the NavSidebar / CircleDetailView so this read is free.
+  const { addresses: userWallets } = useLinkedWallets()
+  const { accounts: trustedAccounts } = useTrustCircle(userWallets)
 
   const memberTermId = member?.termId ?? null
 
@@ -60,6 +71,14 @@ export function useTrustMember(
     const id = trustCartId(memberTermId)
     return cart.items.some((i) => i.id === id)
   }, [cart.items, memberTermId])
+
+  const alreadyTrusted = useMemo(() => {
+    if (!member?.walletAddress) return false
+    const target = member.walletAddress.toLowerCase()
+    return trustedAccounts.some(
+      (a) => a.walletAddress?.toLowerCase() === target,
+    )
+  }, [trustedAccounts, member])
 
   const disabledReason = useMemo<TrustBlockedReason | null>(() => {
     if (!authenticated) return 'no-wallet'
@@ -70,7 +89,7 @@ export function useTrustMember(
 
   const trust = useCallback(() => {
     if (!member || !memberTermId || !userAccountAtomId) return
-    if (disabledReason) return
+    if (disabledReason || alreadyTrusted) return
     if (inCart) {
       cart.open()
       return
@@ -84,11 +103,20 @@ export function useTrustMember(
     if (!item) return
     cart.addItem(item)
     cart.open()
-  }, [member, memberTermId, userAccountAtomId, disabledReason, inCart, cart])
+  }, [
+    member,
+    memberTermId,
+    userAccountAtomId,
+    disabledReason,
+    alreadyTrusted,
+    inCart,
+    cart,
+  ])
 
   return {
     trust,
     inCart,
+    alreadyTrusted,
     disabledReason,
     disabledHint: disabledReason ? REASON_HINT[disabledReason] : null,
   }

--- a/apps/explorer/src/hooks/useTrustMember.ts
+++ b/apps/explorer/src/hooks/useTrustMember.ts
@@ -1,0 +1,95 @@
+/**
+ * useTrustMember — orchestrates a "trust this member" intent into the
+ * cart. Resolves the user's Account atom (subject of the trust triple),
+ * watches the cart for a duplicate, surfaces a friendly blocked-reason
+ * when prerequisites aren't met yet, and exposes a single `trust()`
+ * callback the action button can fire.
+ *
+ * The cart-item shape lives in `trustEmissionService` so the React
+ * layer never deals with predicate ids directly. Mirrors useJoinCircle.
+ */
+
+import { useCallback, useMemo } from 'react'
+import { usePrivy } from '@privy-io/react-auth'
+import { useUserAccountAtom } from './useUserAccountAtom'
+import { useCart } from './useCart'
+import {
+  buildTrustCartItem,
+  trustCartId,
+} from '@/services/trustEmissionService'
+import type { TrustCircleAccount } from '@/services/trustCircleService'
+
+export type TrustBlockedReason = 'no-wallet' | 'no-account-atom' | 'loading'
+
+export interface UseTrustMemberResult {
+  /** Adds the trust intent to the cart and opens the drawer. No-op when
+   *  `disabledReason` is set or the item is already queued. */
+  trust: () => void
+  /** True when an item with the same `trustCartId(termId)` is already
+   *  queued — the button swaps its label for a "queued" hint. */
+  inCart: boolean
+  /** Reason the trust button must be disabled, if any. */
+  disabledReason: TrustBlockedReason | null
+  /** Pre-mapped UX string for `disabledReason`. */
+  disabledHint: string | null
+}
+
+const REASON_HINT: Record<TrustBlockedReason, string> = {
+  'no-wallet': 'Connect your wallet to trust',
+  'no-account-atom':
+    'Make any cert first to register your account on Intuition',
+  loading: 'Resolving your identity…',
+}
+
+export function useTrustMember(
+  member: TrustCircleAccount | null,
+): UseTrustMemberResult {
+  const { user, authenticated } = usePrivy()
+  const userWallet = user?.wallet?.address
+  const {
+    termId: userAccountAtomId,
+    exists: accountAtomExists,
+    isLoading: accountAtomLoading,
+  } = useUserAccountAtom(userWallet)
+  const cart = useCart()
+
+  const memberTermId = member?.termId ?? null
+
+  const inCart = useMemo(() => {
+    if (!memberTermId) return false
+    const id = trustCartId(memberTermId)
+    return cart.items.some((i) => i.id === id)
+  }, [cart.items, memberTermId])
+
+  const disabledReason = useMemo<TrustBlockedReason | null>(() => {
+    if (!authenticated) return 'no-wallet'
+    if (accountAtomLoading) return 'loading'
+    if (!accountAtomExists) return 'no-account-atom'
+    return null
+  }, [authenticated, accountAtomLoading, accountAtomExists])
+
+  const trust = useCallback(() => {
+    if (!member || !memberTermId || !userAccountAtomId) return
+    if (disabledReason) return
+    if (inCart) {
+      cart.open()
+      return
+    }
+    const item = buildTrustCartItem({
+      memberTermId,
+      memberLabel: member.label,
+      memberImage: member.image,
+      userAccountAtomId,
+    })
+    if (!item) return
+    cart.addItem(item)
+    cart.open()
+  }, [member, memberTermId, userAccountAtomId, disabledReason, inCart, cart])
+
+  return {
+    trust,
+    inCart,
+    disabledReason,
+    disabledHint: disabledReason ? REASON_HINT[disabledReason] : null,
+  }
+}

--- a/apps/explorer/src/services/trustEmissionService.ts
+++ b/apps/explorer/src/services/trustEmissionService.ts
@@ -1,0 +1,60 @@
+/**
+ * trustEmissionService — pure builder for the cart item that represents
+ * "user wants to emit `I → trusts → memberX` on-chain". Stateless: no
+ * cart access, no auth lookup, no side effects. Callers add the
+ * returned item to the cart and open the drawer.
+ *
+ * Mirrors `circleJoinService` so all our `create-triple` cart items go
+ * through the same WeightModal pipeline (atomCreationService +
+ * SofiaFeeProxy.createTriples) at submit time.
+ */
+
+import { PREDICATE_IDS } from '@/config'
+import type { CartItem } from '@/hooks/useCart'
+
+export interface TrustMemberInput {
+  /** Atom term_id of the member to trust. Required. */
+  memberTermId: string
+  /** Display name — shown in the cart row and WeightModal triplet card. */
+  memberLabel: string
+  /** Optional avatar URL surfaced as the cart row's favicon. */
+  memberImage?: string | null
+  /** User's Account atom term_id — the subject of the trust triple. */
+  userAccountAtomId: string
+  /** Tinted dot color for the cart row. Defaults to the trusted accent. */
+  color?: string
+}
+
+/** Stable cart id prefix so two "Trust member X" items for the same
+ *  target never show up twice. Public — `useCart().items.some(i => i.id === trustCartId(termId))`
+ *  is the idiomatic "is queued?" check. */
+export function trustCartId(memberTermId: string): string {
+  return `trust-${memberTermId}`
+}
+
+/**
+ * Build the cart item for a "trust this member" intent. Returns `null`
+ * when any required input is missing so the caller can short-circuit
+ * without throwing.
+ */
+export function buildTrustCartItem(input: TrustMemberInput): CartItem | null {
+  const { memberTermId, memberLabel, memberImage, userAccountAtomId, color } =
+    input
+  if (!memberTermId || !userAccountAtomId) return null
+
+  return {
+    id: trustCartId(memberTermId),
+    kind: 'create-triple',
+    side: 'support',
+    // Placeholder triple term_id for cart dedupe — the real one is
+    // computed by SofiaFeeProxy.calculateTripleId at submit time.
+    termId: `triple-trust-${memberTermId}`,
+    subjectId: userAccountAtomId,
+    predicateId: PREDICATE_IDS.TRUSTS,
+    objectId: memberTermId,
+    intention: 'Trust member',
+    title: memberLabel,
+    favicon: memberImage ?? '',
+    intentionColor: color ?? 'var(--trusted, #6dd4a0)',
+  }
+}


### PR DESCRIPTION
## Summary

Closes the conceptual loop opened by the MCP star rating chantier (PR #483). Members of a circle can now emit \`I → trusts → otherMember\` triples on-chain straight from the AllMembers drawer, densifying the trust graph that compute_personalized_trust traverses.

- **Service** \`trustEmissionService.buildTrustCartItem\` — pure builder mirroring \`circleJoinService\`. Returns a \`create-triple\` cart item with subject = user's Account atom, predicate = TRUSTS, object = member's atom. WeightModal expands it into \`SofiaFeeProxy.createTriples\` at submit time.
- **Hook** \`useTrustMember\` — resolves the user's account atom, watches the cart for duplicates, surfaces \`no-wallet\` / \`no-account-atom\` / \`loading\` disabled states. Reads \`useTrustCircle\` (cache-shared) to expose \`alreadyTrusted\` once the on-chain triple exists.
- **Component** \`TrustMemberButton\` — small pill at the end of each member row. Three visual states:
  - **IDLE** (\"Trust\") — neutral outline, ready to queue.
  - **QUEUED** (\"Queued\") — muted, intent is in the cart awaiting submit.
  - **TRUSTED** (\"Trusted\") — solid green with check icon, on-chain confirmed, read-only.
- **AllMembersPanel** row split so the row-wide profile link and the button are independent siblings; click on Trust no longer triggers navigation.

## Why this matters

\`compute_personalized_trust\` returned \`score: 0, pathCount: 0\` on every certifier in PR #483 because the on-chain trust graph between roster members is mostly empty. With this PR every member can emit trust signals toward each other in one click, building the multi-hop paths MCP needs to surface meaningful scores.

## Test plan

- [ ] Open AllMembersPanel on \`/circles/trust\` — all members appear as **Trusted** (solid green) since the user definitionally trusts them
- [ ] Open AllMembersPanel on a joined group — members already in the trust ring show **Trusted**, others show **Trust** (neutral)
- [ ] Click **Trust** on a non-trusted member → cart drawer opens with the new item, button flips to **Queued**
- [ ] Submit the cart → WeightModal fires \`SofiaFeeProxy.createTriples\`, triple lands on-chain
- [ ] After the WS positions cache refreshes, the button auto-flips to **Trusted**

🤖 Generated with [Claude Code](https://claude.com/claude-code)