### PR TITLE
feat(explorer): Connect/Install CTA replaces dead-end empty + locked states

### DIFF
--- a/apps/explorer/src/components/circles/CircleDetailView.tsx
+++ b/apps/explorer/src/components/circles/CircleDetailView.tsx
@@ -15,6 +15,7 @@
  */
 import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { usePrivy } from '@privy-io/react-auth'
 import { ArrowLeft } from 'lucide-react'
 import { useTopicSelection } from '@/hooks/useDomainSelection'
 import { useCircleFeed } from '@/hooks/useCircleFeed'
@@ -25,6 +26,7 @@ import CircleMembersCard from './CircleMembersCard'
 import CircleMostActiveCard from './CircleMostActiveCard'
 import CircleTopTopicsCard from './CircleTopTopicsCard'
 import CircleFeedSection from './CircleFeedSection'
+import CircleFeedConnectCta from './CircleFeedConnectCta'
 import AllMembersPanel from './AllMembersPanel'
 import CircleJoinOverlay from './CircleJoinOverlay'
 import type { CircleData } from '@/types/circle'
@@ -76,6 +78,11 @@ export default function CircleDetailView({
     topTopicSlugs,
   )
   const stats = useMemo(() => computeCircleStats(feedItems), [feedItems])
+  const { authenticated } = usePrivy()
+  // Non-auth visitor landing on a locked group: the blurred-feed
+  // teaser doesn't help — turn the whole activity slot into a
+  // Connect / Install Sofia CTA so the visitor has a clear next step.
+  const showConnectCta = locked && !authenticated
   const [allMembersOpen, setAllMembersOpen] = useState(false)
 
   const effectiveColor = colorOverride ?? circle.color
@@ -136,17 +143,22 @@ export default function CircleDetailView({
 
       {/* Activity feed — the only section gated for non-members. The
           `aria-hidden` mirrors the visual blur so assistive tech sees
-          the same surface as a sighted viewer. */}
-      <div
-        className={locked ? 'crd-feed-locked' : undefined}
-        aria-hidden={locked}
-      >
-        <CircleFeedSection
-          addresses={circle.addresses}
-          circleName={circle.name}
-          members={circle.members}
-        />
-      </div>
+          the same surface as a sighted viewer. Non-auth visitors get
+          a Connect/Install CTA in place of the blurred teaser. */}
+      {showConnectCta ? (
+        <CircleFeedConnectCta />
+      ) : (
+        <div
+          className={locked ? 'crd-feed-locked' : undefined}
+          aria-hidden={locked}
+        >
+          <CircleFeedSection
+            addresses={circle.addresses}
+            circleName={circle.name}
+            members={circle.members}
+          />
+        </div>
+      )}
 
       <AllMembersPanel
         open={allMembersOpen}

--- a/apps/explorer/src/components/circles/CircleDetailView.tsx
+++ b/apps/explorer/src/components/circles/CircleDetailView.tsx
@@ -108,10 +108,11 @@ export default function CircleDetailView({
         stats={!locked ? stats : undefined}
         // Non-member CTA lives inside the hero's middle slot so the
         // page doesn't grow a separate banner row above the activity
-        // feed. The hero is the only thing the user reads first; the
-        // join action belongs there.
+        // feed. Hidden when the bottom Connect CTA is already on
+        // screen (non-auth case) so the visitor doesn't see two
+        // competing prompts.
         cta={
-          locked && onJoin ? (
+          locked && onJoin && !showConnectCta ? (
             <CircleJoinOverlay
               circleName={circle.name}
               inCart={joinInCart}

--- a/apps/explorer/src/components/circles/CircleFeedConnectCta.tsx
+++ b/apps/explorer/src/components/circles/CircleFeedConnectCta.tsx
@@ -1,0 +1,52 @@
+/**
+ * CircleFeedConnectCta — replaces the empty-feed message for non-auth
+ * visitors. Two CTAs side-by-side: Connect wallet (triggers Privy
+ * login) and Install Sofia (Chrome Web Store link, hidden when the
+ * extension is already detected). Sits inside the masonry-grid slot
+ * so the layout doesn't jump when the feed eventually loads.
+ */
+import { useLogin } from '@privy-io/react-auth'
+import { Wallet, Puzzle, ShieldCheck } from 'lucide-react'
+import { useExtensionInstalled } from '@/hooks/useExtensionInstalled'
+import { CHROME_STORE_URL } from '@/utils/sofiaDetect'
+
+export default function CircleFeedConnectCta() {
+  const { login } = useLogin()
+  const extensionInstalled = useExtensionInstalled()
+
+  return (
+    <section className="crd-feed-cta" role="status" aria-live="polite">
+      <span className="crd-feed-cta__icon" aria-hidden="true">
+        <ShieldCheck className="h-6 w-6" />
+      </span>
+      <h3 className="crd-feed-cta__title">See what this circle certifies</h3>
+      <p className="crd-feed-cta__lede">
+        Connect your wallet to browse the curated feed, certify URLs and
+        emit trust signals that shape what surfaces here.
+      </p>
+      <div className="crd-feed-cta__actions">
+        <button
+          type="button"
+          className="crd-feed-cta__btn crd-feed-cta__btn--primary"
+          onClick={() => login()}
+        >
+          <Wallet className="h-4 w-4" aria-hidden="true" />
+          <span>Connect wallet</span>
+          <span className="crd-feed-cta__arrow">→</span>
+        </button>
+        {!extensionInstalled && (
+          <a
+            className="crd-feed-cta__btn crd-feed-cta__btn--ghost"
+            href={CHROME_STORE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Puzzle className="h-4 w-4" aria-hidden="true" />
+            <span>Install Sofia</span>
+            <span className="crd-feed-cta__arrow">→</span>
+          </a>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/apps/explorer/src/components/circles/CircleFeedSection.tsx
+++ b/apps/explorer/src/components/circles/CircleFeedSection.tsx
@@ -40,6 +40,7 @@ import CircleTopicFilterDropdown, {
 import CircleMemberFilterDropdown from './CircleMemberFilterDropdown'
 import CircleFeedSort from './CircleFeedSort'
 import CircleTopEngagedStrip from './CircleTopEngagedStrip'
+import CircleFeedConnectCta from './CircleFeedConnectCta'
 import '@/components/styles/feed-card.css'
 
 interface CircleFeedSectionProps {
@@ -212,6 +213,11 @@ export default function CircleFeedSection({
           message="Couldn't load the feed."
           hint="Check your connection and refresh the page."
         />
+      ) : shown.length === 0 && !authenticated && verb === 'all' ? (
+        // Non-auth visitor + empty feed: turn the dead-end message into
+        // a CTA so the page reads as an invitation rather than a
+        // wall. Authenticated users still see the regular empty state.
+        <CircleFeedConnectCta />
       ) : shown.length === 0 ? (
         <EmptyFeedState
           gridClassName="masonry-grid crd-feed"

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -1656,6 +1656,103 @@
   flex-shrink: 0;
 }
 
+/* ── CircleFeedConnectCta — non-auth empty state ───────────────────
+   Replaces the dead-end "No certifications yet" placeholder with an
+   invitation card. Two CTAs side-by-side so the visitor lands on one
+   of the two entry points (wallet connect or extension install) with
+   one click. */
+.crd-feed-cta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 12px;
+  padding: 48px 32px;
+  border-radius: 14px;
+  background: var(--ds-card);
+  border: 1px solid var(--ds-border);
+  border-left: 4px solid var(--circle-color, var(--ds-accent));
+  max-width: 540px;
+  margin: 8px auto;
+}
+.crd-feed-cta__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  background: color-mix(
+    in srgb,
+    var(--circle-color, var(--ds-accent)) 12%,
+    transparent
+  );
+  color: var(--circle-color, var(--ds-accent));
+}
+.crd-feed-cta__title {
+  font-family: 'Fraunces', serif;
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--ds-ink);
+  margin: 4px 0 0;
+  font-variation-settings:
+    'SOFT' 30,
+    'opsz' 144;
+  letter-spacing: -0.01em;
+}
+.crd-feed-cta__lede {
+  font-size: 13px;
+  color: var(--ds-muted);
+  line-height: 1.5;
+  max-width: 420px;
+  margin: 0;
+}
+.crd-feed-cta__actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 8px;
+}
+.crd-feed-cta__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-family: 'Geist', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  border: 1px solid var(--ds-border);
+  background: transparent;
+  color: var(--ds-ink);
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    opacity 0.15s ease;
+}
+.crd-feed-cta__btn:hover {
+  border-color: var(--ds-ink-soft);
+  background: var(--ds-bg-subtle);
+}
+.crd-feed-cta__btn--primary {
+  background: var(--ds-ink);
+  color: var(--ds-bg);
+  border-color: var(--ds-ink);
+}
+.crd-feed-cta__btn--primary:hover {
+  background: var(--ds-ink);
+  border-color: var(--ds-ink);
+  opacity: 0.88;
+}
+.crd-feed-cta__arrow {
+  transition: transform 0.15s ease;
+}
+.crd-feed-cta__btn:hover .crd-feed-cta__arrow {
+  transform: translateX(2px);
+}
+
 /* ── CircleTopEngagedStrip ──────────────────────────────────────── */
 .crd-top-engaged {
   display: flex;


### PR DESCRIPTION
## Summary

Turns two dead-end UX moments for non-authenticated visitors into clear next-step CTAs.

1. **Empty feed + non-auth** — the \"No certifications from the circle yet\" flat message becomes an invitation card with Connect wallet and Install Sofia actions.
2. **Locked group + non-auth** — the blurred-feed teaser that helps an auth user weigh a join was useless for someone who isn't connected. The whole activity slot turns into the same CTA card.

To avoid two competing prompts on screen, the hero's Join overlay is hidden whenever the bottom Connect CTA is rendered. Authenticated non-members keep the existing flow (hero Join overlay + blurred teaser feed).

- New \`CircleFeedConnectCta\` component — shield icon in the circle's accent color, Fraunces serif title, two side-by-side CTAs (\"Connect wallet\" primary, \"Install Sofia\" ghost). \`Install Sofia\` is hidden when \`useExtensionInstalled\` already detects it.
- \`CircleFeedSection\` branches the empty-feed slot on \`authenticated && verb === 'all'\` so the verb-filter empty case still reads.
- \`CircleDetailView\` swaps the locked-feed wrapper for the CTA when \`locked && !authenticated\`, and suppresses the hero overlay in that case.

## Test plan

- [ ] \`/circles/trust\` signed out → CTA card visible in the feed slot, hero clean (no Join overlay)
- [ ] \`/circles/:groupId\` signed out → CTA replaces blurred feed, hero clean
- [ ] \`/circles/:groupId\` signed in but non-member → hero Join overlay + blurred feed teaser (unchanged)
- [ ] \`/circles/:groupId\` signed in + member → normal feed, no CTA
- [ ] Connect wallet button triggers Privy login modal
- [ ] Install Sofia button opens Chrome Web Store in a new tab
- [ ] When the Sofia extension is already installed, only the Connect button shows
- [ ] Signed-in user with empty feed still sees the regular \"No certifications yet\" empty state
- [ ] Verb filter applied + empty results still shows the verb-specific hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)