### PR TITLE
fix(landing): force @noble/* into single Rollup chunk to break crypto…

### DIFF
--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -10,4 +10,21 @@ export default defineConfig({
       '@site/src': path.resolve(__dirname, 'src'),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        // Keep all @noble/* crypto primitives in a single chunk.
+        // Privy v3 + Rollup's default chunking otherwise puts the
+        // secp256k1 curve module in its own chunk while leaving
+        // sha256 (the curve's required hash) in the parent bundle —
+        // their cross-chunk import is circular and TDZ-evaluates
+        // sha256 as `undefined`, which crashes the curve constructor
+        // with "param hash is invalid. Expected hash, got undefined"
+        // before any UI mounts (blank page).
+        manualChunks(id) {
+          if (id.includes('node_modules/@noble/')) return 'noble-crypto'
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
… TDZ

Diagnostic: deployed bundle has `secp256k1` split into its own chunk that imports `sha256` (aliased `wc`) from the parent index chunk. The parent chunk doesn't initialize sha256 before secp256k1's top-level runs — `wc` is `undefined` at the cross-chunk read, so the curve constructor receives `hash: undefined` and throws
"param hash is invalid. Expected hash, got undefined" before any UI mounts. This circular-import TDZ is triggered by Privy v3's many dynamic imports prompting Rollup to split crypto deps across chunks.

manualChunks pins every `@noble/*` module into one chunk so the curve and its hash live together with no cross-chunk read.