### PR TITLE
feat(explorer): Trust this account button on PublicProfilePage

### DIFF
--- a/apps/explorer/src/components/profile/ProfileTrustButton.tsx
+++ b/apps/explorer/src/components/profile/ProfileTrustButton.tsx
@@ -1,0 +1,98 @@
+/**
+ * ProfileTrustButton — large "Trust this account" action rendered in
+ * the hero of `/profile/:address`. Resolves the viewed wallet's atom
+ * term_id, hides itself when the viewer is on their own profile,
+ * and reflects the on-chain state (idle / queued / trusted).
+ *
+ * Mirrors the TrustMemberButton flow used in AllMembersPanel but
+ * surfaces as the page's primary action instead of a row affordance.
+ */
+import type { MouseEvent } from 'react'
+import { ShieldCheck, Check } from 'lucide-react'
+import { useLinkedWallets } from '@/hooks/useLinkedWallets'
+import { useUserAccountAtom } from '@/hooks/useUserAccountAtom'
+import { useTrustMember } from '@/hooks/useTrustMember'
+import type { TrustCircleAccount } from '@/services/trustCircleService'
+
+interface ProfileTrustButtonProps {
+  /** Resolved wallet address (lowercased EVM string). */
+  walletAddress: string | undefined
+  /** Display name (ENS or short address). */
+  displayName: string
+  /** Optional ENS avatar URL. */
+  avatarUrl: string
+}
+
+export default function ProfileTrustButton({
+  walletAddress,
+  displayName,
+  avatarUrl,
+}: ProfileTrustButtonProps) {
+  // Need the viewed wallet's atom term_id to build the trust triple.
+  const { termId: targetTermId } = useUserAccountAtom(walletAddress)
+  // Hide on the viewer's own profile — trusting yourself is meaningless.
+  const { addresses: viewerWallets } = useLinkedWallets()
+  const isSelf =
+    !!walletAddress &&
+    viewerWallets.some((w) => w.toLowerCase() === walletAddress.toLowerCase())
+
+  // Build a minimal TrustCircleAccount shape so useTrustMember can
+  // reuse the existing cart-item builder without a new code path.
+  const member: TrustCircleAccount | null =
+    walletAddress && targetTermId
+      ? {
+          id: targetTermId,
+          termId: targetTermId,
+          tripleId: '',
+          label: displayName,
+          image: avatarUrl || null,
+          walletAddress,
+          trustAmount: 0,
+          createdAt: 0,
+        }
+      : null
+
+  const { trust, inCart, alreadyTrusted, disabledReason, disabledHint } =
+    useTrustMember(member)
+
+  // Bail out cleanly when there's nothing actionable on the page.
+  if (isSelf || !walletAddress || !targetTermId) return null
+
+  const handleClick = (e: MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    trust()
+  }
+
+  if (alreadyTrusted) {
+    return (
+      <button
+        type="button"
+        className="pp-trust-btn pp-trust-btn--trusted"
+        disabled
+        aria-label="You trust this account"
+        title="You trust this account on-chain"
+      >
+        <Check className="h-4 w-4" aria-hidden="true" />
+        <span>Trusted</span>
+      </button>
+    )
+  }
+
+  const label = inCart ? 'Queued in cart' : 'Trust this account'
+  const title = disabledHint ?? (inCart ? 'Submit to emit on-chain' : label)
+
+  return (
+    <button
+      type="button"
+      className={`pp-trust-btn${inCart ? ' pp-trust-btn--queued' : ''}`}
+      onClick={handleClick}
+      disabled={!!disabledReason}
+      aria-label={title}
+      title={title}
+    >
+      <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+      <span>{label}</span>
+    </button>
+  )
+}

--- a/apps/explorer/src/components/styles/profile-sections.css
+++ b/apps/explorer/src/components/styles/profile-sections.css
@@ -1107,6 +1107,7 @@
   z-index: 2;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 20px;
 }
 .pp-public-hero-text {
@@ -1114,6 +1115,57 @@
   flex-direction: column;
   gap: 12px;
   min-width: 0;
+  flex: 1;
+}
+
+/* Primary "Trust this account" action sitting at the right end of the
+   public-profile hero row. Three visual states mirror the smaller
+   TrustMemberButton in AllMembersPanel (idle / queued / trusted)
+   but at a larger size so the action reads as the page's main call
+   to action. */
+.pp-trust-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  margin-left: auto;
+  flex-shrink: 0;
+  border-radius: 999px;
+  border: 1px solid var(--ds-ink, #1a1620);
+  background: var(--ds-ink, #1a1620);
+  color: var(--ds-bg, #ffffff);
+  font-family: 'Geist', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
+}
+.pp-trust-btn:hover:not(:disabled) {
+  opacity: 0.88;
+}
+.pp-trust-btn--queued {
+  background: transparent;
+  color: var(--ds-muted);
+  border-color: var(--ds-border);
+}
+.pp-trust-btn--trusted {
+  background: var(--trusted, #6dd4a0);
+  border-color: var(--trusted, #6dd4a0);
+  color: #02000e;
+  cursor: default;
+}
+.pp-trust-btn--trusted:disabled {
+  opacity: 1;
+  cursor: default;
+}
+.pp-trust-btn:disabled:not(.pp-trust-btn--trusted) {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 .pp-public-hero-text .ph-title {
   margin: 0;

--- a/apps/explorer/src/pages/PublicProfilePage.tsx
+++ b/apps/explorer/src/pages/PublicProfilePage.tsx
@@ -24,6 +24,7 @@ import { useUserOnChainProfile } from '@/hooks/useUserOnChainProfile'
 import { userCertsToActivityInputs } from '@/hooks/useIntentionGroups'
 import { useTopClaims } from '@/hooks/useTopClaims'
 import { useEnsNames } from '@/hooks/useEnsNames'
+import ProfileTrustButton from '@/components/profile/ProfileTrustButton'
 import { useTrustScore } from '@/hooks/useTrustScore'
 import { useUserCertCountsByTopic } from '@/hooks/useUserCertCountsByTopic'
 import { useReputationScores } from '@/hooks/useReputationScores'
@@ -210,6 +211,11 @@ export default function PublicProfilePage() {
               <p className="ph-description">{heroDescription}</p>
             )}
           </div>
+          <ProfileTrustButton
+            walletAddress={walletAddress}
+            displayName={displayName || shortAddress}
+            avatarUrl={ensAvatar}
+          />
         </div>
         <div className="ph-deco" aria-hidden="true" />
       </div>


### PR DESCRIPTION
## Summary

Extends the trust-emission UI from AllMembersPanel (PR #484) to the public profile page. Visitors landing on /profile/:address see a primary \"Trust this account\" pill at the right end of the hero, sharing the same cart-item plumbing as the in-circle Trust button.

- **New** \`ProfileTrustButton\` component — resolves the viewed wallet's atom term_id via \`useUserAccountAtom\`, builds a minimal \`TrustCircleAccount\` so \`useTrustMember\` reuses \`buildTrustCartItem\` unchanged.
- **Self-hide** — the button is hidden when the viewer is on one of their own linked wallets (trusting yourself isn't meaningful), when the wallet has no atom yet, or while the atom is resolving.
- **Three states** — idle (solid ink), queued (muted outline once the cart picks it up), trusted (solid green, read-only on-chain confirmation).
- Hero row uses \`flex: 1\` on the text block + \`flex-wrap\` so the button pushes right on wide viewports and wraps cleanly on narrow ones.

## Test plan

- [ ] \`/profile/0xMine\` → no Trust button (isSelf)
- [ ] \`/profile/0xRandomWallet\` (not in trust ring) → \"Trust this account\" (solid ink)
- [ ] Click → cart drawer opens with the new item, button flips to \"Queued in cart\"
- [ ] Submit the cart → SofiaFeeProxy.createTriples fires, triple lands on-chain
- [ ] After the WS positions cache hydrates, the button auto-flips to \"Trusted\" (solid green, disabled)
- [ ] \`/profile/0xAlreadyTrusted\` (in trust ring) → \"Trusted\" immediately
- [ ] Signed out → button hidden (disabledReason \`no-wallet\` returns null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)