### PR TITLE
feat(explorer): polish Create-a-circle drawer + hide Add-a-member

### DIFF
--- a/apps/explorer/src/components/circles/AllMembersPanel.tsx
+++ b/apps/explorer/src/components/circles/AllMembersPanel.tsx
@@ -9,7 +9,6 @@ import { Link } from 'react-router-dom'
 import type { TrustCircleAccount } from '@/services/trustCircleService'
 import { useEnsNames } from '@/hooks/useEnsNames'
 import type { Address } from 'viem'
-import { UserPlus } from 'lucide-react'
 import MemberAvatar from './MemberAvatar'
 import TrustMemberButton from './TrustMemberButton'
 
@@ -72,19 +71,11 @@ export default function AllMembersPanel({
           </button>
         </div>
 
-        <button
-          type="button"
-          className="crd-members-invite-btn"
-          onClick={() => {
-            // TODO: wire to real invite flow once available.
-            // Placeholder: copy a prefilled share link to clipboard.
-            const url = `${window.location.origin}/circles/trust?invite=1`
-            navigator.clipboard?.writeText(url).catch(() => {})
-          }}
-        >
-          <UserPlus className="h-4 w-4" />
-          Add a member
-        </button>
+        {/* "Add a member" CTA is intentionally hidden until the invite
+            backend exists. When it ships, render an inline compact
+            search (avatar row + click-to-add), not the wide CTA pill
+            we had before. See crd-members-invite-btn rule in
+            circles.css for the old visual reference. */}
 
         <div className="crd-members-list">
           {members.length === 0 ? (

--- a/apps/explorer/src/components/circles/CreateCircleDrawer.tsx
+++ b/apps/explorer/src/components/circles/CreateCircleDrawer.tsx
@@ -7,7 +7,7 @@
  */
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { ArrowUpRight, ChevronDown, Search, X } from 'lucide-react'
+import { ArrowUpRight, Check, ChevronDown, Search, X } from 'lucide-react'
 import { type AccountAtom, useSearchAccounts } from '@/hooks/useSearchAccounts'
 import { SOFIA_TOPICS } from '@/config/taxonomy'
 import { useCart, type CircleDraft } from '@/hooks/useCart'
@@ -345,9 +345,9 @@ export default function CreateCircleDrawer({
                 </button>
               )}
             </div>
-            <div className="cc-topics">
+            <div className="cc-topics-grid">
               {visibleTopics.length === 0 && (
-                <span className="cc-help">
+                <span className="cc-help cc-topics-empty">
                   No theme matches “{topicQuery}”.
                 </span>
               )}
@@ -357,7 +357,7 @@ export default function CreateCircleDrawer({
                   <button
                     type="button"
                     key={t.id}
-                    className={`cc-topic${active ? ' is-active' : ''}`}
+                    className={`cc-topic-cell${active ? ' is-active' : ''}`}
                     style={
                       active
                         ? ({
@@ -371,34 +371,49 @@ export default function CreateCircleDrawer({
                     <span
                       className="cc-topic-dot"
                       style={{ background: t.color }}
+                      aria-hidden="true"
                     />
-                    {t.label}
+                    <span className="cc-topic-label">{t.label}</span>
+                    {active && (
+                      <Check
+                        className="cc-topic-check h-3 w-3"
+                        aria-hidden="true"
+                      />
+                    )}
                   </button>
                 )
               })}
             </div>
-            {hiddenTopicCount > 0 && (
+            {(hiddenTopicCount > 0 ||
+              (topicsExpanded &&
+                !topicQuery &&
+                filteredTopics.length > TOPIC_PREVIEW_COUNT)) && (
               <button
                 type="button"
-                className="cc-view-more"
-                onClick={() => setTopicsExpanded(true)}
+                className="cc-topics-toggle"
+                onClick={() => setTopicsExpanded((v) => !v)}
+                aria-expanded={topicsExpanded}
               >
-                View {hiddenTopicCount} more
-                <ChevronDown className="cc-view-more-icon h-3.5 w-3.5" />
+                {topicsExpanded ? (
+                  <>
+                    Show less
+                    <ChevronDown
+                      className="cc-topics-toggle-icon cc-topics-toggle-icon--up h-3.5 w-3.5"
+                      aria-hidden="true"
+                    />
+                  </>
+                ) : (
+                  <>
+                    View {hiddenTopicCount} more theme
+                    {hiddenTopicCount === 1 ? '' : 's'}
+                    <ChevronDown
+                      className="cc-topics-toggle-icon h-3.5 w-3.5"
+                      aria-hidden="true"
+                    />
+                  </>
+                )}
               </button>
             )}
-            {topicsExpanded &&
-              !topicQuery &&
-              filteredTopics.length > TOPIC_PREVIEW_COUNT && (
-                <button
-                  type="button"
-                  className="cc-view-more"
-                  onClick={() => setTopicsExpanded(false)}
-                >
-                  Show less
-                  <ChevronDown className="cc-view-more-icon cc-view-more-icon--up h-3.5 w-3.5" />
-                </button>
-              )}
           </fieldset>
 
           <div className="cc-field">
@@ -498,28 +513,40 @@ export default function CreateCircleDrawer({
             )}
           </div>
 
-          <div className="cc-actions">
-            <button
-              type="button"
-              className="cc-btn cc-btn-ghost"
-              onClick={onClose}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className="cc-btn cc-btn-primary"
-              disabled={!canSubmit}
-              title={validationError ?? undefined}
-            >
-              Add to cart
-            </button>
-          </div>
-          {validationError && (
-            <p className="cc-help" style={{ textAlign: 'right', marginTop: 4 }}>
-              {validationError}
-            </p>
-          )}
+          <footer className="cc-actions">
+            <div className="cc-actions-summary" aria-live="polite">
+              {validationError ? (
+                <span className="cc-actions-summary-error">
+                  {validationError}
+                </span>
+              ) : (
+                <span className="cc-actions-summary-recap">
+                  <strong>{draft.topicIds.length}</strong> theme
+                  {draft.topicIds.length === 1 ? '' : 's'}
+                  {' · '}
+                  <strong>{draft.members.length}</strong> member
+                  {draft.members.length === 1 ? '' : 's'}
+                </span>
+              )}
+            </div>
+            <div className="cc-actions-buttons">
+              <button
+                type="button"
+                className="cc-btn cc-btn-ghost"
+                onClick={onClose}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="cc-btn cc-btn-primary"
+                disabled={!canSubmit}
+                title={validationError ?? undefined}
+              >
+                Add to cart
+              </button>
+            </div>
+          </footer>
         </form>
       </aside>
     </>

--- a/apps/explorer/src/components/styles/circles.css
+++ b/apps/explorer/src/components/styles/circles.css
@@ -2199,52 +2199,24 @@
   color: var(--ds-ink);
 }
 
-/* View more / Show less — uses the shared `.pf-btn` pill recipe so it
-   sits in the same family as the other neutral pills in the app. */
-.cc-view-more {
-  align-self: flex-start;
-  margin-top: 8px;
-  display: inline-flex;
+/* Theme picker — 2-col grid of cell-style toggles. Each cell has a
+   color dot on the left, the theme label center-left, and a check on
+   the right when active. Easier to scan than a wrap-flow pill row. */
+.cc-topics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+.cc-topics-empty {
+  grid-column: 1 / -1;
+}
+.cc-topic-cell {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 6px;
-  padding: 7px 12px;
-  border: 1px solid var(--ds-border);
-  border-radius: 999px;
-  background: var(--ds-card);
-  color: var(--ds-ink);
-  font-family: 'Geist', sans-serif;
-  font-size: 11px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-.cc-view-more:hover {
-  border-color: var(--ds-ink);
-  transform: translateY(-1px);
-}
-.cc-view-more-icon {
-  transition: transform 0.15s ease;
-  color: var(--ds-muted);
-}
-.cc-view-more:hover .cc-view-more-icon {
-  color: var(--ds-ink);
-}
-.cc-view-more-icon--up {
-  transform: rotate(180deg);
-}
-
-/* Theme picker — wrapping pill list, single selection. */
-.cc-topics {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-.cc-topic {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 7px 12px;
-  border-radius: 999px;
+  gap: 8px;
+  padding: 9px 12px;
+  border-radius: 10px;
   border: 1px solid var(--ds-border);
   background: var(--ds-bg);
   color: var(--ds-ink);
@@ -2252,21 +2224,69 @@
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.15s ease;
+  text-align: left;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease,
+    transform 0.15s ease;
 }
-.cc-topic:hover {
+.cc-topic-cell:hover {
   border-color: var(--ds-ink-soft);
 }
-.cc-topic.is-active {
+.cc-topic-cell.is-active {
   border-color: var(--cc-topic-color);
-  background: color-mix(in srgb, var(--cc-topic-color) 16%, var(--ds-bg));
-  color: var(--ds-ink);
+  background: color-mix(in srgb, var(--cc-topic-color) 14%, var(--ds-bg));
+}
+.cc-topic-cell.is-active .cc-topic-check {
+  color: var(--cc-topic-color);
+}
+.cc-topic-label {
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .cc-topic-dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
+}
+
+/* Single toggle row that flips between "View N more themes" and
+   "Show less". Sits at the bottom of the grid, full-width, dashed
+   so it reads as a continuation of the picker rather than a CTA. */
+.cc-topics-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 6px;
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px dashed var(--ds-border);
+  border-radius: 10px;
+  background: transparent;
+  color: var(--ds-muted);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+.cc-topics-toggle:hover {
+  border-color: var(--ds-ink-soft);
+  color: var(--ds-ink);
+}
+.cc-topics-toggle-icon {
+  transition: transform 0.15s ease;
+}
+.cc-topics-toggle-icon--up {
+  transform: rotate(180deg);
 }
 
 /* Member input + chip list. */
@@ -2455,17 +2475,52 @@
   color: var(--ds-ink);
 }
 
-/* Footer actions — sit just below the form. */
+/* Sticky footer — pinned to the bottom of the scrolling drawer so the
+   primary action is always reachable, with a card-tinted background +
+   top border so it reads as a separate slab from the form. */
 .cc-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: sticky;
+  bottom: -8px;
+  margin: 4px -24px -8px;
+  padding: 14px 24px;
+  background: color-mix(in srgb, var(--ds-card) 96%, transparent);
+  border-top: 1px solid var(--ds-border);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 2;
+}
+.cc-actions-summary {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ds-muted);
+  min-height: 14px;
+  line-height: 1.4;
+}
+.cc-actions-summary-recap strong {
+  font-weight: 700;
+  color: var(--ds-ink);
+  font-variant-numeric: tabular-nums;
+}
+.cc-actions-summary-error {
+  color: var(--distrusted, #e87c7c);
+  text-transform: none;
+  letter-spacing: 0;
+  font-family: 'Geist', sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+}
+.cc-actions-buttons {
   display: flex;
   gap: 10px;
   justify-content: flex-end;
-  padding-top: 12px;
-  margin-top: 4px;
-  border-top: 1px solid var(--ds-border);
 }
 .cc-btn {
-  padding: 9px 16px;
+  padding: 10px 18px;
   border-radius: 10px;
   font-family: 'Geist', sans-serif;
   font-size: 13px;
@@ -2476,23 +2531,31 @@
 }
 .cc-btn-ghost {
   background: transparent;
-  border-color: var(--ds-border);
-  color: var(--ds-ink);
+  border-color: transparent;
+  color: var(--ds-muted);
+  padding: 10px 12px;
 }
 .cc-btn-ghost:hover {
-  border-color: var(--ds-ink);
+  color: var(--ds-ink);
 }
 .cc-btn-primary {
   background: var(--ds-ink);
   color: var(--ds-bg);
+  border-color: var(--ds-ink);
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--ds-ink) 30%, transparent);
 }
 .cc-btn-primary:hover:not(:disabled) {
   background: var(--ds-accent);
+  border-color: var(--ds-accent);
   color: var(--ds-on-accent, var(--ds-ink));
   transform: translateY(-1px);
+  box-shadow: 0 4px 12px color-mix(in srgb, var(--ds-accent) 35%, transparent);
 }
 .cc-btn-primary:disabled {
-  opacity: 0.4;
+  background: var(--ds-bg-subtle, var(--ds-bg));
+  color: var(--ds-muted);
+  border-color: var(--ds-border);
+  box-shadow: none;
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
## Summary
- **Themes picker** passe d'une flex-wrap pill row à une grille 2-cols de cellules card-style (dot + label tronqué + check à droite quand actif). Plus lisible que des pilules qui sautent.
- **View N more / Show less** fusionnent en un seul toggle dashed full-width au bas de la grille, avec chevron qui flip.
- **Sticky footer** avec backdrop blur — toujours reachable même quand le form scroll. Cancel devient un ghost text-only, "Add to cart" un vrai primary (border + shadow + accent peach glow au hover). Une ligne live au-dessus des boutons affiche le récap (`2 themes · 3 members`) ou l'erreur de validation en rouge dans le même slot — fini le message décollé sous le bouton.
- **All members panel** — le CTA "Add a member" est caché tant que le backend invite n'existe pas. Le handler précédent ne faisait que copier un fake share link au clipboard. Commentaire laissé en place pour pointer vers le design compact inline search à faire quand on wire le vrai flow.

## Test plan
- [ ] /circles → "Create a circle" → themes en grille 2-cols, toggle "View N more" propre
- [ ] Scroll dans la drawer → footer reste collé en bas avec blur
- [ ] Validation: vider Name → erreur rouge dans le récap; remplir → recap themes/members en mono
- [ ] Hover "Add to cart" valide → accent peach + glow
- [ ] Cercle detail → "All members" → plus de bouton "Add a member" au-dessus de la liste

🤖 Generated with [Claude Code](https://claude.com/claude-code)