### PR TITLE
feat(doc/og): editorial OG image for documentation site

### DIFF
--- a/apps/doc/docusaurus.config.ts
+++ b/apps/doc/docusaurus.config.ts
@@ -112,7 +112,9 @@ const config: Config = {
   ],
 
   themeConfig: {
-    image: 'img/Sofia_Chronicles.webp',
+    // OG image served by apps/og (Next.js + @vercel/og).
+    // Route source: apps/og/app/api/og/doc/route.tsx — accepts ?title=&subtitle=&eyebrow= for per-page overrides.
+    image: 'https://sofia-og.vercel.app/api/og/doc',
     metadata: [
       {
         name: 'keywords',

--- a/apps/doc/docusaurus.config.ts
+++ b/apps/doc/docusaurus.config.ts
@@ -114,7 +114,7 @@ const config: Config = {
   themeConfig: {
     // OG image served by apps/og (Next.js + @vercel/og).
     // Route source: apps/og/app/api/og/doc/route.tsx — accepts ?title=&subtitle=&eyebrow= for per-page overrides.
-    image: 'https://sofia-og.vercel.app/api/og/doc',
+    image: 'https://og.sofia.intuition.box/api/og/doc',
     metadata: [
       {
         name: 'keywords',

--- a/apps/og/app/api/og/doc/route.tsx
+++ b/apps/og/app/api/og/doc/route.tsx
@@ -1,0 +1,195 @@
+import { ImageResponse } from '@vercel/og'
+import { NextRequest } from 'next/server'
+
+export const runtime = 'edge'
+
+const DEFAULT_TITLE = 'Sofia Documentation'
+const DEFAULT_SUBTITLE =
+  'Sofia turns your browsing into verifiable, blockchain-backed knowledge — privately and on your terms.'
+const DEFAULT_EYEBROW = 'DOCUMENTATION'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl
+  const title = searchParams.get('title') || DEFAULT_TITLE
+  const subtitle = searchParams.get('subtitle') || DEFAULT_SUBTITLE
+  const eyebrow = (searchParams.get('eyebrow') || DEFAULT_EYEBROW).toUpperCase()
+
+  const logoSrc = 'https://sofia-og.vercel.app/sofia-logo.png'
+
+  // Design-system dark tokens (theme.css):
+  //   bg #0b0a12, card #13121f, border #25223a,
+  //   ink #f5f3ff, muted #8f8ca8, accent peach #ffc6b0
+  return new ImageResponse(
+    <div
+      style={{
+        width: '1200px',
+        height: '630px',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        background: '#0b0a12',
+        fontFamily: 'sans-serif',
+        color: '#f5f3ff',
+        padding: '72px 88px',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Ambient peach glow — top right */}
+      <div
+        style={{
+          position: 'absolute',
+          top: '-180px',
+          right: '-120px',
+          width: '620px',
+          height: '620px',
+          background:
+            'radial-gradient(circle, rgba(255, 198, 176, 0.18) 0%, transparent 65%)',
+          display: 'flex',
+        }}
+      />
+
+      {/* Ambient indigo glow — bottom left */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: '-200px',
+          left: '-160px',
+          width: '560px',
+          height: '560px',
+          background:
+            'radial-gradient(circle, rgba(99, 102, 241, 0.12) 0%, transparent 65%)',
+          display: 'flex',
+        }}
+      />
+
+      {/* Top: Sofia logo + brand */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '18px',
+          zIndex: 1,
+        }}
+      >
+        <img
+          src={logoSrc}
+          alt="Sofia"
+          width={56}
+          height={56}
+          style={{ borderRadius: '14px' }}
+        />
+        <span
+          style={{
+            fontSize: '24px',
+            fontWeight: 600,
+            color: '#f5f3ff',
+            letterSpacing: '-0.01em',
+            display: 'flex',
+          }}
+        >
+          Sofia
+        </span>
+      </div>
+
+      {/* Middle: eyebrow + title + subtitle */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '24px',
+          zIndex: 1,
+        }}
+      >
+        <span
+          style={{
+            fontSize: '15px',
+            fontWeight: 600,
+            color: '#ffc6b0',
+            letterSpacing: '0.18em',
+            display: 'flex',
+          }}
+        >
+          {eyebrow}
+        </span>
+        <span
+          style={{
+            fontSize: '76px',
+            fontWeight: 700,
+            color: '#f5f3ff',
+            letterSpacing: '-0.025em',
+            lineHeight: 1.05,
+            display: 'flex',
+            maxWidth: '960px',
+          }}
+        >
+          {title}
+        </span>
+        <span
+          style={{
+            fontSize: '26px',
+            fontWeight: 400,
+            color: '#8f8ca8',
+            lineHeight: 1.4,
+            display: 'flex',
+            maxWidth: '880px',
+          }}
+        >
+          {subtitle}
+        </span>
+      </div>
+
+      {/* Footer: URL + accent rule */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          zIndex: 1,
+        }}
+      >
+        <span
+          style={{
+            fontSize: '20px',
+            fontWeight: 500,
+            color: '#f5f3ff',
+            display: 'flex',
+          }}
+        >
+          doc.sofia.intuition.box
+        </span>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+          }}
+        >
+          <div
+            style={{
+              width: '8px',
+              height: '8px',
+              borderRadius: '50%',
+              background: '#ffc6b0',
+              display: 'flex',
+            }}
+          />
+          <span
+            style={{
+              fontSize: '16px',
+              color: '#8f8ca8',
+              letterSpacing: '0.05em',
+              display: 'flex',
+            }}
+          >
+            intuition.box
+          </span>
+        </div>
+      </div>
+    </div>,
+    {
+      width: 1200,
+      height: 630,
+    },
+  )
+}

--- a/apps/og/app/api/og/doc/route.tsx
+++ b/apps/og/app/api/og/doc/route.tsx
@@ -14,7 +14,9 @@ export async function GET(req: NextRequest) {
   const subtitle = searchParams.get('subtitle') || DEFAULT_SUBTITLE
   const eyebrow = (searchParams.get('eyebrow') || DEFAULT_EYEBROW).toUpperCase()
 
-  const logoSrc = 'https://sofia-og.vercel.app/sofia-logo.png'
+  // Self-reference the deployment's origin so the logo loads from whichever
+  // domain serves this route (Coolify og.sofia.intuition.box in prod, localhost in dev).
+  const logoSrc = `${req.nextUrl.origin}/sofia-logo.png`
 
   // Design-system dark tokens (theme.css):
   //   bg #0b0a12, card #13121f, border #25223a,


### PR DESCRIPTION
## Summary
- New \`/api/og/doc\` route in apps/og — editorial Sofia preview (1200x630), design-system dark tokens, ambient peach + indigo glows
- Accepts \`?title=&subtitle=&eyebrow=\` for per-page overrides
- Logo self-references the request origin (no longer hardcoded to the dead Vercel URL)
- doc.sofia.intuition.box og:image now points to https://og.sofia.intuition.box/api/og/doc

## Test plan
- [ ] Open https://og.sofia.intuition.box/api/og/doc directly — should render the 1200x630 PNG with logo
- [ ] After doc redeploys, view-source on https://doc.sofia.intuition.box/ and confirm \`<meta property="og:image" content="https://og.sofia.intuition.box/api/og/doc">\`
- [ ] Validate on https://cards-dev.twitter.com/validator
- [ ] Discord cache-bust: share \`https://doc.sofia.intuition.box/?v=2\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)