### PR TITLE
  feat(extension): full-screen Amplify/Mark, cart→Amplify, DS-only colors

### DIFF
--- a/apps/extension/components/modals/WeightModal.tsx
+++ b/apps/extension/components/modals/WeightModal.tsx
@@ -18,7 +18,10 @@ import type { ModalTriplet } from "~/hooks"
 import { EXPLORER_URLS } from "~/lib/config/chainConfig"
 import { TOPIC_COLORS, TOPIC_LABELS } from "~/lib/config/topicConfig"
 import { createHookLogger, getFaviconUrl } from "~/lib/utils"
-import { INTENTION_CONFIG } from "~/types/intentionCategories"
+import {
+  INTENTION_CONFIG,
+  predicateLabelToIntentionType
+} from "~/types/intentionCategories"
 import type { IntentionType } from "~/types/intentionCategories"
 
 import contributorBadge from "../ui/img/badges/contributor.png"
@@ -428,10 +431,6 @@ const WeightModal = ({
   const showAmpForm =
     isFormState && !showSuccessHandoff && !(rewardClaimed && discoveryReward)
 
-  const ampDateStr = new Date()
-    .toLocaleDateString("fr-FR")
-    .replace(/\//g, " · ")
-
   return createPortal(
     <div className={`modal-overlay ${isProcessing ? "processing" : ""}`}>
       <div className="modal-content">
@@ -657,20 +656,6 @@ const WeightModal = ({
             )}
 
             <div className="b3-ticket">
-              <div className="b3-stub">
-                <div className="b3-stub-row">
-                  <span className="b3-stub-k">ITEMS</span>
-                  <span className="b3-stub-v">
-                    {activeCount}/{triplets.length}
-                  </span>
-                </div>
-                <div className="b3-stub-row">
-                  <span className="b3-stub-k">DATE</span>
-                  <span className="b3-stub-v">{ampDateStr}</span>
-                </div>
-              </div>
-              <div className="b3-perf" />
-
               <div className="b3-body">
                 <div className="b3-headline">
                   <span className="b3-drop">A</span>
@@ -703,14 +688,16 @@ const WeightModal = ({
                     const on = !removedIndices.has(index)
                     const sel = selectedWeights[index]
                     const name = triplet.description || triplet.triplet.object
-                    const intentKey = triplet.intention
+                    const intentKey: IntentionType | null = triplet.intention
                       ? (((triplet.intention as string) in INTENTION_CONFIG
                           ? triplet.intention
                           : triplet.intention.replace(
                               /^for_/,
                               ""
                             )) as IntentionType)
-                      : null
+                      : // Trust / distrust rows carry no `intention` —
+                        // resolve the verb from the predicate label.
+                        predicateLabelToIntentionType(triplet.triplet.predicate)
                     const intentEntry =
                       intentKey && intentKey in INTENTION_CONFIG
                         ? INTENTION_CONFIG[intentKey]
@@ -719,7 +706,8 @@ const WeightModal = ({
                       ? TOPIC_LABELS[triplet.interestContext]
                       : null
                     const topicColor = triplet.interestContext
-                      ? TOPIC_COLORS[triplet.interestContext] || "#888"
+                      ? TOPIC_COLORS[triplet.interestContext] ||
+                        "var(--ds-muted)"
                       : null
                     const canToggleOff = activeCount > 1
                     const lockedSingle = triplets.length <= 1
@@ -767,7 +755,7 @@ const WeightModal = ({
                               fill="none">
                               <path
                                 d="M5 12l4 4L19 6"
-                                stroke="#f5ead3"
+                                stroke="var(--ds-on-accent)"
                                 strokeWidth="3"
                                 strokeLinecap="round"
                                 strokeLinejoin="round"
@@ -787,9 +775,6 @@ const WeightModal = ({
                         />
 
                         <div className="b3-row-meta">
-                          <div className="b3-row-kicker">
-                            {triplet.triplet.predicate}
-                          </div>
                           <div className="b3-row-name" title={name}>
                             {name}
                           </div>

--- a/apps/extension/components/modals/reward/BatchRewardContent.tsx
+++ b/apps/extension/components/modals/reward/BatchRewardContent.tsx
@@ -21,7 +21,10 @@ import { useBatchRewards, useGoldSystem } from "~/hooks"
 import { TOPIC_COLORS, TOPIC_LABELS } from "~/lib/config/topicConfig"
 import type { CartItemRecord } from "~/lib/database"
 import { createHookLogger, getFaviconUrl } from "~/lib/utils"
-import { INTENTION_CONFIG } from "~/types/intentionCategories"
+import {
+  INTENTION_CONFIG,
+  predicateLabelToIntentionType
+} from "~/types/intentionCategories"
 import type { IntentionType } from "~/types/intentionCategories"
 
 import contributorBadge from "../../ui/img/badges/contributor.png"
@@ -76,7 +79,6 @@ export interface BatchRewardContentProps {
 
 const BatchRewardContent = ({
   items,
-  txHash,
   onClose,
   onViewEchoes,
   enabled
@@ -213,37 +215,10 @@ const BatchRewardContent = ({
     <div className="rc">
       <div className="rc-ember" />
       <div className="rc-ticket">
-        <div className="rc-stub">
-          <div className="rc-stub-row">
-            <span className="rc-stub-k">N°</span>
-            <span className="rc-stub-v">
-              {txHash ? txHash.slice(2, 10).toUpperCase() : "—"}
-            </span>
-          </div>
-          <div className="rc-stub-row">
-            <span className="rc-stub-k">DATE</span>
-            <span className="rc-stub-v">
-              {new Date().toLocaleDateString("fr-FR").replace(/\//g, " · ")}
-            </span>
-          </div>
-        </div>
-        <div className="rc-perf" />
-
         <div className="rc-body">
           <div className="rc-headline">
-            <span className="rc-drop">M</span>
-            <h1 className="rc-h1">
-              {isSingle ? "ark" : "arks"}
-              <br />
-              captured.
-            </h1>
+            <h1 className="rc-h1">{isSingle ? "Mark" : "Marks"} captured.</h1>
           </div>
-          <p className="rc-sub">
-            {isSingle
-              ? "Awarded for marking one page."
-              : `Awarded for marking ${rewards.length} pages.`}
-          </p>
-
           <div className="rc-marks">
             {rewards.slice(0, isSingle ? 1 : 8).map((reward) => {
               const item = reward.item
@@ -251,14 +226,16 @@ const BatchRewardContent = ({
               // Same intent/topic resolution as the Amplify rows so the verb
               // ("visited", …) renders via the DS <VerbTag> and the context
               // pill matches it 1:1.
-              const intentKey = item.intention
+              const intentKey: IntentionType | null = item.intention
                 ? (((item.intention as string) in INTENTION_CONFIG
                     ? item.intention
                     : (item.intention as string).replace(
                         /^for_/,
                         ""
                       )) as IntentionType)
-                : null
+                : // Trust / distrust marks carry no `intention` — resolve the
+                  // verb from the predicate name ("trusts" → "trusted").
+                  predicateLabelToIntentionType(item.predicateName)
               const intentEntry =
                 intentKey && intentKey in INTENTION_CONFIG
                   ? INTENTION_CONFIG[intentKey]
@@ -267,7 +244,7 @@ const BatchRewardContent = ({
                 ? TOPIC_LABELS[item.interestContext]
                 : null
               const topicColor = item.interestContext
-                ? TOPIC_COLORS[item.interestContext] || "#888"
+                ? TOPIC_COLORS[item.interestContext] || "var(--ds-muted)"
                 : null
               return (
                 <div className="rc-mark" key={item.id}>
@@ -318,30 +295,27 @@ const BatchRewardContent = ({
             )}
           </div>
 
-          <div className="rc-tiers">
-            <div className="rc-tiers-k">Tier ladder</div>
-            {TIER_ORDER.map((tier) => {
-              const count = tierCount(tier)
-              const earned = count > 0
-              return (
-                <div
-                  className={`rc-tier${earned ? " is-earned" : ""}`}
-                  key={tier}>
-                  <UserBadge
-                    tier={tier}
-                    iconUrl={BADGE_IMAGES[tier]}
-                    size={32}
-                  />
-                  <span className="rc-tier-label">
-                    {tier.charAt(0).toUpperCase() + tier.slice(1)}
-                  </span>
-                  <span className="rc-tier-state">
-                    {earned ? `${count} earned` : "locked"}
-                  </span>
-                </div>
-              )
-            })}
-          </div>
+          {TIER_ORDER.some((tier) => tierCount(tier) > 0) && (
+            <div className="rc-tiers">
+              <div className="rc-tiers-k">Tier ladder</div>
+              {TIER_ORDER.filter((tier) => tierCount(tier) > 0).map((tier) => {
+                const count = tierCount(tier)
+                return (
+                  <div className="rc-tier is-earned" key={tier}>
+                    <UserBadge
+                      tier={tier}
+                      iconUrl={BADGE_IMAGES[tier]}
+                      size={32}
+                    />
+                    <span className="rc-tier-label">
+                      {tier.charAt(0).toUpperCase() + tier.slice(1)}
+                    </span>
+                    <span className="rc-tier-state">{count} earned</span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
 
           <div className="rc-ledger">
             <div className="rc-ledger-row">

--- a/apps/extension/components/pages/core-tabs/EchoesTab.tsx
+++ b/apps/extension/components/pages/core-tabs/EchoesTab.tsx
@@ -322,21 +322,22 @@ const EchoesTab = () => {
               </button>
             ))}
           </div>
-          <button
-            className="sort-btn gm-manage-btn"
-            style={{ marginLeft: "auto" }}
-            onClick={() => handleOpenManager("all")}
-            title="Manage groups">
-            Manage
-          </button>
-          <button
-            className="sort-btn gm-manage-btn echoes-open-sofia-btn"
-            onClick={() =>
-              chrome.tabs.create({ url: getProfileUrl(), active: true })
-            }
-            title="Open my profile on Explorer">
-            Open on Explorer ↗
-          </button>
+          <div className="echoes-actions">
+            <button
+              className="sort-btn gm-manage-btn"
+              onClick={() => handleOpenManager("all")}
+              title="Manage groups">
+              Manage
+            </button>
+            <button
+              className="sort-btn gm-manage-btn echoes-open-sofia-btn"
+              onClick={() =>
+                chrome.tabs.create({ url: getProfileUrl(), active: true })
+              }
+              title="Open my profile on Explorer">
+              Open on Explorer ↗
+            </button>
+          </div>
         </div>
 
         {filteredGroups.length === 0 ? (

--- a/apps/extension/components/styles/CategoryStyles.css
+++ b/apps/extension/components/styles/CategoryStyles.css
@@ -39,7 +39,9 @@
   backdrop-filter: blur(50px) saturate(100%);
   -webkit-backdrop-filter: blur(50px) saturate(100%);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.5),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
   cursor: pointer;
   transition: all 0.3s ease;
   flex-shrink: 0;
@@ -97,8 +99,13 @@
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 0.3; }
-  50% { opacity: 0.6; }
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.6;
+  }
 }
 
 /* Category Detail View — Bookmark detail
@@ -147,7 +154,7 @@
 }
 
 .category-detail-name {
-  font-family: 'Fraunces', serif;
+  font-family: "Fraunces", serif;
   color: var(--ds-ink);
   font-size: 28px;
   font-weight: 700;
@@ -158,7 +165,7 @@
 }
 
 .category-detail-count {
-  font-family: var(--font-family-mono, 'JetBrains Mono', monospace);
+  font-family: var(--font-family-mono, "JetBrains Mono", monospace);
   font-size: 11px;
   font-weight: 600;
   color: var(--ds-muted);
@@ -184,13 +191,16 @@
   border-radius: 999px;
   background: transparent;
   color: var(--ds-muted);
-  font-family: 'Geist', sans-serif;
+  font-family: "Geist", sans-serif;
   font-size: 11px;
   font-weight: 500;
   cursor: pointer;
   flex-shrink: 0;
   margin-left: auto;
-  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease,
+    background 0.15s ease;
 }
 
 .url-redeem-btn:hover:not(:disabled) {
@@ -276,6 +286,17 @@
   white-space: nowrap;
 }
 
+/* Manage + Open-on-Explorer stay side by side as one unit, pushed to
+   the right. If the row runs out of width the pair wraps together
+   (still side by side) — the row container size is unchanged. */
+.echoes-sort-row .echoes-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
 /* Filter chips row — All + intention chips, wraps */
 .echoes-filter-row {
   display: flex;
@@ -304,7 +325,7 @@
 
 .echoes-sort-toggle .scope-btn {
   padding: 4px 10px;
-  font-family: 'Geist', sans-serif;
+  font-family: "Geist", sans-serif;
   font-size: 11px;
   font-weight: 500;
   color: var(--ds-muted);
@@ -334,7 +355,9 @@
   border-radius: 10px;
   padding: 10px 14px;
   gap: 10px;
-  transition: border-color 0.15s ease, background 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
 }
 
 .category-search-container:focus-within {
@@ -348,7 +371,7 @@
   border: none;
   outline: none;
   color: var(--ds-ink);
-  font-family: 'Geist', sans-serif;
+  font-family: "Geist", sans-serif;
   font-size: 13px;
 }
 

--- a/apps/extension/components/styles/CommonPage.css
+++ b/apps/extension/components/styles/CommonPage.css
@@ -11,7 +11,7 @@
   padding: 12px 16px;
   transition: all 0.3s ease;
   margin-bottom: 5px;
-  margin-top: 28px
+  margin-top: 28px;
 }
 
 .search-input {
@@ -40,7 +40,7 @@
 
 /* Trending Section Styles */
 .trending-section {
-  border-top: none
+  border-top: none;
 }
 
 .trending-section .section-title {
@@ -153,8 +153,6 @@
   grid-row: span 2;
 }
 
-
-
 .bento-mega {
   grid-column: span 2;
   grid-row: span 3;
@@ -189,21 +187,21 @@
     gap: 10px;
     grid-auto-rows: 130px;
   }
-  
+
   .bento-mega {
     grid-column: span 2;
     grid-row: span 1;
   }
-  
+
   .bento-tall {
     grid-column: span 1;
     grid-row: span 2;
   }
-  
+
   .bento-title {
     font-size: 12px;
   }
-  
+
   .bento-mega .bento-title {
     font-size: 14px;
   }
@@ -237,7 +235,7 @@
 
 .group-bento-card.can-level-up::before,
 .group-bento-card.can-level-up::after {
-  content: '';
+  content: "";
   position: absolute;
   width: 100%;
   height: 2px;
@@ -266,13 +264,21 @@
 }
 
 @keyframes bento-star-top {
-  from { transform: translateX(-100%); }
-  to   { transform: translateX(100%); }
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
+  }
 }
 
 @keyframes bento-star-bottom {
-  from { transform: translateX(100%); }
-  to   { transform: translateX(-100%); }
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(-100%);
+  }
 }
 
 .group-bento-header {
@@ -294,7 +300,7 @@
 }
 
 .group-bento-title {
-  font-family: 'Fraunces', serif;
+  font-family: "Fraunces", serif;
   color: var(--ds-ink);
   font-size: 15px;
   font-weight: 600;
@@ -470,7 +476,7 @@
   border: 1px solid var(--ds-border);
   border-radius: 8px;
   background: var(--ds-card);
-  font-family: 'Geist', ui-sans-serif, system-ui, sans-serif;
+  font-family: "Geist", ui-sans-serif, system-ui, sans-serif;
   font-size: 12px;
   font-weight: 500;
   color: var(--ds-ink);
@@ -503,7 +509,7 @@
 }
 
 .group-detail-domain {
-  font-family: 'Fraunces', serif;
+  font-family: "Fraunces", serif;
   color: var(--ds-ink);
   font-size: 32px;
   font-weight: 700;
@@ -514,7 +520,10 @@
 }
 
 /* Level colors for detail view */
-.group-detail-level.level-1  { background: var(--ds-muted);     color: #000; }
+.group-detail-level.level-1 {
+  background: var(--ds-muted);
+  color: #000;
+}
 .group-detail-stats {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -561,7 +570,7 @@
 .stat-number {
   display: block;
   color: #000;
-  font-family: 'Fraunces', serif;
+  font-family: "Fraunces", serif;
   font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -570,7 +579,7 @@
 
 .stat-text {
   color: rgba(0, 0, 0, 0.7);
-  font-family: var(--font-family-mono, 'JetBrains Mono', monospace);
+  font-family: var(--font-family-mono, "JetBrains Mono", monospace);
   font-size: 10px;
   text-transform: uppercase;
   font-weight: 600;
@@ -595,7 +604,7 @@
   border: 1px solid var(--ds-border);
   background: var(--ds-bg);
   color: var(--ds-ink-soft);
-  font-family: 'Geist', sans-serif;
+  font-family: "Geist", sans-serif;
   font-size: 11px;
   font-weight: 500;
   cursor: pointer;
@@ -644,7 +653,9 @@
   border-radius: 12px;
   padding: 0;
   border: 1px dashed var(--ds-border);
-  transition: border-color 0.15s ease, background 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
 }
 
 .url-row:hover {
@@ -736,7 +747,7 @@
 .url-date,
 .url-duration {
   color: var(--ds-muted);
-  font-family: var(--font-family-mono, 'JetBrains Mono', monospace);
+  font-family: var(--font-family-mono, "JetBrains Mono", monospace);
   font-size: 10px;
   letter-spacing: 0.04em;
 }
@@ -756,7 +767,9 @@
   width: 24px;
   height: 24px;
   color: var(--ds-muted);
-  transition: transform 0.18s ease, color 0.15s ease;
+  transition:
+    transform 0.18s ease,
+    color 0.15s ease;
 }
 
 .url-row-main:hover .url-chevron {
@@ -780,7 +793,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease,
+    background 0.15s ease;
 }
 
 .remove-btn:hover:not(:disabled) {
@@ -804,7 +820,7 @@
   padding: 5px 11px;
   border-radius: 6px;
   color: #000;
-  font-family: var(--font-family-mono, 'JetBrains Mono', monospace);
+  font-family: var(--font-family-mono, "JetBrains Mono", monospace);
   font-size: 10px;
   font-weight: 700;
   line-height: 1;
@@ -815,9 +831,12 @@
   border: none;
 }
 
+/* Topic/context badge — same size & font as the verb badge, but the
+   topic color applies to the text + border instead of the background
+   (color + borderColor injected inline from the topic palette). */
 .cert-badge--context {
-  font-size: 9px;
-  padding: 4px 9px;
+  background: transparent;
+  border: 1px solid currentColor;
 }
 
 .empty-urls {
@@ -852,7 +871,7 @@
   border: 1px solid var(--ds-border);
   background: var(--ds-bg);
   color: var(--ds-ink-soft);
-  font-family: 'Geist', sans-serif;
+  font-family: "Geist", sans-serif;
   font-size: 11px;
   font-weight: 500;
   cursor: pointer;
@@ -936,7 +955,7 @@
 }
 
 .history-detail-link {
-  font-family: 'Geist', sans-serif;
+  font-family: "Geist", sans-serif;
   font-size: 12px;
   color: var(--ds-muted);
   text-decoration: none;
@@ -953,7 +972,7 @@
 
 .url-row.expanded {
   background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(255, 198, 176, 0.30);
+  border-color: rgba(255, 198, 176, 0.3);
 }
 
 .menu-dots-btn .dot {
@@ -977,7 +996,7 @@
 
 /* Subtitle above the intention pills */
 .url-expanded-subtitle {
-  font-family: var(--font-family-mono, 'JetBrains Mono', monospace);
+  font-family: var(--font-family-mono, "JetBrains Mono", monospace);
   font-size: 10px;
   font-weight: 700;
   color: rgba(255, 255, 255, 0.5);
@@ -1015,7 +1034,7 @@
 
 .url-expanded-section .interest-context__label {
   display: block;
-  font-family: var(--font-family-mono, 'JetBrains Mono', monospace);
+  font-family: var(--font-family-mono, "JetBrains Mono", monospace);
   font-size: 10px;
   font-weight: 700;
   color: rgba(255, 255, 255, 0.5);
@@ -1034,22 +1053,24 @@
   display: inline-block;
   padding: 8px 16px;
   background: var(--btn-primary-bg);
-  
+
   border: none;
   border-radius: 28px;
   color: var(--btn-primary-fg);
-  font-family: 'Geist', sans-serif;
+  font-family: "Geist", sans-serif;
   font-size: 12px;
   font-weight: 700;
-  
+
   cursor: pointer;
   text-transform: lowercase;
-  transition: background 0.15s ease, transform 0.15s ease;
+  transition:
+    background 0.15s ease,
+    transform 0.15s ease;
 }
 
 .oauth-predicate-btn:hover:not(:disabled) {
   transform: translateY(-2px);
-  box-shadow: 0 12px 48px rgba(255, 198, 176, 0.60);
+  box-shadow: 0 12px 48px rgba(255, 198, 176, 0.6);
 }
 
 .oauth-predicate-btn:disabled {
@@ -1077,7 +1098,7 @@
   background: var(--ds-card);
   border: 1px solid var(--ds-accent);
   border-radius: 8px;
-  font-family: 'Geist', sans-serif;
+  font-family: "Geist", sans-serif;
   font-size: 12px;
   color: var(--ds-ink);
   line-height: 1.4;
@@ -1109,7 +1130,9 @@
   padding: 2px 6px;
   border-radius: 4px;
   flex-shrink: 0;
-  transition: color 0.15s ease, background 0.15s ease;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
 }
 
 .level-up-success-inline .dismiss-btn:hover {
@@ -1218,7 +1241,7 @@
 }
 
 .level-up-error .error-text {
-  color: #EF4444;
+  color: #ef4444;
   font-size: 13px;
   font-weight: 500;
 }
@@ -1280,7 +1303,7 @@
 }
 
 .amplify-error .error-text {
-  color: #EF4444;
+  color: #ef4444;
   font-size: 13px;
   flex: 1;
 }
@@ -1300,7 +1323,14 @@
   justify-content: space-between;
   gap: 12px;
   padding: 16px 18px;
-  background: linear-gradient(135deg, #B8860B 0%, #DAA520 25%, #FFD700 50%, #DAA520 75%, #B8860B 100%);
+  background: linear-gradient(
+    135deg,
+    #b8860b 0%,
+    #daa520 25%,
+    #ffd700 50%,
+    #daa520 75%,
+    #b8860b 100%
+  );
   background-size: 200% 100%;
   border: 1px solid rgba(255, 215, 0, 0.5);
   border-radius: 12px;
@@ -1309,14 +1339,22 @@
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 2px 8px rgba(218, 165, 32, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+  box-shadow:
+    0 2px 8px rgba(218, 165, 32, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
   animation: goldShimmer 3s ease infinite;
 }
 
 @keyframes goldShimmer {
-  0% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
 }
 
 .level-up-integrated-btn:hover:not(:disabled) {
@@ -1331,7 +1369,7 @@
 }
 
 .level-up-integrated-btn .level-up-text {
-  font-family: 'Fraunces', serif;
+  font-family: "Fraunces", serif;
   font-size: 18px;
   font-weight: 700;
   letter-spacing: -0.01em;
@@ -1342,7 +1380,7 @@
   padding: 4px 10px;
   background: rgba(0, 0, 0, 0.18);
   border-radius: 6px;
-  font-family: var(--font-family-mono, 'JetBrains Mono', monospace);
+  font-family: var(--font-family-mono, "JetBrains Mono", monospace);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -1364,7 +1402,8 @@
   animation:
     freshMarkDropIn 480ms cubic-bezier(0.16, 1, 0.3, 1) backwards,
     freshMarkPulse 2000ms ease-out 480ms;
-  animation-delay: calc(var(--fresh-stagger-index, 0) * 100ms), calc(var(--fresh-stagger-index, 0) * 100ms + 480ms);
+  animation-delay: calc(var(--fresh-stagger-index, 0) * 100ms),
+    calc(var(--fresh-stagger-index, 0) * 100ms + 480ms);
 }
 
 @keyframes freshMarkDropIn {
@@ -1406,7 +1445,10 @@
   padding: 6px 12px;
   border-radius: 999px;
   cursor: pointer;
-  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+  transition:
+    background 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
 }
 
 .group-detail-view-on-sofia:hover {

--- a/apps/extension/components/styles/Modal.css
+++ b/apps/extension/components/styles/Modal.css
@@ -34,6 +34,23 @@
   pointer-events: auto;
 }
 
+/* Amplify (.amp.b3) and Mark-captured (.rc) take the full screen —
+   drop the overlay padding and the modal-content frame/size caps. */
+.modal-overlay:has(.amp.b3),
+.modal-overlay:has(.rc) {
+  padding: 0;
+}
+.modal-content:has(.amp.b3),
+.modal-content:has(.rc) {
+  max-width: none;
+  max-height: none;
+  width: 100vw;
+  height: 100vh;
+  border: 0;
+  border-radius: 0;
+  overflow: hidden;
+}
+
 @keyframes modalAppear {
   from {
     opacity: 0;
@@ -1207,17 +1224,15 @@
 .rc {
   position: relative;
   z-index: 10;
-  margin: -24px;
-  min-height: 560px;
-  border-radius: 24px;
+  margin: 0;
+  min-height: 100vh;
+  border-radius: 0;
   overflow: hidden;
-  background: #0a0a0a;
+  background: var(--ds-bg-subtle);
   isolation: isolate;
   animation: rcAppear 0.4s ease-out;
-  --peach-1: #ffe9df;
-  --peach-2: #ffc6b0;
-  --peach-3: #ffaa8a;
-  --peach-4: #e87a52;
+  display: flex;
+  flex-direction: column;
 }
 
 @keyframes rcAppear {
@@ -1229,53 +1244,15 @@
   }
 }
 
-/* Ember scene — replaces the old gold <video>, pure CSS */
+/* Flat surface — same as the cart drawer (var(--ds-card)) */
 .rc-ember {
   position: absolute;
   inset: 0;
   z-index: 0;
-  background: radial-gradient(
-    120% 80% at 50% 100%,
-    rgba(232, 122, 82, 0.14),
-    #0a0a0a 50%,
-    #050505 100%
-  );
+  background: var(--ds-card);
 }
 .rc-ember::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(
-      2px 2px at 12% 80%,
-      rgba(255, 160, 60, 0.9),
-      transparent 60%
-    ),
-    radial-gradient(
-      1.5px 1.5px at 78% 60%,
-      rgba(255, 200, 120, 0.9),
-      transparent 60%
-    ),
-    radial-gradient(
-      1.2px 1.2px at 30% 40%,
-      rgba(255, 140, 40, 0.7),
-      transparent 60%
-    ),
-    radial-gradient(
-      1.6px 1.6px at 62% 30%,
-      rgba(255, 170, 80, 0.8),
-      transparent 60%
-    ),
-    radial-gradient(
-      2px 2px at 88% 90%,
-      rgba(255, 210, 140, 0.7),
-      transparent 60%
-    ),
-    radial-gradient(
-      1.4px 1.4px at 22% 18%,
-      rgba(255, 180, 90, 0.5),
-      transparent 60%
-    );
-  animation: rcEmberRise 7s linear infinite;
+  display: none;
 }
 @keyframes rcEmberRise {
   from {
@@ -1295,13 +1272,12 @@
   position: relative;
   z-index: 2;
   margin: 18px;
-  background: #141414;
-  color: #ffffff;
+  flex: 1;
+  background: var(--ds-card);
+  color: var(--ds-ink);
+  border: 1px solid var(--ds-border);
   border-radius: 6px;
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.06) inset,
-    0 30px 60px -10px rgba(0, 0, 0, 0.7),
-    0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.55);
   display: flex;
   flex-direction: column;
   font-family: "Inter Tight", "Geist", sans-serif;
@@ -1363,31 +1339,21 @@
 
 .rc-headline {
   display: flex;
-  align-items: flex-start;
-  gap: 2px;
+  align-items: baseline;
 }
-.rc-drop {
-  font-family: "Fraunces", Georgia, serif;
-  font-weight: 900;
-  font-variation-settings:
-    "SOFT" 30,
-    "opsz" 144;
-  font-size: 70px;
-  line-height: 0.82;
-  letter-spacing: -0.06em;
-  color: #ffffff;
-}
+/* Single-line title, uniform size for every character. */
 .rc-h1 {
   font-family: "Fraunces", Georgia, serif;
   font-weight: 900;
   font-variation-settings:
     "SOFT" 30,
     "opsz" 144;
-  font-size: 40px;
-  line-height: 0.88;
+  font-size: 38px;
+  line-height: 1;
   letter-spacing: -0.035em;
-  margin: 4px 0 0 -2px;
-  color: #ffffff;
+  margin: 0;
+  color: var(--ds-ink);
+  white-space: nowrap;
 }
 .rc-sub {
   font-family: "Fraunces", Georgia, serif;
@@ -1403,6 +1369,7 @@
   gap: 6px;
   max-height: 240px;
   overflow-y: auto;
+  margin-top: 28px;
   margin-bottom: 12px;
 }
 .rc-mark {
@@ -1436,38 +1403,30 @@
   gap: 6px;
   flex-wrap: wrap;
 }
-/* Context pill — identical shape to the DS <VerbTag> ("visited" …) so the
- * two read as one matched family; background is the topic color. */
-/* Interest pill — same design as the explorer's .pc-interest-pill
- * (soft topic-tinted rounded pill + colored badge dot + mono uppercase
- * label), adapted to the dark .rc ticket and driven by the topic color. */
+/* Topic pill — same size & font as the DS <VerbTag> (.fc-verb-tag), but
+   the topic color applies to the text + border, not the background. */
 .rc-mark-ctx {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 10px 4px 8px;
-  border-radius: 999px;
-  background: color-mix(
-    in srgb,
-    var(--tag-color, var(--peach-3)) 16%,
-    transparent
-  );
-  border: 1px solid
-    color-mix(in srgb, var(--tag-color, var(--peach-3)) 42%, transparent);
+  padding: 5px 11px;
+  border-radius: 6px;
+  background: transparent;
+  border: 1px solid var(--tag-color, var(--ds-accent));
   font-family: "JetBrains Mono", monospace;
   font-size: 10px;
-  font-weight: 600;
+  font-weight: 700;
   line-height: 1;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #ffffff;
+  color: var(--tag-color, var(--ds-accent));
   white-space: nowrap;
 }
 .rc-mark-ctx-dot {
   width: 8px;
   height: 8px;
   border-radius: 999px;
-  background: var(--tag-color, var(--peach-3));
+  background: var(--tag-color, var(--ds-accent));
   flex: 0 0 auto;
 }
 .rc-mark-title {
@@ -1574,7 +1533,7 @@
   gap: 6px;
   margin-top: auto;
   padding-top: 10px;
-  border-top: 1px solid rgba(255, 255, 255, 0.18);
+  border-top: 1px solid var(--ds-border);
 }
 .rc-btn {
   flex: 1;
@@ -1608,9 +1567,9 @@
   flex: 1.6;
 }
 .rc-btn--primary:hover {
-  background: var(--peach-3);
+  background: var(--ds-accent);
   color: #0a0a0a;
-  border-color: var(--peach-3);
+  border-color: var(--ds-accent);
 }
 
 /* ========== GLOBAL STAKE SLIDER ========== */
@@ -2466,21 +2425,17 @@
 .amp.b3 {
   position: relative;
   z-index: 10;
-  margin: -24px;
-  min-height: 560px;
-  border-radius: 24px;
+  margin: 0;
+  height: 100vh;
+  border-radius: 0;
   overflow: hidden;
   isolation: isolate;
   display: flex;
   align-items: stretch;
   justify-content: center;
   font-family: "Inter Tight", system-ui, sans-serif;
-  background: #0a0a0a;
+  background: var(--ds-bg-subtle);
   animation: rcAppear 0.4s ease-out;
-  --peach-1: #ffe9df;
-  --peach-2: #ffc6b0;
-  --peach-3: #ffaa8a;
-  --peach-4: #e87a52;
 }
 
 .amp .b3-bg {
@@ -2490,12 +2445,11 @@
   overflow: hidden;
 }
 .amp .b3-bg--v5 {
-  background: linear-gradient(160deg, #0a0a0a 0%, #050505 100%);
+  /* Flat surface — same as the cart drawer (var(--ds-card)) */
+  background: var(--ds-card);
 }
 .amp .b3-bg--v5 .b3-bg-hex {
-  position: absolute;
-  background: rgba(255, 255, 255, 0.05);
-  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
+  display: none;
 }
 .amp .b3-bg-hex--1 {
   width: 360px;
@@ -2521,26 +2475,26 @@
   background: rgba(255, 255, 255, 0.03);
 }
 .amp .b3-bg-grain {
-  position: absolute;
-  inset: 0;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence baseFrequency='0.9'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/></svg>");
-  opacity: 0.08;
-  mix-blend-mode: screen;
+  display: none;
 }
 
 /* Music / topic / intention tag */
+/* Topic tag — same size & font as the DS <VerbTag> (.fc-verb-tag), but
+   the topic color applies to the text + border, not the background. */
 .amp .amp-tag {
   display: inline-flex;
   align-items: center;
-  padding: 3px 10px;
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: -0.005em;
-  background: color-mix(in oklab, var(--tag-pastel) 22%, transparent);
-  border: 1px solid color-mix(in oklab, var(--tag-pastel) 60%, transparent);
-  color: color-mix(in oklab, var(--tag-color) 72%, white);
-  font-family: "Inter Tight", sans-serif;
+  padding: 5px 11px;
+  border-radius: 6px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: transparent;
+  border: 1px solid var(--tag-color, var(--ds-accent));
+  color: var(--tag-color, var(--ds-accent));
 }
 
 /* Ticket (foreground, parchment) */
@@ -2549,15 +2503,15 @@
   z-index: 2;
   margin: 18px;
   flex: 1;
-  background: #141414;
-  color: #ffffff;
+  background: var(--ds-card);
+  color: var(--ds-ink);
+  border: 1px solid var(--ds-border);
   border-radius: 8px;
   display: flex;
   flex-direction: column;
-  box-shadow:
-    0 1px 0 rgba(255, 255, 255, 0.06) inset,
-    0 30px 60px -10px rgba(0, 0, 0, 0.7),
-    0 0 0 1px rgba(255, 255, 255, 0.08);
+  min-height: 0;
+  overflow: hidden;
+  box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.55);
 }
 .amp .b3-stub {
   padding: 12px 22px 10px;
@@ -2613,6 +2567,12 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+  flex: 1;
+  /* Long baskets scroll inside the body so the actions stay reachable.
+     margin-top:auto on .b3-actions still pins them to the bottom when
+     the content is short. */
+  min-height: 0;
+  overflow-y: auto;
 }
 
 /* Headline */
@@ -2646,10 +2606,11 @@
   color: #ffffff;
 }
 .amp .b3-sub {
-  font-family: "Fraunces", Georgia, serif;
-  font-style: italic;
-  font-size: 13.5px;
-  color: rgba(255, 255, 255, 0.65);
+  font-family: "Geist", sans-serif;
+  font-style: normal;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ds-muted);
   margin: 0;
 }
 
@@ -2728,13 +2689,13 @@
   bottom: 12px;
   width: 3px;
   border-radius: 0 3px 3px 0;
-  background: var(--peach-3);
+  background: var(--ds-accent);
 }
 .amp .b3-check {
   width: 22px;
   height: 22px;
   border-radius: 5px;
-  border: 1.5px solid rgba(255, 255, 255, 0.6);
+  border: 1.5px solid var(--ds-border);
   background: transparent;
   display: flex;
   align-items: center;
@@ -2747,8 +2708,8 @@
     border-color 0.12s;
 }
 .amp .b3-row.is-on .b3-check {
-  background: var(--peach-4);
-  border-color: var(--peach-4);
+  background: var(--ds-accent);
+  border-color: var(--ds-accent);
 }
 .amp .b3-check:disabled {
   cursor: default;
@@ -2759,11 +2720,14 @@
   border-radius: 8px;
   object-fit: cover;
   flex: 0 0 auto;
-  background: rgba(255, 255, 255, 0.06);
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1);
+  background: var(--ds-border-soft);
+  box-shadow: 0 0 0 1px var(--ds-border);
 }
 .amp .b3-row-meta {
   min-width: 0;
+  /* Bottom-align with .b3-row-right so the verb/topic tags share a
+     baseline with the light/medium/strong tier pills. */
+  align-self: end;
 }
 .amp .b3-row-kicker {
   font-family: "JetBrains Mono", monospace;
@@ -2778,11 +2742,11 @@
 }
 .amp .b3-row-name {
   font-size: 14px;
-  font-weight: 700;
-  color: #ffffff;
+  font-weight: 600;
+  color: var(--ds-ink);
   margin-top: 3px;
-  letter-spacing: -0.01em;
-  font-family: "Fraunces", Georgia, serif;
+  letter-spacing: -0.005em;
+  font-family: "Geist", sans-serif;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2808,6 +2772,7 @@
   flex-direction: column;
   align-items: flex-end;
   gap: 8px;
+  align-self: end;
 }
 .amp .b3-row-trust {
   display: inline-flex;
@@ -2859,7 +2824,7 @@
   background: rgba(255, 255, 255, 0.06);
 }
 .amp .b3-tier.is-on {
-  background: var(--peach-3);
+  background: var(--ds-accent);
   color: #0a0a0a;
 }
 .amp .b3-tier-label {
@@ -2901,7 +2866,7 @@
   color: #ffffff;
 }
 .amp .b3-extra .gs-slider-breakdown-value.pool {
-  color: var(--peach-4);
+  color: var(--ds-accent);
 }
 /* Beta Season Pool slider — peach thumb that clearly stands out on
    parchment (overrides the legacy gold-on-dark .gs-slider-input). */
@@ -2909,8 +2874,8 @@
   height: 6px;
   background: linear-gradient(
     to right,
-    var(--peach-4) 0%,
-    var(--peach-3) var(--gs-fill-pct, 40%),
+    var(--ds-accent) 0%,
+    var(--ds-accent) var(--gs-fill-pct, 40%),
     rgba(255, 255, 255, 0.16) var(--gs-fill-pct, 40%),
     rgba(255, 255, 255, 0.16) 100%
   );
@@ -2918,7 +2883,7 @@
 .amp .b3-extra .gs-slider-input::-webkit-slider-thumb {
   width: 22px;
   height: 22px;
-  background: var(--peach-4);
+  background: var(--ds-accent);
   border: 3px solid #141414;
   box-shadow:
     0 2px 9px rgba(232, 122, 82, 0.6),
@@ -2933,7 +2898,7 @@
 .amp .b3-extra .gs-slider-input::-moz-range-thumb {
   width: 22px;
   height: 22px;
-  background: var(--peach-4);
+  background: var(--ds-accent);
   border: 3px solid #141414;
   box-shadow: 0 2px 9px rgba(232, 122, 82, 0.6);
 }
@@ -2976,15 +2941,15 @@
 .amp .b3-actions {
   display: flex;
   gap: 8px;
-  margin-top: 4px;
+  margin-top: auto;
   padding-top: 12px;
-  border-top: 1px solid rgba(255, 255, 255, 0.85);
+  border-top: 1px solid var(--ds-border);
 }
 .amp .b3-btn {
   height: 48px;
-  border: 1px solid rgba(255, 255, 255, 0.85);
+  border: 1px solid var(--ds-border);
   background: transparent;
-  color: #ffffff;
+  color: var(--ds-ink);
   font-family: "Inter Tight", sans-serif;
   font-weight: 700;
   font-size: 13.5px;
@@ -3010,7 +2975,7 @@
   gap: 10px;
 }
 .amp .b3-btn--primary:hover:not(:disabled) {
-  background: var(--peach-3);
+  background: var(--ds-accent);
   color: #000000;
 }
 .amp .b3-btn--primary:disabled,
@@ -3186,7 +3151,7 @@
   font-family: "JetBrains Mono", monospace;
   font-size: 10.5px;
   letter-spacing: 0.04em;
-  color: var(--peach-4);
+  color: var(--ds-accent);
   margin: 8px 0 0;
 }
 /* Loader: white stroke on the dark overlay, larger, soft light glow. */

--- a/apps/extension/components/styles/Modal.css
+++ b/apps/extension/components/styles/Modal.css
@@ -1225,7 +1225,7 @@
   position: relative;
   z-index: 10;
   margin: 0;
-  min-height: 100vh;
+  height: 100vh;
   border-radius: 0;
   overflow: hidden;
   background: var(--ds-bg-subtle);
@@ -1280,6 +1280,8 @@
   box-shadow: 0 24px 48px -16px rgba(0, 0, 0, 0.55);
   display: flex;
   flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
   font-family: "Inter Tight", "Geist", sans-serif;
 }
 
@@ -1335,6 +1337,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-height: 0;
 }
 
 .rc-headline {
@@ -1363,11 +1366,15 @@
   margin: 6px 0 12px;
 }
 
+/* Marks list fills the available height (many tx visible) and scrolls
+   internally; the tier ladder + ledger (Balance) + actions sit just
+   below it, pinned near the bottom. */
 .rc-marks {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  max-height: 240px;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   margin-top: 28px;
   margin-bottom: 12px;

--- a/apps/extension/components/styles/PageBlockchainCard.css
+++ b/apps/extension/components/styles/PageBlockchainCard.css
@@ -18,8 +18,9 @@
   transition: var(--transition-fast, all 0.2s ease);
 }
 
-/* Refreshing state — stale data shown with reduced opacity */
-.blockchain-card--refreshing .website-header-section,
+/* Refreshing state — ONLY the Stats panel reflects the refresh.
+   Header + Actions stay fully visible and interactive so a stats
+   refresh no longer greys out / freezes the whole Mark card. */
 .blockchain-card--refreshing .credibility-content {
   opacity: 0.5;
   transition: opacity 0.3s ease;
@@ -61,18 +62,8 @@
   animation-delay: 0.22s;
 }
 
-/* Subtle pulse on the salmon header while data is being refreshed
-   in the background so users see something is happening even when
-   stale data is visible. */
-@keyframes blockchain-card-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 198, 176, 0); }
-  50%      { box-shadow: 0 0 0 6px rgba(255, 198, 176, 0.22); }
-}
-
-.blockchain-card--refreshing .website-info-container {
-  animation: blockchain-card-pulse 1.4s ease-in-out infinite;
-  border-radius: 14px;
-}
+/* Header no longer pulses during a background refresh — the refresh
+   indication is confined to the Stats panel only. */
 
 /* ── Neutral notice (persistent error) ── */
 
@@ -145,7 +136,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-family: var(--font-family-mono, 'JetBrains Mono', monospace);
+  font-family: var(--font-family-mono, "JetBrains Mono", monospace);
   font-size: 11px;
   font-weight: 700;
   color: var(--ds-muted);
@@ -243,7 +234,9 @@
   text-transform: uppercase;
   letter-spacing: 0.06em;
   cursor: pointer;
-  transition: background 0.15s ease, transform 0.15s ease;
+  transition:
+    background 0.15s ease,
+    transform 0.15s ease;
 }
 
 .validate-btn:hover:not(:disabled) {
@@ -259,7 +252,6 @@
 .credibility-analysis {
   margin-top: var(--spacing-md, 12px);
 }
-
 
 .trust-buttons-row .trust-page-button {
   flex: 1;
@@ -351,12 +343,22 @@
 /* ── Keyframes ── */
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes successPulse {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.05); }
-  100% { transform: scale(1); }
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+  100% {
+    transform: scale(1);
+  }
 }

--- a/apps/extension/components/ui/CartDrawer.tsx
+++ b/apps/extension/components/ui/CartDrawer.tsx
@@ -1,17 +1,17 @@
-import { useState, useRef } from "react"
-import { X, Trash2, ShoppingCart } from "lucide-react"
-import { VerbTag } from "@0xsofia/design-system"
-import type { IntentionSlug } from "@0xsofia/design-system"
+import { ShoppingCart } from "lucide-react"
+import { useRef } from "react"
+
 import { useCart, useCartSubmit } from "~/hooks"
-import type { IntentionType } from "~/types/intentionCategories"
-import { getIntentionBadge, predicateLabelToIntentionType } from "~/types/intentionCategories"
-import { TOPIC_LABELS, TOPIC_COLORS } from "~/lib/config/topicConfig"
+
 import { useRouter } from "../layout/RouterProvider"
-import WeightModal from "../modals/WeightModal"
 import BatchRewardContent from "../modals/reward/BatchRewardContent"
+import WeightModal from "../modals/WeightModal"
+
 import "../styles/BatchRewardModal.css"
+
 import type { ModalTriplet } from "~/hooks"
 import type { CartItemRecord } from "~/lib/database"
+
 import "../styles/CartDrawer.css"
 
 const hostFromUrl = (url: string): string => {
@@ -27,50 +27,49 @@ interface CartDrawerProps {
   onClose: () => void
 }
 
+/**
+ * Opening the cart goes straight to the Amplify ticket — there is no
+ * separate slide-up "cart list" surface anymore. The Amplify basket
+ * (.b3-basket) already lists every item with a per-row toggle (remove)
+ * and a weight selector, so it fully replaces the old drawer list.
+ * The legacy `.cart-drawer*` markup has been removed; only the post-tx
+ * reward handoff (BatchRewardContent) is stitched in on success.
+ */
 const CartDrawer = ({ isOpen, onClose }: CartDrawerProps) => {
-  const { items, count, atomsToCreate, removeFromCart, clearCart } = useCart()
+  const { items, atomsToCreate, removeFromCart } = useCart()
   const { submitCart, submitting, result, error, reset, clearSubmittedItems } =
     useCartSubmit()
   const { navigateTo, setMyProfileIntent } = useRouter()
-  const [showWeightModal, setShowWeightModal] = useState(false)
   const submittedItemsRef = useRef<CartItemRecord[]>([])
 
-  if (!isOpen) return null
-
-  const handleCertifyAll = () => {
-    // Save a snapshot of items before submission
+  const handleWeightSubmit = async (customWeights?: (bigint | null)[]) => {
+    // Snapshot the items being submitted — the post-tx reward handoff
+    // renders from this snapshot even after the cart is cleared.
     submittedItemsRef.current = [...items]
-    setShowWeightModal(true)
-  }
-
-  const handleWeightSubmit = async (
-    customWeights?: (bigint | null)[]
-  ) => {
     const weight = customWeights?.[0] ?? undefined
     await submitCart(items, weight ?? undefined)
   }
 
   /**
-   * Closes the WeightModal. When the tx succeeded, BatchRewardContent has been
-   * rendered inside the modal (Phase 3a stitching) and the user has now dismissed it
-   * via Done — so we also clear the submitted items and close the cart drawer.
-   * On cancel/error we just close the weight modal and keep the cart open.
+   * Closes the Amplify modal. On success the reward handoff has already
+   * been shown and dismissed (Done) — clear the submitted items. On
+   * cancel/error just close. In every case the cart closes (there is no
+   * drawer to fall back to).
    */
   const handleWeightClose = async () => {
-    setShowWeightModal(false)
     if (result?.success) {
       await clearSubmittedItems()
       submittedItemsRef.current = []
-      onClose()
     }
     reset()
+    onClose()
   }
 
   /**
    * Primary CTA on the post-tx reward screen.
    * Mono: navigate to MyProfile › Echoes and auto-open the matching group.
-   * Multi: navigate to MyProfile › Echoes (bento) and highlight every freshly-Marked domain.
-   * In both cases we clean up cart state and close the drawer, like a normal close.
+   * Multi: navigate to MyProfile › Echoes (bento) and highlight every
+   * freshly-Marked domain. Cleans up cart state and closes, like a close.
    */
   const handleViewEchoes = async () => {
     const submitted = submittedItemsRef.current
@@ -90,7 +89,6 @@ const CartDrawer = ({ isOpen, onClose }: CartDrawerProps) => {
       })
     }
 
-    setShowWeightModal(false)
     await clearSubmittedItems()
     submittedItemsRef.current = []
     reset()
@@ -99,216 +97,52 @@ const CartDrawer = ({ isOpen, onClose }: CartDrawerProps) => {
   }
 
   // Build modal triplets for WeightModal
-  const modalTriplets: ModalTriplet[] = items.map(item => {
-    return {
-      id: item.id,
-      triplet: {
-        subject: "You",
-        predicate: item.predicateName,
-        object: item.pageTitle || item.normalizedUrl
-      },
-      description: item.pageTitle || item.normalizedUrl,
-      url: item.url,
-      intention: item.intention ?? undefined,
-      interestContext: item.interestContext
-    }
-  })
+  const modalTriplets: ModalTriplet[] = items.map((item) => ({
+    id: item.id,
+    triplet: {
+      subject: "You",
+      predicate: item.predicateName,
+      object: item.pageTitle || item.normalizedUrl
+    },
+    description: item.pageTitle || item.normalizedUrl,
+    url: item.url,
+    intention: item.intention ?? undefined,
+    interestContext: item.interestContext
+  }))
+
+  if (!isOpen) return null
 
   return (
-    <>
-      {/* Cart Drawer */}
-      {isOpen && (
-        <div
-          className="cart-drawer-overlay"
-          onClick={(e) => {
-            if (e.target === e.currentTarget) onClose()
-          }}
-        >
-          <div className="cart-drawer">
-            {/* Header */}
-            <div className="cart-drawer__header">
-              <div className="cart-drawer__title">
-                Cart
-                <span className="cart-drawer__title-count">({count})</span>
-              </div>
-              <div className="cart-drawer__actions">
-                {count > 0 && (
-                  <button
-                    className="cart-drawer__clear-btn"
-                    onClick={clearCart}
-                  >
-                    Clear all
-                  </button>
-                )}
-                <button
-                  className="cart-drawer__close-btn"
-                  onClick={onClose}
-                >
-                  <X size={18} />
-                </button>
-              </div>
-            </div>
-
-            {/* Items */}
-            {count === 0 ? (
-              <div className="cart-drawer__empty">
-                <ShoppingCart size={40} className="cart-drawer__empty-icon" strokeWidth={1.5} />
-                <span className="cart-drawer__empty-text">
-                  Click intentions to add them here
-                </span>
-              </div>
-            ) : (
-              <div className="cart-drawer__list">
-                {items.map(item => {
-                  const intentionType: IntentionType | null = item.intention
-                    ? (item.intention.replace('for_', '') as IntentionType)
-                    : predicateLabelToIntentionType(item.predicateName)
-                  const badge = getIntentionBadge(item.intention ?? undefined)
-                    || (intentionType ? getIntentionBadge(intentionType) : null)
-                  const isVote = !!item.voteAction
-                  const hasContext = !!(item.interestContext && TOPIC_LABELS[item.interestContext])
-                  return (
-                    <div key={item.id} className="cart-drawer__item">
-                      {/* Top row: favicon + title/url + remove */}
-                      <div className="cart-drawer__item-main">
-                        {item.faviconUrl ? (
-                          <img
-                            src={item.faviconUrl}
-                            className="cart-drawer__item-favicon"
-                            alt=""
-                          />
-                        ) : (
-                          <div className="cart-drawer__item-favicon--fallback">
-                            ?
-                          </div>
-                        )}
-                        <div className="cart-drawer__item-info">
-                          <div className="cart-drawer__item-title">
-                            {item.pageTitle || item.normalizedUrl}
-                          </div>
-                          <div className="cart-drawer__item-url">
-                            {item.normalizedUrl}
-                          </div>
-                        </div>
-                        <button
-                          className="cart-drawer__item-remove"
-                          onClick={() => removeFromCart(item.id)}
-                          title="Remove from cart"
-                          aria-label="Remove from cart"
-                        >
-                          <Trash2 size={14} />
-                        </button>
-                      </div>
-
-                      {/* Bottom row: pills (intention/vote + topic context) */}
-                      {(isVote || badge || hasContext) && (
-                        <div className="cart-drawer__item-pills">
-                          {isVote ? (
-                            <span
-                              className={`cart-drawer__item-pill cart-drawer__item-pill--${item.voteAction}`}
-                            >
-                              {item.voteAction === "support" ? "▲ Support" : "▼ Oppose"}
-                            </span>
-                          ) : intentionType ? (
-                            <VerbTag
-                              intent={intentionType as IntentionSlug}
-                              label={badge?.label || intentionType}
-                            />
-                          ) : null}
-                          {hasContext && (
-                            <span
-                              className="cart-drawer__item-pill cart-drawer__item-pill--context"
-                              style={{
-                                background: TOPIC_COLORS[item.interestContext!] || "var(--ds-accent)"
-                              }}
-                            >
-                              {TOPIC_LABELS[item.interestContext!]}
-                            </span>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  )
-                })}
-              </div>
-            )}
-
-            {/* Footer */}
-            {count > 0 && (() => {
-              const certCount = items.filter(i => !i.voteAction).length
-              const voteItemCount = items.filter(i => !!i.voteAction).length
-              const hasVotes = voteItemCount > 0
-              const hasCerts = certCount > 0
-              const summary = [
-                hasCerts ? `${certCount} cert${certCount > 1 ? "s" : ""}` : "",
-                hasVotes ? `${voteItemCount} vote${voteItemCount > 1 ? "s" : ""}` : ""
-              ].filter(Boolean).join(" + ")
-              const btnLabel = hasVotes && !hasCerts
-                ? `Vote All (${count})`
-                : hasVotes
-                  ? `Submit All (${count})`
-                  : `Mark All (${count})`
-
-              return (
-                <div className="cart-drawer__footer">
-                  <div className="cart-drawer__fee-row">
-                    <span>{summary}</span>
-                    <span className="cart-drawer__fee-value">
-                      {hasCerts && hasVotes
-                        ? `${1 + voteItemCount} transaction${voteItemCount > 0 ? "s" : ""}`
-                        : hasVotes
-                          ? `${voteItemCount} transaction${voteItemCount > 1 ? "s" : ""}`
-                          : "1 transaction"}
-                    </span>
-                  </div>
-                  <button
-                    className="cart-drawer__submit-btn"
-                    onClick={handleCertifyAll}
-                    disabled={submitting}
-                  >
-                    {submitting ? "Processing..." : btnLabel}
-                  </button>
-                </div>
-              )
-            })()}
-          </div>
-        </div>
-      )}
-
-      {/* WeightModal — stitched with BatchRewardContent on success (Phase 3a) */}
-      {showWeightModal && (
-        <WeightModal
-          isOpen={showWeightModal}
-          triplets={modalTriplets}
-          isProcessing={submitting}
-          transactionSuccess={result?.success ?? false}
-          transactionError={error || undefined}
-          transactionHash={result?.txHash || undefined}
-          createdCount={result?.createdCount ?? 0}
-          depositCount={result?.depositCount ?? 0}
-          isIntentionCertification={true}
-          showXpAnimation={true}
-          estimateOptions={{
-            isNewTriple: true,
-            newAtomCount: atomsToCreate.newObjectAtoms,
-            newPredicateAtomCount: atomsToCreate.newPredicateAtoms,
-            needsContextPredicateAtom: atomsToCreate.needsContextPredicateAtom
-          }}
-          successContent={
-            <BatchRewardContent
-              items={submittedItemsRef.current}
-              txHash={result?.txHash}
-              onClose={handleWeightClose}
-              onViewEchoes={handleViewEchoes}
-              enabled={!!result?.success}
-            />
-          }
-          onRemoveTriplet={(tripletId) => removeFromCart(tripletId)}
+    <WeightModal
+      isOpen={isOpen}
+      triplets={modalTriplets}
+      isProcessing={submitting}
+      transactionSuccess={result?.success ?? false}
+      transactionError={error || undefined}
+      transactionHash={result?.txHash || undefined}
+      createdCount={result?.createdCount ?? 0}
+      depositCount={result?.depositCount ?? 0}
+      isIntentionCertification={true}
+      showXpAnimation={true}
+      estimateOptions={{
+        isNewTriple: true,
+        newAtomCount: atomsToCreate.newObjectAtoms,
+        newPredicateAtomCount: atomsToCreate.newPredicateAtoms,
+        needsContextPredicateAtom: atomsToCreate.needsContextPredicateAtom
+      }}
+      successContent={
+        <BatchRewardContent
+          items={submittedItemsRef.current}
+          txHash={result?.txHash}
           onClose={handleWeightClose}
-          onSubmit={handleWeightSubmit}
+          onViewEchoes={handleViewEchoes}
+          enabled={!!result?.success}
         />
-      )}
-    </>
+      }
+      onRemoveTriplet={(tripletId) => removeFromCart(tripletId)}
+      onClose={handleWeightClose}
+      onSubmit={handleWeightSubmit}
+    />
   )
 }
 

--- a/apps/extension/components/ui/GroupDetailView.tsx
+++ b/apps/extension/components/ui/GroupDetailView.tsx
@@ -4,41 +4,70 @@
  * Shows on-chain certification status and allows creating new certifications
  */
 
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
-import { createPortal } from 'react-dom'
-import {
-  useIntentionCertify, useRedeemTriple, useGroupOnChainCertifications, useLevelUp,
-  useDiscoveryReward, useDiscoveryScore, usePageDiscovery, useCart,
-  useTopicInterests, useUserCertifications, useWalletFromStorage, getCertificationForUrl,
-  type IntentionGroupWithStats, type UrlCertificationStatus, type LevelUpPreview
-} from '../../hooks'
-import type { UserTopicPosition } from '~/lib/services/TopicPositionsService'
-import type { CertificationEntry } from '~/lib/services/UserCertificationsService'
-import { InterestContextSelector } from './InterestContextSelector'
-import type { GroupUrlRecord } from '~types/database'
-import type { CertificationType } from '~/lib/services'
-import type { IntentionPurpose } from '../../types/discovery'
-import { INTENTION_PREDICATES } from '../../types/discovery'
-import { CERTIFICATION_LIST, INTENTION_ITEMS, TRUST_ITEMS } from '~/types/intentionCategories'
-import { TOPIC_LABELS, TOPIC_COLORS } from '~/lib/config/topicConfig'
-import { intuitionGraphqlClient } from '../../lib/clients/graphql-client'
-import WeightModal from '../modals/WeightModal'
-import { calculateLevel, calculateLevelProgress, getFaviconUrl, formatDuration, formatShortDate, intentionToCertification, getEffectiveCertStatus, getProfilePlatformUrl } from '~/lib/utils'
-import { createHookLogger } from '../../lib/utils/logger'
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { createPortal } from "react-dom"
 
-const logger = createHookLogger('GroupDetailView')
-import { cleanTitle, getDisplayTitle } from '../../lib/utils/cleanTitle'
-import { CartToast } from './CartDrawer'
-import '../styles/IntentionBubbleSelector.css'
+import { TOPIC_COLORS, TOPIC_LABELS } from "~/lib/config/topicConfig"
+import type { CertificationType } from "~/lib/services"
+import type { UserTopicPosition } from "~/lib/services/TopicPositionsService"
+import type { CertificationEntry } from "~/lib/services/UserCertificationsService"
+import {
+  calculateLevel,
+  calculateLevelProgress,
+  formatDuration,
+  formatShortDate,
+  getEffectiveCertStatus,
+  getFaviconUrl,
+  getProfilePlatformUrl,
+  intentionToCertification
+} from "~/lib/utils"
+import {
+  CERTIFICATION_LIST,
+  INTENTION_ITEMS,
+  TRUST_ITEMS
+} from "~/types/intentionCategories"
+import type { GroupUrlRecord } from "~types/database"
+
+import {
+  getCertificationForUrl,
+  useCart,
+  useDiscoveryReward,
+  useDiscoveryScore,
+  useGroupOnChainCertifications,
+  useIntentionCertify,
+  useLevelUp,
+  usePageDiscovery,
+  useRedeemTriple,
+  useTopicInterests,
+  useUserCertifications,
+  useWalletFromStorage,
+  type IntentionGroupWithStats,
+  type LevelUpPreview,
+  type UrlCertificationStatus
+} from "../../hooks"
+import { intuitionGraphqlClient } from "../../lib/clients/graphql-client"
+import { cleanTitle, getDisplayTitle } from "../../lib/utils/cleanTitle"
+import { createHookLogger } from "../../lib/utils/logger"
+import type { IntentionPurpose } from "../../types/discovery"
+import { INTENTION_PREDICATES } from "../../types/discovery"
+import WeightModal from "../modals/WeightModal"
+import { CartToast } from "./CartDrawer"
+import { InterestContextSelector } from "./InterestContextSelector"
+
+import "../styles/IntentionBubbleSelector.css"
+
+const logger = createHookLogger("GroupDetailView")
 
 interface GroupDetailViewProps {
   group: IntentionGroupWithStats
   onBack: () => void
-  onCertifyUrl: (url: string, certification: CertificationType) => Promise<boolean>
+  onCertifyUrl: (
+    url: string,
+    certification: CertificationType
+  ) => Promise<boolean>
   onRemoveUrl: (url: string) => Promise<boolean>
   onRefresh?: () => Promise<void>
 }
-
 
 // URL Row Component
 const UrlRow = ({
@@ -56,8 +85,16 @@ const UrlRow = ({
 }: {
   urlRecord: GroupUrlRecord
   onChainStatus?: UrlCertificationStatus
-  onAddToCart: (intention: IntentionPurpose, title?: string, context?: string | null) => void
-  onAddTrustToCart: (predicateName: string, title?: string, context?: string | null) => void
+  onAddToCart: (
+    intention: IntentionPurpose,
+    title?: string,
+    context?: string | null
+  ) => void
+  onAddTrustToCart: (
+    predicateName: string,
+    title?: string,
+    context?: string | null
+  ) => void
   onOAuthCertify: (urlRecord: GroupUrlRecord) => void
   onRemove: () => void
   isProcessing: boolean
@@ -78,7 +115,7 @@ const UrlRow = ({
     // not already in the cart.
     if (!slug) return
     for (const certLabel of allCertLabels) {
-      const intentionItem = INTENTION_ITEMS.find(i => i.type === certLabel)
+      const intentionItem = INTENTION_ITEMS.find((i) => i.type === certLabel)
       if (intentionItem) {
         const predicateName = INTENTION_PREDICATES[intentionItem.key]
         if (!cartPredicates.includes(predicateName)) {
@@ -86,7 +123,7 @@ const UrlRow = ({
         }
         continue
       }
-      const trustItem = TRUST_ITEMS.find(t => t.type === certLabel)
+      const trustItem = TRUST_ITEMS.find((t) => t.type === certLabel)
       if (trustItem && !cartPredicates.includes(trustItem.predicateLabel)) {
         onAddTrustToCart(trustItem.predicateLabel, urlRecord.title, slug)
       }
@@ -98,71 +135,75 @@ const UrlRow = ({
     getEffectiveCertStatus(urlRecord, onChainStatus)
 
   const allCertInfos = allCertLabels
-    .map(label => CERTIFICATION_LIST.find(c => c.type === label))
+    .map((label) => CERTIFICATION_LIST.find((c) => c.type === label))
     .filter(Boolean) as typeof CERTIFICATION_LIST
 
   const canToggle = !urlRecord.removed && !isProcessing
   const handleToggle = () => {
     if (!canToggle) return
-    setIsExpanded(prev => !prev)
+    setIsExpanded((prev) => !prev)
   }
 
   return (
-    <div className={`url-row ${urlRecord.removed ? 'removed' : ''} ${isExpanded ? 'expanded' : ''} ${isCertifiedOnChain ? 'on-chain' : ''}`}>
+    <div
+      className={`url-row ${urlRecord.removed ? "removed" : ""} ${isExpanded ? "expanded" : ""} ${isCertifiedOnChain ? "on-chain" : ""}`}>
       <div
         className="url-row-main"
         onClick={handleToggle}
-        role={canToggle ? 'button' : undefined}
+        role={canToggle ? "button" : undefined}
         tabIndex={canToggle ? 0 : undefined}
         onKeyDown={(e) => {
-          if (canToggle && (e.key === 'Enter' || e.key === ' ')) {
+          if (canToggle && (e.key === "Enter" || e.key === " ")) {
             e.preventDefault()
             handleToggle()
           }
         }}
-        style={{ cursor: canToggle ? 'pointer' : 'default' }}
-      >
+        style={{ cursor: canToggle ? "pointer" : "default" }}>
         <div className="url-info">
           <a
             href={urlRecord.url}
             target="_blank"
             rel="noopener noreferrer"
             className="url-title"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {urlRecord.title ? getDisplayTitle(urlRecord.title, urlRecord.url) : urlRecord.url}
+            onClick={(e) => e.stopPropagation()}>
+            {urlRecord.title
+              ? getDisplayTitle(urlRecord.title, urlRecord.url)
+              : urlRecord.url}
           </a>
           <div className="url-meta">
-            {((isCertifiedOnChain && allCertInfos.length > 0) || certifiedContexts.length > 0) && (
+            {((isCertifiedOnChain && allCertInfos.length > 0) ||
+              certifiedContexts.length > 0) && (
               <div className="cert-badges">
                 {allCertInfos.map((certInfo) => (
                   <span
                     key={certInfo.type}
                     className="cert-badge on-chain"
                     style={{ backgroundColor: certInfo.color }}
-                    title={`Marked as ${certInfo.label} (on-chain)`}
-                  >
+                    title={`Marked as ${certInfo.label} (on-chain)`}>
                     {certInfo.label}
                   </span>
                 ))}
                 {certifiedContexts.map((slug) => {
                   const label = TOPIC_LABELS[slug] || slug
-                  const color = TOPIC_COLORS[slug] || 'var(--ds-accent)'
+                  const color = TOPIC_COLORS[slug] || "var(--ds-accent)"
                   return (
                     <span
                       key={`ctx-${slug}`}
                       className="cert-badge cert-badge--context"
-                      style={{ backgroundColor: color }}
-                      title={`Marked in context of ${label}`}
-                    >
+                      style={{ color, borderColor: color }}
+                      title={`Marked in context of ${label}`}>
                       {label}
                     </span>
                   )
                 })}
               </div>
             )}
-            <span className="url-date">{formatShortDate(urlRecord.addedAt)}</span>
-            <span className="url-duration">{formatDuration(urlRecord.attentionTime)}</span>
+            <span className="url-date">
+              {formatShortDate(urlRecord.addedAt)}
+            </span>
+            <span className="url-duration">
+              {formatDuration(urlRecord.attentionTime)}
+            </span>
           </div>
         </div>
 
@@ -170,10 +211,17 @@ const UrlRow = ({
           {!urlRecord.removed && (
             <>
               <span
-                className={`url-chevron ${isExpanded ? 'expanded' : ''}`}
-                aria-hidden="true"
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                className={`url-chevron ${isExpanded ? "expanded" : ""}`}
+                aria-hidden="true">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round">
                   <path d="m6 9 6 6 6-6" />
                 </svg>
               </span>
@@ -185,8 +233,7 @@ const UrlRow = ({
                 }}
                 disabled={isProcessing}
                 title="Remove URL"
-                aria-label="Remove URL"
-              >
+                aria-label="Remove URL">
                 ×
               </button>
             </>
@@ -206,8 +253,7 @@ const UrlRow = ({
                   onOAuthCertify(urlRecord)
                   setIsExpanded(false)
                 }}
-                disabled={isProcessing}
-              >
+                disabled={isProcessing}>
                 {urlRecord.oauthPredicate}
               </button>
             )}
@@ -215,20 +261,30 @@ const UrlRow = ({
               const isAlreadyCertified = allCertLabels.includes(type)
               const isInCart = cartPredicates.includes(predicateLabel)
               const canDepositContext = isAlreadyCertified && !!selectedContext
-              const canAdd = !isInCart && (!isAlreadyCertified || canDepositContext)
+              const canAdd =
+                !isInCart && (!isAlreadyCertified || canDepositContext)
               return (
                 <button
                   key={type}
-                  className={`intention-pill intention-pill--${type} ${isAlreadyCertified ? 'certified' : ''} ${isInCart ? 'in-cart' : ''}`}
+                  className={`intention-pill intention-pill--${type} ${isAlreadyCertified ? "certified" : ""} ${isInCart ? "in-cart" : ""}`}
                   onClick={() => {
                     if (canAdd) {
-                      onAddTrustToCart(predicateLabel, urlRecord.title, selectedContext)
+                      onAddTrustToCart(
+                        predicateLabel,
+                        urlRecord.title,
+                        selectedContext
+                      )
                     }
                   }}
                   disabled={isProcessing || !canAdd}
-                  title={canDepositContext ? 'Deposit + add context' : undefined}
-                >
-                  {isInCart ? `${label} ✓` : canDepositContext ? `+ ${label}` : label}
+                  title={
+                    canDepositContext ? "Deposit + add context" : undefined
+                  }>
+                  {isInCart
+                    ? `${label} ✓`
+                    : canDepositContext
+                      ? `+ ${label}`
+                      : label}
                 </button>
               )
             })}
@@ -237,20 +293,26 @@ const UrlRow = ({
               const predicateName = INTENTION_PREDICATES[key]
               const isInCart = cartPredicates.includes(predicateName)
               const canDepositContext = isAlreadyCertified && !!selectedContext
-              const canAdd = !isInCart && (!isAlreadyCertified || canDepositContext)
+              const canAdd =
+                !isInCart && (!isAlreadyCertified || canDepositContext)
               return (
                 <button
                   key={key}
-                  className={`intention-pill intention-pill--${type} ${isAlreadyCertified ? 'certified' : ''} ${isInCart ? 'in-cart' : ''}`}
+                  className={`intention-pill intention-pill--${type} ${isAlreadyCertified ? "certified" : ""} ${isInCart ? "in-cart" : ""}`}
                   onClick={() => {
                     if (canAdd) {
                       onAddToCart(key, urlRecord.title, selectedContext)
                     }
                   }}
                   disabled={isProcessing || !canAdd}
-                  title={canDepositContext ? 'Deposit + add context' : undefined}
-                >
-                  {isInCart ? `${label} ✓` : canDepositContext ? `+ ${label}` : label}
+                  title={
+                    canDepositContext ? "Deposit + add context" : undefined
+                  }>
+                  {isInCart
+                    ? `${label} ✓`
+                    : canDepositContext
+                      ? `+ ${label}`
+                      : label}
                 </button>
               )
             })}
@@ -270,10 +332,20 @@ const UrlRow = ({
   )
 }
 
-const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }: GroupDetailViewProps) => {
+const GroupDetailView = ({
+  group,
+  onBack,
+  onCertifyUrl,
+  onRemoveUrl,
+  onRefresh
+}: GroupDetailViewProps) => {
   const [processingUrls, setProcessingUrls] = useState<Set<string>>(new Set())
-  const [filter, setFilter] = useState<'all' | 'uncertified' | CertificationType>('all')
-  const [levelUpPreview, setLevelUpPreview] = useState<LevelUpPreview | null>(null)
+  const [filter, setFilter] = useState<
+    "all" | "uncertified" | CertificationType
+  >("all")
+  const [levelUpPreview, setLevelUpPreview] = useState<LevelUpPreview | null>(
+    null
+  )
 
   // Cart
   const cart = useCart()
@@ -286,7 +358,10 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
   const getCertifiedContexts = useCallback(
     (url: string): string[] => {
       if (certifications.size === 0) return []
-      const entry: CertificationEntry | null = getCertificationForUrl(certifications, url)
+      const entry: CertificationEntry | null = getCertificationForUrl(
+        certifications,
+        url
+      )
       return entry?.interestContexts ?? []
     },
     [certifications]
@@ -294,7 +369,7 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
 
   // Get active URLs for on-chain query - memoize to prevent unnecessary refetches
   const activeUrls = useMemo(
-    () => group.urls.filter(u => !u.removed).map(u => u.url),
+    () => group.urls.filter((u) => !u.removed).map((u) => u.url),
     [group.urls]
   )
 
@@ -324,12 +399,13 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
   const [pendingCertification, setPendingCertification] = useState<{
     url: string
     intention: IntentionPurpose
-    oauthPredicate?: string  // For OAuth URLs, use this predicate directly instead of intention
-    title?: string           // Page title for atom name
+    oauthPredicate?: string // For OAuth URLs, use this predicate directly instead of intention
+    title?: string // Page title for atom name
   } | null>(null)
 
   // Discovery reward hooks (same pattern as PageBlockchainCard)
-  const { claimDiscoveryGold, refetch: refetchDiscoveryScore } = useDiscoveryScore()
+  const { claimDiscoveryGold, refetch: refetchDiscoveryScore } =
+    useDiscoveryScore()
   const reward = useDiscoveryReward()
   const {
     totalCertifications: pendingUrlCertCount,
@@ -378,8 +454,8 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
   // Get cart predicates for a specific URL
   const getCartPredicatesForUrl = (url: string): string[] => {
     return cart.items
-      .filter(item => item.url === url)
-      .map(item => item.predicateName)
+      .filter((item) => item.url === url)
+      .map((item) => item.predicateName)
   }
 
   // Auto-dismiss cart toast
@@ -408,8 +484,8 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
     // Count from Pipeline 2 (useGroupOnChainCertifications)
     const p2Count = onChainStats?.certifiedCount ?? 0
     // Count from Pipeline 1 fallback (urlRecord.onChainCertification)
-    const p1Count = group.urls.filter(u =>
-      !u.removed && u.isOnChain && u.onChainCertification
+    const p1Count = group.urls.filter(
+      (u) => !u.removed && u.isOnChain && u.onChainCertification
     ).length
     return Math.max(p2Count, p1Count, group.certifiedCount)
   }, [onChainStats, group.urls, group.certifiedCount])
@@ -429,7 +505,11 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
   // Handle level up
   const handleLevelUp = async () => {
     // Always pass certification breakdown from UI (has on-chain data)
-    const result = await levelUp(group.id, group.certificationBreakdown, currentLevel)
+    const result = await levelUp(
+      group.id,
+      group.certificationBreakdown,
+      currentLevel
+    )
     if (result.success) {
       // Refresh the preview after successful level up
       const newPreview = await previewLevelUp(group.id, currentLevel)
@@ -442,21 +522,25 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
   }
 
   // Progress toward NEXT level threshold
-  const { progressPercent, xpToNextLevel } = calculateLevelProgress(certifiedCount, currentLevel)
+  const { progressPercent, xpToNextLevel } = calculateLevelProgress(
+    certifiedCount,
+    currentLevel
+  )
 
   // Level Up available when on-chain level exceeds highest level with a generated predicate
-  const highestPredicateLevel = group.predicateHistory?.length > 0
-    ? Math.max(...group.predicateHistory.map(h => h.toLevel))
-    : 0
+  const highestPredicateLevel =
+    group.predicateHistory?.length > 0
+      ? Math.max(...group.predicateHistory.map((h) => h.toLevel))
+      : 0
   const canLevelUp = currentLevel > 1 && currentLevel > highestPredicateLevel
 
   // Filter URLs - use Pipeline 2 with Pipeline 1 fallback for trust/distrust
-  const filteredUrls = group.urls.filter(url => {
+  const filteredUrls = group.urls.filter((url) => {
     if (url.removed) return false
     const status = getEffectiveCertStatus(url, getUrlCertification(url.url))
 
-    if (filter === 'all') return true
-    if (filter === 'uncertified') return !status.isCertified
+    if (filter === "all") return true
+    if (filter === "uncertified") return !status.isCertified
     return status.labels.includes(filter)
   })
 
@@ -464,12 +548,11 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
   const sortedUrls = [...filteredUrls].sort((a, b) => b.addedAt - a.addedAt)
 
   // Calculate uncertified count using Pipeline 2 + Pipeline 1 fallback
-  const uncertifiedCount = group.urls.filter(u => {
+  const uncertifiedCount = group.urls.filter((u) => {
     if (u.removed) return false
     const status = getEffectiveCertStatus(u, getUrlCertification(u.url))
     return !status.isCertified
   }).length
-
 
   // Handle OAuth certification - uses predicate from OAuth extraction
   const handleOAuthCertify = (urlRecord: GroupUrlRecord) => {
@@ -479,7 +562,7 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
     const triplet = {
       id: `oauth-${urlRecord.oauthPredicate}-${Date.now()}`,
       triplet: {
-        subject: 'I',
+        subject: "I",
         predicate: urlRecord.oauthPredicate,
         object: cleanTitle(urlRecord.title)
       },
@@ -490,7 +573,7 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
     // Store OAuth predicate to use the correct predicate on-chain
     setPendingCertification({
       url: urlRecord.url,
-      intention: 'for_fun', // Fallback only
+      intention: "for_fun", // Fallback only
       oauthPredicate: urlRecord.oauthPredicate,
       title: urlRecord.title
     })
@@ -500,32 +583,45 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
 
   // Handle modal submit - create on-chain triple
   const handleModalSubmit = async (customWeights?: (bigint | null)[]) => {
-    if (!pendingCertification || !customWeights || customWeights.length === 0) return
+    if (!pendingCertification || !customWeights || customWeights.length === 0)
+      return
 
     const { url, intention, oauthPredicate, title } = pendingCertification
 
     // Capture pre-certification count BEFORE the transaction
     prevDiscoveryTotalRef.current = pendingUrlCertCount
 
-    setProcessingUrls(prev => new Set(prev).add(url))
+    setProcessingUrls((prev) => new Set(prev).add(url))
 
     try {
       const weight = customWeights[0] || undefined
 
       // Use OAuth predicate if available, otherwise use intention predicate
       if (oauthPredicate) {
-        await certifyWithCustomPredicate(url, oauthPredicate, undefined, title, weight as bigint | undefined)
+        await certifyWithCustomPredicate(
+          url,
+          oauthPredicate,
+          undefined,
+          title,
+          weight as bigint | undefined
+        )
       } else {
-        await certifyWithIntention(url, intention, title, weight as bigint | undefined)
+        await certifyWithIntention(
+          url,
+          intention,
+          title,
+          weight as bigint | undefined
+        )
       }
 
       // Also update local database
-      const certification = oauthPredicate || intentionToCertification[intention]
+      const certification =
+        oauthPredicate || intentionToCertification[intention]
       await onCertifyUrl(url, certification as CertificationType)
 
       // Wait for GraphQL indexer to process the transaction before refetching
       // The indexer typically needs 2-5 seconds to index new transactions
-      await new Promise(resolve => setTimeout(resolve, 3000))
+      await new Promise((resolve) => setTimeout(resolve, 3000))
 
       // Clear GraphQL cache to force fresh data
       intuitionGraphqlClient.clearCache()
@@ -545,9 +641,9 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
         await onRefresh()
       }
     } catch (error) {
-      logger.error('Certification failed', error)
+      logger.error("Certification failed", error)
     } finally {
-      setProcessingUrls(prev => {
+      setProcessingUrls((prev) => {
         const newSet = new Set(prev)
         newSet.delete(url)
         return newSet
@@ -568,13 +664,20 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
     const onChainStatus = getUrlCertification(url)
 
     // If URL is certified on-chain, redeem positions first
-    if (onChainStatus?.isCertifiedOnChain && onChainStatus.tripleDetails?.length) {
-      const confirmed = confirm('This will redeem your position and withdraw your stake. Continue?')
+    if (
+      onChainStatus?.isCertifiedOnChain &&
+      onChainStatus.tripleDetails?.length
+    ) {
+      const confirmed = confirm(
+        "This will redeem your position and withdraw your stake. Continue?"
+      )
       if (!confirmed) return
 
-      setProcessingUrls(prev => new Set(prev).add(url))
+      setProcessingUrls((prev) => new Set(prev).add(url))
       try {
-        const tripleVaultIds = onChainStatus.tripleDetails.map(t => t.tripleTermId)
+        const tripleVaultIds = onChainStatus.tripleDetails.map(
+          (t) => t.tripleTermId
+        )
         const result = await redeemAllPositions(tripleVaultIds)
 
         if (!result.success) {
@@ -586,12 +689,12 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
         await onRemoveUrl(url)
 
         // Wait for indexer then refresh on-chain data
-        await new Promise(resolve => setTimeout(resolve, 3000))
+        await new Promise((resolve) => setTimeout(resolve, 3000))
         intuitionGraphqlClient.clearCache()
         await refetchOnChain()
         if (onRefresh) await onRefresh()
       } finally {
-        setProcessingUrls(prev => {
+        setProcessingUrls((prev) => {
           const newSet = new Set(prev)
           newSet.delete(url)
           return newSet
@@ -601,11 +704,11 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
     }
 
     // Not certified on-chain: just remove locally
-    setProcessingUrls(prev => new Set(prev).add(url))
+    setProcessingUrls((prev) => new Set(prev).add(url))
     try {
       await onRemoveUrl(url)
     } finally {
-      setProcessingUrls(prev => {
+      setProcessingUrls((prev) => {
         const newSet = new Set(prev)
         newSet.delete(url)
         return newSet
@@ -618,7 +721,16 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
       {/* Header — back button on top row, domain title (large) below */}
       <div className="group-detail-header">
         <button className="pf-btn back-btn" onClick={onBack}>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true">
             <path d="m15 18-6-6 6-6" />
           </svg>
           Back to my Echoes
@@ -629,7 +741,7 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
             alt=""
             className="group-detail-favicon"
             onError={(e) => {
-              (e.target as HTMLImageElement).style.display = 'none'
+              ;(e.target as HTMLImageElement).style.display = "none"
             }}
           />
           <h2 className="group-detail-domain">{group.domain}</h2>
@@ -642,26 +754,29 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
               active: true
             })
           }
-          title={`View all my ${group.domain} Marks on Sofia`}
-        >
+          title={`View all my ${group.domain} Marks on Sofia`}>
           View all my {group.domain} Marks on Sofia ↗
         </button>
       </div>
 
       {/* Level Progress — sits above the stats, single source of level info */}
-      <div className={`level-progress-section ${canLevelUp && levelUpPreview?.canLevelUp ? 'ready-to-level-up' : ''}`}>
+      <div
+        className={`level-progress-section ${canLevelUp && levelUpPreview?.canLevelUp ? "ready-to-level-up" : ""}`}>
         {canLevelUp && levelUpPreview?.canLevelUp && !levelUpResult?.success ? (
           <button
             className="level-up-integrated-btn"
             onClick={handleLevelUp}
-            disabled={levelUpLoading}
-          >
+            disabled={levelUpLoading}>
             {levelUpLoading ? (
               <span className="loading-text">Generating signal...</span>
             ) : (
               <>
-                <span className="level-up-text">Level Up to {levelUpPreview.nextLevel}</span>
-                <span className="level-up-cost">{levelUpPreview.cost} Gold</span>
+                <span className="level-up-text">
+                  Level Up to {levelUpPreview.nextLevel}
+                </span>
+                <span className="level-up-cost">
+                  {levelUpPreview.cost} Gold
+                </span>
               </>
             )}
           </button>
@@ -670,11 +785,11 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
             <div className="level-progress-header">
               <span className="level-label">Level {currentLevel}</span>
               <span className="level-xp">
-                {onChainLoading ? '...' : (
-                  xpToNextLevel > 0
-                    ? `${xpToNextLevel} cert${xpToNextLevel > 1 ? 's' : ''} to Level ${currentLevel + 1}`
-                    : 'Max level!'
-                )}
+                {onChainLoading
+                  ? "..."
+                  : xpToNextLevel > 0
+                    ? `${xpToNextLevel} cert${xpToNextLevel > 1 ? "s" : ""} to Level ${currentLevel + 1}`
+                    : "Max level!"}
               </span>
             </div>
             <div className="progress-bar-container level-bar">
@@ -682,22 +797,25 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
                 className="progress-bar-fill"
                 style={{
                   width: `${progressPercent}%`,
-                  background: 'var(--ds-accent)'
+                  background: "var(--ds-accent)"
                 }}
               />
             </div>
             {levelUpResult?.success && (
               <div className="level-up-success-inline">
-                <span className="success-icon" aria-hidden="true">🎉</span>
+                <span className="success-icon" aria-hidden="true">
+                  🎉
+                </span>
                 <span className="success-text">
-                  Level Up — new identity:{' '}
-                  <strong>I {levelUpResult.newPredicate} {group.domain}</strong>
+                  Level Up — new identity:{" "}
+                  <strong>
+                    I {levelUpResult.newPredicate} {group.domain}
+                  </strong>
                 </span>
                 <button
                   className="dismiss-btn"
                   onClick={resetLevelUp}
-                  aria-label="Dismiss"
-                >
+                  aria-label="Dismiss">
                   ×
                 </button>
               </div>
@@ -713,11 +831,15 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
           <span className="stat-text">URLs</span>
         </div>
         <div className="stat-card">
-          <span className="stat-number">{onChainLoading ? '...' : certifiedCount}</span>
+          <span className="stat-number">
+            {onChainLoading ? "..." : certifiedCount}
+          </span>
           <span className="stat-text">On-chain</span>
         </div>
         <div className="stat-card highlight">
-          <span className="stat-number">{onChainLoading ? '...' : uncertifiedCount}</span>
+          <span className="stat-number">
+            {onChainLoading ? "..." : uncertifiedCount}
+          </span>
           <span className="stat-text">To certify</span>
         </div>
       </div>
@@ -725,18 +847,16 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
       {/* Certification Filter */}
       <div className="filter-section">
         <button
-          className={`filter-btn ${filter === 'all' ? 'active' : ''}`}
-          onClick={() => setFilter('all')}
-        >
+          className={`filter-btn ${filter === "all" ? "active" : ""}`}
+          onClick={() => setFilter("all")}>
           All ({group.activeUrlCount})
         </button>
         <button
-          className={`filter-btn filter-btn--uncertified ${filter === 'uncertified' ? 'active' : ''}`}
-          onClick={() => setFilter('uncertified')}
-        >
+          className={`filter-btn filter-btn--uncertified ${filter === "uncertified" ? "active" : ""}`}
+          onClick={() => setFilter("uncertified")}>
           Uncertified ({uncertifiedCount})
         </button>
-        {CERTIFICATION_LIST.map(cert => {
+        {CERTIFICATION_LIST.map((cert) => {
           // Count from Pipeline 2 + Pipeline 1 fallback
           let count = 0
           for (const u of group.urls) {
@@ -748,9 +868,8 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
           return (
             <button
               key={cert.type}
-              className={`filter-btn ${filter === cert.type ? 'active' : ''}`}
-              onClick={() => setFilter(cert.type)}
-            >
+              className={`filter-btn ${filter === cert.type ? "active" : ""}`}
+              onClick={() => setFilter(cert.type)}>
               <span
                 className="filter-btn-dot"
                 aria-hidden="true"
@@ -769,20 +888,33 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
             <p>No URLs match the filter</p>
           </div>
         ) : (
-          sortedUrls.map(urlRecord => (
+          sortedUrls.map((urlRecord) => (
             <UrlRow
               key={urlRecord.url}
               urlRecord={urlRecord}
               onChainStatus={getUrlCertification(urlRecord.url)}
-              onAddToCart={(intention, title, context) => handleAddToCart(urlRecord.url, intention, title, context)}
-              onAddTrustToCart={(predicateName, title, context) => handleAddTrustToCart(urlRecord.url, predicateName, title, context)}
+              onAddToCart={(intention, title, context) =>
+                handleAddToCart(urlRecord.url, intention, title, context)
+              }
+              onAddTrustToCart={(predicateName, title, context) =>
+                handleAddTrustToCart(
+                  urlRecord.url,
+                  predicateName,
+                  title,
+                  context
+                )
+              }
               onOAuthCertify={handleOAuthCertify}
               onRemove={() => handleRemove(urlRecord.url)}
-              isProcessing={processingUrls.has(urlRecord.url) || intentionLoading}
+              isProcessing={
+                processingUrls.has(urlRecord.url) || intentionLoading
+              }
               cartPredicates={getCartPredicatesForUrl(urlRecord.url)}
               topInterests={topInterests}
               certifiedContexts={getCertifiedContexts(urlRecord.url)}
-              onContextChange={(context) => cart.updateContextForUrl(urlRecord.url, context)}
+              onContextChange={(context) =>
+                cart.updateContextForUrl(urlRecord.url, context)
+              }
             />
           ))
         )}
@@ -795,12 +927,16 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
           <div className="level-up-error">
             <span className="error-icon">⚠️</span>
             <span className="error-text">{levelUpResult.error}</span>
-            {levelUpResult.required && levelUpResult.available !== undefined && (
-              <span className="error-detail">
-                Need {levelUpResult.required} Gold, have {levelUpResult.available} Gold
-              </span>
-            )}
-            <button className="dismiss-btn" onClick={resetLevelUp}>×</button>
+            {levelUpResult.required &&
+              levelUpResult.available !== undefined && (
+                <span className="error-detail">
+                  Need {levelUpResult.required} Gold, have{" "}
+                  {levelUpResult.available} Gold
+                </span>
+              )}
+            <button className="dismiss-btn" onClick={resetLevelUp}>
+              ×
+            </button>
           </div>
         </div>
       )}
@@ -809,26 +945,27 @@ const GroupDetailView = ({ group, onBack, onCertifyUrl, onRemoveUrl, onRefresh }
       <CartToast message={cartToast} />
 
       {/* Weight Modal for on-chain certification (trust/distrust/oauth) */}
-      {showWeightModal && createPortal(
-        <WeightModal
-          isOpen={showWeightModal}
-          triplets={modalTriplets}
-          isProcessing={intentionLoading}
-          transactionSuccess={intentionSuccess}
-          transactionError={intentionError || undefined}
-          transactionHash={intentionTxHash || undefined}
-          createdCount={intentionOperationType === 'created' ? 1 : 0}
-          depositCount={intentionOperationType === 'deposit' ? 1 : 0}
-          isIntentionCertification={true}
-          showXpAnimation={true}
-          discoveryReward={intentionSuccess ? reward.discoveryReward : null}
-          onClaimReward={() => reward.handleClaimReward(claimDiscoveryGold)}
-          rewardClaimed={reward.rewardClaimed}
-          onClose={handleModalClose}
-          onSubmit={handleModalSubmit}
-        />,
-        document.body
-      )}
+      {showWeightModal &&
+        createPortal(
+          <WeightModal
+            isOpen={showWeightModal}
+            triplets={modalTriplets}
+            isProcessing={intentionLoading}
+            transactionSuccess={intentionSuccess}
+            transactionError={intentionError || undefined}
+            transactionHash={intentionTxHash || undefined}
+            createdCount={intentionOperationType === "created" ? 1 : 0}
+            depositCount={intentionOperationType === "deposit" ? 1 : 0}
+            isIntentionCertification={true}
+            showXpAnimation={true}
+            discoveryReward={intentionSuccess ? reward.discoveryReward : null}
+            onClaimReward={() => reward.handleClaimReward(claimDiscoveryGold)}
+            rewardClaimed={reward.rewardClaimed}
+            onClose={handleModalClose}
+            onSubmit={handleModalSubmit}
+          />,
+          document.body
+        )}
     </div>
   )
 }

--- a/apps/extension/components/ui/PageBlockchainCard.tsx
+++ b/apps/extension/components/ui/PageBlockchainCard.tsx
@@ -29,12 +29,11 @@ import { useRouter } from "../layout/RouterProvider"
 import WeightModal from "../modals/WeightModal"
 import ExtendedMetricsPanel from "./blockchain/ExtendedMetricsPanel"
 import PageBlockchainHeader from "./blockchain/PageBlockchainHeader"
-import { CartToast } from "./CartDrawer"
 import { IntentionBubbleSelector } from "./IntentionBubbleSelector"
 import { InterestContextSelector } from "./InterestContextSelector"
 import PagePositionBoard from "./PagePositionBoard"
 import ShareCertificationButton from "./ShareCertificationButton"
-import { PageBlockchainSkeleton } from "./Skeleton"
+import { PageStatsSkeleton } from "./Skeleton"
 
 import "../styles/PageBlockchainCard.css"
 
@@ -126,7 +125,6 @@ const PageBlockchainCard = () => {
 
   // Cart
   const cart = useCart()
-  const [cartToast, setCartToast] = useState<string | null>(null)
   const [isBursting, setIsBursting] = useState(false)
 
   const cartIntentionsForPage = useMemo(() => {
@@ -167,7 +165,6 @@ const PageBlockchainCard = () => {
       )
       if (existing) {
         await cart.removeFromCart(existing.id)
-        setCartToast("Removed from cart")
         return
       }
       const favicon = getFaviconUrl(currentUrl, 128)
@@ -180,10 +177,7 @@ const PageBlockchainCard = () => {
         selectedContext
       )
       if (added) {
-        setCartToast("Added to cart")
         setIsBursting(true)
-      } else {
-        setCartToast("Already in cart")
       }
     },
     [currentUrl, pageTitle, cart, selectedContext]
@@ -198,9 +192,6 @@ const PageBlockchainCard = () => {
       )
       if (existing) {
         await cart.removeFromCart(existing.id)
-        setCartToast(
-          `Removed ${predicate === "trusts" ? "Trust" : "Distrust"} from cart`
-        )
         return
       }
       const favicon = getFaviconUrl(currentUrl, 128)
@@ -213,23 +204,11 @@ const PageBlockchainCard = () => {
         selectedContext
       )
       if (added) {
-        setCartToast(
-          `Added ${predicate === "trusts" ? "Trust" : "Distrust"} to cart`
-        )
         setIsBursting(true)
-      } else {
-        setCartToast("Already in cart")
       }
     },
     [currentUrl, pageTitle, cart, selectedContext]
   )
-
-  // Auto-dismiss toast
-  useEffect(() => {
-    if (!cartToast) return
-    const timer = setTimeout(() => setCartToast(null), 1500)
-    return () => clearTimeout(timer)
-  }, [cartToast])
 
   // Reset cart-burst animation flag once the animation has played
   useEffect(() => {
@@ -254,37 +233,6 @@ const PageBlockchainCard = () => {
   return (
     <div
       className={`blockchain-card ${isRefreshing ? "blockchain-card--refreshing" : ""} ${isBursting ? "blockchain-card--cart-burst" : ""}`}>
-      {/* Skeleton: first load or retrying. Share-on-X + Preview are kept
-          as the real components (empty state) instead of shimmer — the
-          page URL is tab-derived so they're usable before data loads. */}
-      {status === "loading" && (
-        <PageBlockchainSkeleton
-          shareSlot={
-            currentUrl && !isRestricted ? (
-              <ShareCertificationButton
-                pageUrl={currentUrl}
-                pageTitle={pageTitle}
-                userStatus={null}
-                userRank={null}
-                totalPositions={0}
-              />
-            ) : undefined
-          }
-          previewSlot={
-            currentUrl && !isRestricted ? (
-              <div className="cert-section live-sentence-section">
-                <div className="cert-section-title">Preview</div>
-                <div className="live-sentence">
-                  <span className="live-sentence__placeholder">
-                    Pick an intention to start building your signal…
-                  </span>
-                </div>
-              </div>
-            ) : undefined
-          }
-        />
-      )}
-
       {/* Persistent error after retries */}
       {status === "error" && (
         <div className="blockchain-card__notice">
@@ -299,8 +247,9 @@ const PageBlockchainCard = () => {
         </div>
       )}
 
-      {/* Main content: ready or refreshing (stale data visible) */}
-      {isReady && currentUrl && (
+      {/* Header + Actions render as soon as the tab URL is known — these
+          are fast/tab-derived. Only Stats waits on the on-chain data. */}
+      {currentUrl && (
         <div className="website-header-section">
           <PageBlockchainHeader
             currentUrl={currentUrl}
@@ -556,6 +505,16 @@ const PageBlockchainCard = () => {
         </div>
       )}
 
+      {/* Stats panel — the only section that waits on the on-chain data.
+          Shows a skeleton while loading, real panel once ready. */}
+      {status === "loading" && !isRestricted && (
+        <div className="credibility-content">
+          <div className="credibility-analysis">
+            <PageStatsSkeleton />
+          </div>
+        </div>
+      )}
+
       {/* Extended Panel */}
       {isReady && analysis && (
         <div className="credibility-content">
@@ -585,9 +544,6 @@ const PageBlockchainCard = () => {
           </div>
         </div>
       )}
-
-      {/* Cart toast notification */}
-      <CartToast message={cartToast} />
 
       {modal.showWeightModal &&
         createPortal(

--- a/apps/extension/components/ui/Skeleton.tsx
+++ b/apps/extension/components/ui/Skeleton.tsx
@@ -110,42 +110,51 @@ export const PageBlockchainSkeleton = ({
     </div>
 
     {/* Stats on this page */}
-    <div className="extended-metrics-panel blockchain-skeleton__metrics">
-      <div className="section-header">
-        <span className="section-title">Stats on this page</span>
-        <div className="scope-toggle">
-          <button className="scope-btn active" disabled>
-            Domain
-          </button>
-          <button className="scope-btn" disabled>
-            Page
-          </button>
-          <button className="scope-btn" disabled>
-            Certifiers
-          </button>
-          <button className="scope-btn" disabled>
-            Signals
-          </button>
+    <PageStatsSkeleton />
+  </div>
+)
+
+/**
+ * Stats-only skeleton. Rendered standalone in PageBlockchainCard so the
+ * website header + "Actions on this page" show immediately (tab-derived,
+ * fast) and only the Stats panel waits on the on-chain data.
+ */
+export const PageStatsSkeleton = () => (
+  <div className="extended-metrics-panel blockchain-skeleton__metrics">
+    <div className="section-header">
+      <span className="section-title">Stats on this page</span>
+      <div className="scope-toggle">
+        <button className="scope-btn active" disabled>
+          Domain
+        </button>
+        <button className="scope-btn" disabled>
+          Page
+        </button>
+        <button className="scope-btn" disabled>
+          Certifiers
+        </button>
+        <button className="scope-btn" disabled>
+          Signals
+        </button>
+      </div>
+    </div>
+    <div className="blockchain-skeleton__bars">
+      {[
+        { label: 56, count: 18 },
+        { label: 70, count: 18 },
+        { label: 44, count: 18 },
+        { label: 64, count: 18 },
+        { label: 36, count: 18 },
+        { label: 76, count: 18 },
+        { label: 56, count: 18 },
+        { label: 50, count: 18 }
+      ].map((row, idx) => (
+        <div key={idx} className="blockchain-skeleton__bar-row">
+          <SkeletonPill width={row.label} height={20} />
+          <div className="blockchain-skeleton__bar" />
+          <SkeletonLine width={row.count} height={11} />
         </div>
-      </div>
-      <div className="blockchain-skeleton__bars">
-        {[
-          { label: 56, count: 18 },
-          { label: 70, count: 18 },
-          { label: 44, count: 18 },
-          { label: 64, count: 18 },
-          { label: 36, count: 18 },
-          { label: 76, count: 18 },
-          { label: 56, count: 18 },
-          { label: 50, count: 18 }
-        ].map((row, idx) => (
-          <div key={idx} className="blockchain-skeleton__bar-row">
-            <SkeletonPill width={row.label} height={20} />
-            <div className="blockchain-skeleton__bar" />
-            <SkeletonLine width={row.count} height={11} />
-          </div>
-        ))}
-      </div>
+      ))}
     </div>
   </div>
 )

--- a/packages/graphql/schema.graphql
+++ b/packages/graphql/schema.graphql
@@ -4,11 +4,17 @@ schema {
   subscription: subscription_root
 }
 
-"""whether this query should be cached (Hasura Cloud only)"""
+"""
+whether this query should be cached (Hasura Cloud only)
+"""
 directive @cached(
-  """refresh the cache entry"""
+  """
+  refresh the cache entry
+  """
   refresh: Boolean! = false
-  """measured in seconds"""
+  """
+  measured in seconds
+  """
   ttl: Int! = 60
 ) on QUERY
 
@@ -260,7 +266,9 @@ input String_comparison_exp {
   _eq: String
   _gt: String
   _gte: String
-  """does the column match the given case-insensitive pattern"""
+  """
+  does the column match the given case-insensitive pattern
+  """
   _ilike: String
   _in: [String!]
   """
@@ -268,31 +276,41 @@ input String_comparison_exp {
   """
   _iregex: String
   _is_null: Boolean
-  """does the column match the given pattern"""
+  """
+  does the column match the given pattern
+  """
   _like: String
   _lt: String
   _lte: String
   _neq: String
-  """does the column NOT match the given case-insensitive pattern"""
+  """
+  does the column NOT match the given case-insensitive pattern
+  """
   _nilike: String
   _nin: [String!]
   """
   does the column NOT match the given POSIX regular expression, case insensitive
   """
   _niregex: String
-  """does the column NOT match the given pattern"""
+  """
+  does the column NOT match the given pattern
+  """
   _nlike: String
   """
   does the column NOT match the given POSIX regular expression, case sensitive
   """
   _nregex: String
-  """does the column NOT match the given SQL regular expression"""
+  """
+  does the column NOT match the given SQL regular expression
+  """
   _nsimilar: String
   """
   does the column match the given POSIX regular expression, case sensitive
   """
   _regex: String
-  """does the column match the given SQL regular expression"""
+  """
+  does the column match the given SQL regular expression
+  """
   _similar: String
 }
 
@@ -362,7 +380,9 @@ type account_pnl_rank_aggregate_fields {
   variance: account_pnl_rank_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type account_pnl_rank_avg_fields {
   percentile: Float
   pnl_pct: Float
@@ -398,7 +418,9 @@ input account_pnl_rank_bool_exp {
   win_rate: numeric_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type account_pnl_rank_max_fields {
   account_id: String
   account_image: String
@@ -415,7 +437,9 @@ type account_pnl_rank_max_fields {
   win_rate: numeric
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type account_pnl_rank_min_fields {
   account_id: String
   account_image: String
@@ -432,7 +456,9 @@ type account_pnl_rank_min_fields {
   win_rate: numeric
 }
 
-"""Ordering options when selecting data from "account_pnl_rank"."""
+"""
+Ordering options when selecting data from "account_pnl_rank".
+"""
 input account_pnl_rank_order_by {
   account_id: order_by
   account_image: order_by
@@ -453,35 +479,63 @@ input account_pnl_rank_order_by {
 select columns of table "account_pnl_rank"
 """
 enum account_pnl_rank_select_column {
-  """column name"""
+  """
+  column name
+  """
   account_id
-  """column name"""
+  """
+  column name
+  """
   account_image
-  """column name"""
+  """
+  column name
+  """
   account_label
-  """column name"""
+  """
+  column name
+  """
   percentile
-  """column name"""
+  """
+  column name
+  """
   pnl_pct
-  """column name"""
+  """
+  column name
+  """
   rank
-  """column name"""
+  """
+  column name
+  """
   total_accounts
-  """column name"""
+  """
+  column name
+  """
   total_pnl_formatted
-  """column name"""
+  """
+  column name
+  """
   total_pnl_raw
-  """column name"""
+  """
+  column name
+  """
   total_position_count
-  """column name"""
+  """
+  column name
+  """
   total_volume_formatted
-  """column name"""
+  """
+  column name
+  """
   total_volume_raw
-  """column name"""
+  """
+  column name
+  """
   win_rate
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type account_pnl_rank_stddev_fields {
   percentile: Float
   pnl_pct: Float
@@ -495,7 +549,9 @@ type account_pnl_rank_stddev_fields {
   win_rate: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type account_pnl_rank_stddev_pop_fields {
   percentile: Float
   pnl_pct: Float
@@ -509,7 +565,9 @@ type account_pnl_rank_stddev_pop_fields {
   win_rate: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type account_pnl_rank_stddev_samp_fields {
   percentile: Float
   pnl_pct: Float
@@ -527,13 +585,19 @@ type account_pnl_rank_stddev_samp_fields {
 Streaming cursor of the table "account_pnl_rank"
 """
 input account_pnl_rank_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: account_pnl_rank_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input account_pnl_rank_stream_cursor_value_input {
   account_id: String
   account_image: String
@@ -550,7 +614,9 @@ input account_pnl_rank_stream_cursor_value_input {
   win_rate: numeric
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type account_pnl_rank_sum_fields {
   percentile: numeric
   pnl_pct: numeric
@@ -564,7 +630,9 @@ type account_pnl_rank_sum_fields {
   win_rate: numeric
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type account_pnl_rank_var_pop_fields {
   percentile: Float
   pnl_pct: Float
@@ -578,7 +646,9 @@ type account_pnl_rank_var_pop_fields {
   win_rate: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type account_pnl_rank_var_samp_fields {
   percentile: Float
   pnl_pct: Float
@@ -592,7 +662,9 @@ type account_pnl_rank_var_samp_fields {
   win_rate: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type account_pnl_rank_variance_fields {
   percentile: Float
   pnl_pct: Float
@@ -627,280 +699,530 @@ input account_type_comparison_exp {
 Blockchain accounts participating in the protocol, including users, atom wallets, and protocol vaults.
 """
 type accounts {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
-  """Optional reference to atom if this account represents an atom wallet."""
+  """
+  Optional reference to atom if this account represents an atom wallet.
+  """
   atom_id: String
-  """An array relationship"""
+  """
+  An array relationship
+  """
   atoms(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [atoms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [atoms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atoms_bool_exp
   ): [atoms!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   atoms_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [atoms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [atoms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atoms_bool_exp
   ): atoms_aggregate!
   cached_image: cached_images_cached_image
-  """An array relationship"""
+  """
+  An array relationship
+  """
   deposits_received(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): [deposits!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   deposits_received_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): deposits_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   deposits_sent(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): [deposits!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   deposits_sent_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): deposits_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   fee_transfers(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [fee_transfers_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [fee_transfers_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: fee_transfers_bool_exp
   ): [fee_transfers!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   fee_transfers_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [fee_transfers_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [fee_transfers_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: fee_transfers_bool_exp
   ): fee_transfers_aggregate!
-  """Account address (Ethereum address or atom wallet address)."""
+  """
+  Account address (Ethereum address or atom wallet address).
+  """
   id: String!
-  """Profile image URL for this account."""
+  """
+  Profile image URL for this account.
+  """
   image: String
   """
   Human-readable label for this account (ENS name, atom label, or address).
   """
   label: String!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   positions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   positions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   redemptions_received(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): [redemptions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   redemptions_received_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): redemptions_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   redemptions_sent(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): [redemptions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   redemptions_sent_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): redemptions_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   season2_iq_ledger_entries(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_iq_ledger_entries_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_iq_ledger_entries_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_iq_ledger_entries_bool_exp
   ): [season2_iq_ledger_entries!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   season2_iq_ledger_entries_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_iq_ledger_entries_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_iq_ledger_entries_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_iq_ledger_entries_bool_exp
   ): season2_iq_ledger_entries_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   signals(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): [signals!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   signals_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): signals_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   triples(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): [triples!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   triples_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): triples_aggregate!
-  """Classification of account type (Default, AtomWallet, ProtocolVault)."""
+  """
+  Classification of account type (Default, AtomWallet, ProtocolVault).
+  """
   type: account_type!
 }
 
@@ -976,19 +1298,29 @@ input accounts_bool_exp {
   type: account_type_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type accounts_max_fields {
-  """Optional reference to atom if this account represents an atom wallet."""
+  """
+  Optional reference to atom if this account represents an atom wallet.
+  """
   atom_id: String
-  """Account address (Ethereum address or atom wallet address)."""
+  """
+  Account address (Ethereum address or atom wallet address).
+  """
   id: String
-  """Profile image URL for this account."""
+  """
+  Profile image URL for this account.
+  """
   image: String
   """
   Human-readable label for this account (ENS name, atom label, or address).
   """
   label: String
-  """Classification of account type (Default, AtomWallet, ProtocolVault)."""
+  """
+  Classification of account type (Default, AtomWallet, ProtocolVault).
+  """
   type: account_type
 }
 
@@ -996,33 +1328,51 @@ type accounts_max_fields {
 order by max() on columns of table "account"
 """
 input accounts_max_order_by {
-  """Optional reference to atom if this account represents an atom wallet."""
+  """
+  Optional reference to atom if this account represents an atom wallet.
+  """
   atom_id: order_by
-  """Account address (Ethereum address or atom wallet address)."""
+  """
+  Account address (Ethereum address or atom wallet address).
+  """
   id: order_by
-  """Profile image URL for this account."""
+  """
+  Profile image URL for this account.
+  """
   image: order_by
   """
   Human-readable label for this account (ENS name, atom label, or address).
   """
   label: order_by
-  """Classification of account type (Default, AtomWallet, ProtocolVault)."""
+  """
+  Classification of account type (Default, AtomWallet, ProtocolVault).
+  """
   type: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type accounts_min_fields {
-  """Optional reference to atom if this account represents an atom wallet."""
+  """
+  Optional reference to atom if this account represents an atom wallet.
+  """
   atom_id: String
-  """Account address (Ethereum address or atom wallet address)."""
+  """
+  Account address (Ethereum address or atom wallet address).
+  """
   id: String
-  """Profile image URL for this account."""
+  """
+  Profile image URL for this account.
+  """
   image: String
   """
   Human-readable label for this account (ENS name, atom label, or address).
   """
   label: String
-  """Classification of account type (Default, AtomWallet, ProtocolVault)."""
+  """
+  Classification of account type (Default, AtomWallet, ProtocolVault).
+  """
   type: account_type
 }
 
@@ -1030,21 +1380,31 @@ type accounts_min_fields {
 order by min() on columns of table "account"
 """
 input accounts_min_order_by {
-  """Optional reference to atom if this account represents an atom wallet."""
+  """
+  Optional reference to atom if this account represents an atom wallet.
+  """
   atom_id: order_by
-  """Account address (Ethereum address or atom wallet address)."""
+  """
+  Account address (Ethereum address or atom wallet address).
+  """
   id: order_by
-  """Profile image URL for this account."""
+  """
+  Profile image URL for this account.
+  """
   image: order_by
   """
   Human-readable label for this account (ENS name, atom label, or address).
   """
   label: order_by
-  """Classification of account type (Default, AtomWallet, ProtocolVault)."""
+  """
+  Classification of account type (Default, AtomWallet, ProtocolVault).
+  """
   type: order_by
 }
 
-"""Ordering options when selecting data from "account"."""
+"""
+Ordering options when selecting data from "account".
+"""
 input accounts_order_by {
   atom: atoms_order_by
   atom_id: order_by
@@ -1068,15 +1428,25 @@ input accounts_order_by {
 select columns of table "account"
 """
 enum accounts_select_column {
-  """column name"""
+  """
+  column name
+  """
   atom_id
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   image
-  """column name"""
+  """
+  column name
+  """
   label
-  """column name"""
+  """
+  column name
+  """
   type
 }
 
@@ -1084,25 +1454,39 @@ enum accounts_select_column {
 Streaming cursor of the table "accounts"
 """
 input accounts_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: accounts_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input accounts_stream_cursor_value_input {
-  """Optional reference to atom if this account represents an atom wallet."""
+  """
+  Optional reference to atom if this account represents an atom wallet.
+  """
   atom_id: String
-  """Account address (Ethereum address or atom wallet address)."""
+  """
+  Account address (Ethereum address or atom wallet address).
+  """
   id: String
-  """Profile image URL for this account."""
+  """
+  Profile image URL for this account.
+  """
   image: String
   """
   Human-readable label for this account (ENS name, atom label, or address).
   """
   label: String
-  """Classification of account type (Default, AtomWallet, ProtocolVault)."""
+  """
+  Classification of account type (Default, AtomWallet, ProtocolVault).
+  """
   type: account_type
 }
 
@@ -1144,45 +1528,85 @@ input atom_type_comparison_exp {
 Polymorphic reference table linking atoms to their typed value tables (person, thing, organization, etc.).
 """
 type atom_values {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   account: accounts
-  """Reference to account table if atom value is an Account."""
+  """
+  Reference to account table if atom value is an Account.
+  """
   account_id: String
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
-  """An object relationship"""
+  """
+  An object relationship
+  """
   book: books
-  """Reference to book table if atom value is a Book."""
+  """
+  Reference to book table if atom value is a Book.
+  """
   book_id: String
-  """An object relationship"""
+  """
+  An object relationship
+  """
   byte_object: byte_object
-  """Reference to byte_object table if atom value is binary data."""
+  """
+  Reference to byte_object table if atom value is binary data.
+  """
   byte_object_id: String
-  """An object relationship"""
+  """
+  An object relationship
+  """
   caip10: caip10
-  """Reference to caip10 table if atom value is a CAIP-10 account."""
+  """
+  Reference to caip10 table if atom value is a CAIP-10 account.
+  """
   caip10_id: String
-  """Unique identifier matching the atom value_id."""
+  """
+  Unique identifier matching the atom value_id.
+  """
   id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   json_object: json_objects
-  """Reference to json_object table if atom value is JSON data."""
+  """
+  Reference to json_object table if atom value is JSON data.
+  """
   json_object_id: String
-  """An object relationship"""
+  """
+  An object relationship
+  """
   organization: organizations
-  """Reference to organization table if atom value is an Organization."""
+  """
+  Reference to organization table if atom value is an Organization.
+  """
   organization_id: String
-  """An object relationship"""
+  """
+  An object relationship
+  """
   person: persons
-  """Reference to person table if atom value is a Person."""
+  """
+  Reference to person table if atom value is a Person.
+  """
   person_id: String
-  """An object relationship"""
+  """
+  An object relationship
+  """
   text_object: text_objects
-  """Reference to text_object table if atom value is plain text."""
+  """
+  Reference to text_object table if atom value is plain text.
+  """
   text_object_id: String
-  """An object relationship"""
+  """
+  An object relationship
+  """
   thing: things
-  """Reference to thing table if atom value is a Thing."""
+  """
+  Reference to thing table if atom value is a Thing.
+  """
   thing_id: String
 }
 
@@ -1232,55 +1656,101 @@ input atom_values_bool_exp {
   thing_id: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type atom_values_max_fields {
-  """Reference to account table if atom value is an Account."""
+  """
+  Reference to account table if atom value is an Account.
+  """
   account_id: String
-  """Reference to book table if atom value is a Book."""
+  """
+  Reference to book table if atom value is a Book.
+  """
   book_id: String
-  """Reference to byte_object table if atom value is binary data."""
+  """
+  Reference to byte_object table if atom value is binary data.
+  """
   byte_object_id: String
-  """Reference to caip10 table if atom value is a CAIP-10 account."""
+  """
+  Reference to caip10 table if atom value is a CAIP-10 account.
+  """
   caip10_id: String
-  """Unique identifier matching the atom value_id."""
+  """
+  Unique identifier matching the atom value_id.
+  """
   id: String
-  """Reference to json_object table if atom value is JSON data."""
+  """
+  Reference to json_object table if atom value is JSON data.
+  """
   json_object_id: String
-  """Reference to organization table if atom value is an Organization."""
+  """
+  Reference to organization table if atom value is an Organization.
+  """
   organization_id: String
-  """Reference to person table if atom value is a Person."""
+  """
+  Reference to person table if atom value is a Person.
+  """
   person_id: String
-  """Reference to text_object table if atom value is plain text."""
+  """
+  Reference to text_object table if atom value is plain text.
+  """
   text_object_id: String
-  """Reference to thing table if atom value is a Thing."""
+  """
+  Reference to thing table if atom value is a Thing.
+  """
   thing_id: String
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type atom_values_min_fields {
-  """Reference to account table if atom value is an Account."""
+  """
+  Reference to account table if atom value is an Account.
+  """
   account_id: String
-  """Reference to book table if atom value is a Book."""
+  """
+  Reference to book table if atom value is a Book.
+  """
   book_id: String
-  """Reference to byte_object table if atom value is binary data."""
+  """
+  Reference to byte_object table if atom value is binary data.
+  """
   byte_object_id: String
-  """Reference to caip10 table if atom value is a CAIP-10 account."""
+  """
+  Reference to caip10 table if atom value is a CAIP-10 account.
+  """
   caip10_id: String
-  """Unique identifier matching the atom value_id."""
+  """
+  Unique identifier matching the atom value_id.
+  """
   id: String
-  """Reference to json_object table if atom value is JSON data."""
+  """
+  Reference to json_object table if atom value is JSON data.
+  """
   json_object_id: String
-  """Reference to organization table if atom value is an Organization."""
+  """
+  Reference to organization table if atom value is an Organization.
+  """
   organization_id: String
-  """Reference to person table if atom value is a Person."""
+  """
+  Reference to person table if atom value is a Person.
+  """
   person_id: String
-  """Reference to text_object table if atom value is plain text."""
+  """
+  Reference to text_object table if atom value is plain text.
+  """
   text_object_id: String
-  """Reference to thing table if atom value is a Thing."""
+  """
+  Reference to thing table if atom value is a Thing.
+  """
   thing_id: String
 }
 
-"""Ordering options when selecting data from "atom_value"."""
+"""
+Ordering options when selecting data from "atom_value".
+"""
 input atom_values_order_by {
   account: accounts_order_by
   account_id: order_by
@@ -1308,25 +1778,45 @@ input atom_values_order_by {
 select columns of table "atom_value"
 """
 enum atom_values_select_column {
-  """column name"""
+  """
+  column name
+  """
   account_id
-  """column name"""
+  """
+  column name
+  """
   book_id
-  """column name"""
+  """
+  column name
+  """
   byte_object_id
-  """column name"""
+  """
+  column name
+  """
   caip10_id
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   json_object_id
-  """column name"""
+  """
+  column name
+  """
   organization_id
-  """column name"""
+  """
+  column name
+  """
   person_id
-  """column name"""
+  """
+  column name
+  """
   text_object_id
-  """column name"""
+  """
+  column name
+  """
   thing_id
 }
 
@@ -1334,33 +1824,59 @@ enum atom_values_select_column {
 Streaming cursor of the table "atom_values"
 """
 input atom_values_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: atom_values_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input atom_values_stream_cursor_value_input {
-  """Reference to account table if atom value is an Account."""
+  """
+  Reference to account table if atom value is an Account.
+  """
   account_id: String
-  """Reference to book table if atom value is a Book."""
+  """
+  Reference to book table if atom value is a Book.
+  """
   book_id: String
-  """Reference to byte_object table if atom value is binary data."""
+  """
+  Reference to byte_object table if atom value is binary data.
+  """
   byte_object_id: String
-  """Reference to caip10 table if atom value is a CAIP-10 account."""
+  """
+  Reference to caip10 table if atom value is a CAIP-10 account.
+  """
   caip10_id: String
-  """Unique identifier matching the atom value_id."""
+  """
+  Unique identifier matching the atom value_id.
+  """
   id: String
-  """Reference to json_object table if atom value is JSON data."""
+  """
+  Reference to json_object table if atom value is JSON data.
+  """
   json_object_id: String
-  """Reference to organization table if atom value is an Organization."""
+  """
+  Reference to organization table if atom value is an Organization.
+  """
   organization_id: String
-  """Reference to person table if atom value is a Person."""
+  """
+  Reference to person table if atom value is a Person.
+  """
   person_id: String
-  """Reference to text_object table if atom value is plain text."""
+  """
+  Reference to text_object table if atom value is plain text.
+  """
   text_object_id: String
-  """Reference to thing table if atom value is a Thing."""
+  """
+  Reference to thing table if atom value is a Thing.
+  """
   thing_id: String
 }
 
@@ -1368,258 +1884,486 @@ input atom_values_stream_cursor_value_input {
 Atomic data units with typed values (person, organization, thing, etc.) and metadata resolved from IPFS or blockchain.
 """
 type atoms {
-  """An array relationship"""
+  """
+  An array relationship
+  """
   accounts(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [accounts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [accounts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: accounts_bool_exp
   ): [accounts!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   accounts_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [accounts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [accounts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: accounts_bool_exp
   ): accounts_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   as_object_predicate_objects(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [predicate_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [predicate_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: predicate_objects_bool_exp
   ): [predicate_objects!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   as_object_predicate_objects_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [predicate_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [predicate_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: predicate_objects_bool_exp
   ): predicate_objects_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   as_object_triples(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): [triples!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   as_object_triples_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): triples_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   as_predicate_predicate_objects(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [predicate_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [predicate_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: predicate_objects_bool_exp
   ): [predicate_objects!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   as_predicate_predicate_objects_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [predicate_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [predicate_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: predicate_objects_bool_exp
   ): predicate_objects_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   as_predicate_triples(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): [triples!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   as_predicate_triples_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): triples_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   as_subject_triples(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): [triples!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   as_subject_triples_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): triples_aggregate!
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: numeric!
   cached_image: cached_images_cached_image
-  """An object relationship"""
+  """
+  An object relationship
+  """
   controller: accounts
-  """Timestamp when this atom was created."""
+  """
+  Timestamp when this atom was created.
+  """
   created_at: timestamptz!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   creator: accounts
-  """Account that created this atom via smart contract transaction."""
+  """
+  Account that created this atom via smart contract transaction.
+  """
   creator_id: String!
-  """Parsed and normalized data URI or value extracted from raw_data."""
+  """
+  Parsed and normalized data URI or value extracted from raw_data.
+  """
   data: String
-  """Optional emoji representation for UI display."""
+  """
+  Optional emoji representation for UI display.
+  """
   emoji: String
-  """URL to image representation, validated by image-guard service."""
+  """
+  URL to image representation, validated by image-guard service.
+  """
   image: String
-  """Human-readable label or title for this atom."""
+  """
+  Human-readable label or title for this atom.
+  """
   label: String
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   positions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   positions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
-  """Original data URI or value as emitted from the smart contract event."""
+  """
+  Original data URI or value as emitted from the smart contract event.
+  """
   raw_data: String!
-  """Current status of metadata resolution (Pending, Resolved, Failed)."""
+  """
+  Current status of metadata resolution (Pending, Resolved, Failed).
+  """
   resolving_status: atom_resolving_status!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   signals(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): [signals!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   signals_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): signals_aggregate!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: String!
-  """Transaction hash of the atom creation event."""
+  """
+  Transaction hash of the atom creation event.
+  """
   transaction_hash: String!
   """
   Classification of atom value type (Person, Organization, Thing, Caip10, etc.).
   """
   type: atom_type!
-  """Timestamp of last update, automatically maintained by trigger."""
+  """
+  Timestamp of last update, automatically maintained by trigger.
+  """
   updated_at: timestamptz!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   value: atom_values
   """
   Foreign key to polymorphic value table (person, organization, thing, etc.).
   """
   value_id: String
-  """Dedicated vault address for this atom, holds staked assets."""
+  """
+  Dedicated vault address for this atom, holds staked assets.
+  """
   wallet_id: String!
 }
 
@@ -1676,11 +2420,17 @@ input atoms_aggregate_order_by {
   variance: atoms_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type atoms_avg_fields {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
 }
 
@@ -1688,9 +2438,13 @@ type atoms_avg_fields {
 order by avg() on columns of table "atom"
 """
 input atoms_avg_order_by {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
 }
 
@@ -1739,43 +2493,73 @@ input atoms_bool_exp {
   wallet_id: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type atoms_max_fields {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: numeric
-  """Timestamp when this atom was created."""
+  """
+  Timestamp when this atom was created.
+  """
   created_at: timestamptz
-  """Account that created this atom via smart contract transaction."""
+  """
+  Account that created this atom via smart contract transaction.
+  """
   creator_id: String
-  """Parsed and normalized data URI or value extracted from raw_data."""
+  """
+  Parsed and normalized data URI or value extracted from raw_data.
+  """
   data: String
-  """Optional emoji representation for UI display."""
+  """
+  Optional emoji representation for UI display.
+  """
   emoji: String
-  """URL to image representation, validated by image-guard service."""
+  """
+  URL to image representation, validated by image-guard service.
+  """
   image: String
-  """Human-readable label or title for this atom."""
+  """
+  Human-readable label or title for this atom.
+  """
   label: String
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
-  """Original data URI or value as emitted from the smart contract event."""
+  """
+  Original data URI or value as emitted from the smart contract event.
+  """
   raw_data: String
-  """Current status of metadata resolution (Pending, Resolved, Failed)."""
+  """
+  Current status of metadata resolution (Pending, Resolved, Failed).
+  """
   resolving_status: atom_resolving_status
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: String
-  """Transaction hash of the atom creation event."""
+  """
+  Transaction hash of the atom creation event.
+  """
   transaction_hash: String
   """
   Classification of atom value type (Person, Organization, Thing, Caip10, etc.).
   """
   type: atom_type
-  """Timestamp of last update, automatically maintained by trigger."""
+  """
+  Timestamp of last update, automatically maintained by trigger.
+  """
   updated_at: timestamptz
   """
   Foreign key to polymorphic value table (person, organization, thing, etc.).
   """
   value_id: String
-  """Dedicated vault address for this atom, holds staked assets."""
+  """
+  Dedicated vault address for this atom, holds staked assets.
+  """
   wallet_id: String
 }
 
@@ -1783,81 +2567,139 @@ type atoms_max_fields {
 order by max() on columns of table "atom"
 """
 input atoms_max_order_by {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: order_by
-  """Timestamp when this atom was created."""
+  """
+  Timestamp when this atom was created.
+  """
   created_at: order_by
-  """Account that created this atom via smart contract transaction."""
+  """
+  Account that created this atom via smart contract transaction.
+  """
   creator_id: order_by
-  """Parsed and normalized data URI or value extracted from raw_data."""
+  """
+  Parsed and normalized data URI or value extracted from raw_data.
+  """
   data: order_by
-  """Optional emoji representation for UI display."""
+  """
+  Optional emoji representation for UI display.
+  """
   emoji: order_by
-  """URL to image representation, validated by image-guard service."""
+  """
+  URL to image representation, validated by image-guard service.
+  """
   image: order_by
-  """Human-readable label or title for this atom."""
+  """
+  Human-readable label or title for this atom.
+  """
   label: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Original data URI or value as emitted from the smart contract event."""
+  """
+  Original data URI or value as emitted from the smart contract event.
+  """
   raw_data: order_by
-  """Current status of metadata resolution (Pending, Resolved, Failed)."""
+  """
+  Current status of metadata resolution (Pending, Resolved, Failed).
+  """
   resolving_status: order_by
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: order_by
-  """Transaction hash of the atom creation event."""
+  """
+  Transaction hash of the atom creation event.
+  """
   transaction_hash: order_by
   """
   Classification of atom value type (Person, Organization, Thing, Caip10, etc.).
   """
   type: order_by
-  """Timestamp of last update, automatically maintained by trigger."""
+  """
+  Timestamp of last update, automatically maintained by trigger.
+  """
   updated_at: order_by
   """
   Foreign key to polymorphic value table (person, organization, thing, etc.).
   """
   value_id: order_by
-  """Dedicated vault address for this atom, holds staked assets."""
+  """
+  Dedicated vault address for this atom, holds staked assets.
+  """
   wallet_id: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type atoms_min_fields {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: numeric
-  """Timestamp when this atom was created."""
+  """
+  Timestamp when this atom was created.
+  """
   created_at: timestamptz
-  """Account that created this atom via smart contract transaction."""
+  """
+  Account that created this atom via smart contract transaction.
+  """
   creator_id: String
-  """Parsed and normalized data URI or value extracted from raw_data."""
+  """
+  Parsed and normalized data URI or value extracted from raw_data.
+  """
   data: String
-  """Optional emoji representation for UI display."""
+  """
+  Optional emoji representation for UI display.
+  """
   emoji: String
-  """URL to image representation, validated by image-guard service."""
+  """
+  URL to image representation, validated by image-guard service.
+  """
   image: String
-  """Human-readable label or title for this atom."""
+  """
+  Human-readable label or title for this atom.
+  """
   label: String
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
-  """Original data URI or value as emitted from the smart contract event."""
+  """
+  Original data URI or value as emitted from the smart contract event.
+  """
   raw_data: String
-  """Current status of metadata resolution (Pending, Resolved, Failed)."""
+  """
+  Current status of metadata resolution (Pending, Resolved, Failed).
+  """
   resolving_status: atom_resolving_status
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: String
-  """Transaction hash of the atom creation event."""
+  """
+  Transaction hash of the atom creation event.
+  """
   transaction_hash: String
   """
   Classification of atom value type (Person, Organization, Thing, Caip10, etc.).
   """
   type: atom_type
-  """Timestamp of last update, automatically maintained by trigger."""
+  """
+  Timestamp of last update, automatically maintained by trigger.
+  """
   updated_at: timestamptz
   """
   Foreign key to polymorphic value table (person, organization, thing, etc.).
   """
   value_id: String
-  """Dedicated vault address for this atom, holds staked assets."""
+  """
+  Dedicated vault address for this atom, holds staked assets.
+  """
   wallet_id: String
 }
 
@@ -1865,45 +2707,75 @@ type atoms_min_fields {
 order by min() on columns of table "atom"
 """
 input atoms_min_order_by {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: order_by
-  """Timestamp when this atom was created."""
+  """
+  Timestamp when this atom was created.
+  """
   created_at: order_by
-  """Account that created this atom via smart contract transaction."""
+  """
+  Account that created this atom via smart contract transaction.
+  """
   creator_id: order_by
-  """Parsed and normalized data URI or value extracted from raw_data."""
+  """
+  Parsed and normalized data URI or value extracted from raw_data.
+  """
   data: order_by
-  """Optional emoji representation for UI display."""
+  """
+  Optional emoji representation for UI display.
+  """
   emoji: order_by
-  """URL to image representation, validated by image-guard service."""
+  """
+  URL to image representation, validated by image-guard service.
+  """
   image: order_by
-  """Human-readable label or title for this atom."""
+  """
+  Human-readable label or title for this atom.
+  """
   label: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Original data URI or value as emitted from the smart contract event."""
+  """
+  Original data URI or value as emitted from the smart contract event.
+  """
   raw_data: order_by
-  """Current status of metadata resolution (Pending, Resolved, Failed)."""
+  """
+  Current status of metadata resolution (Pending, Resolved, Failed).
+  """
   resolving_status: order_by
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: order_by
-  """Transaction hash of the atom creation event."""
+  """
+  Transaction hash of the atom creation event.
+  """
   transaction_hash: order_by
   """
   Classification of atom value type (Person, Organization, Thing, Caip10, etc.).
   """
   type: order_by
-  """Timestamp of last update, automatically maintained by trigger."""
+  """
+  Timestamp of last update, automatically maintained by trigger.
+  """
   updated_at: order_by
   """
   Foreign key to polymorphic value table (person, organization, thing, etc.).
   """
   value_id: order_by
-  """Dedicated vault address for this atom, holds staked assets."""
+  """
+  Dedicated vault address for this atom, holds staked assets.
+  """
   wallet_id: order_by
 }
 
-"""Ordering options when selecting data from "atom"."""
+"""
+Ordering options when selecting data from "atom".
+"""
 input atoms_order_by {
   accounts_aggregate: accounts_aggregate_order_by
   as_object_predicate_objects_aggregate: predicate_objects_aggregate_order_by
@@ -1939,45 +2811,83 @@ input atoms_order_by {
 select columns of table "atom"
 """
 enum atoms_select_column {
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   creator_id
-  """column name"""
+  """
+  column name
+  """
   data
-  """column name"""
+  """
+  column name
+  """
   emoji
-  """column name"""
+  """
+  column name
+  """
   image
-  """column name"""
+  """
+  column name
+  """
   label
-  """column name"""
+  """
+  column name
+  """
   log_index
-  """column name"""
+  """
+  column name
+  """
   raw_data
-  """column name"""
+  """
+  column name
+  """
   resolving_status
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
-  """column name"""
+  """
+  column name
+  """
   type
-  """column name"""
+  """
+  column name
+  """
   updated_at
-  """column name"""
+  """
+  column name
+  """
   value_id
-  """column name"""
+  """
+  column name
+  """
   wallet_id
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type atoms_stddev_fields {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
 }
 
@@ -1985,17 +2895,27 @@ type atoms_stddev_fields {
 order by stddev() on columns of table "atom"
 """
 input atoms_stddev_order_by {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type atoms_stddev_pop_fields {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
 }
 
@@ -2003,17 +2923,27 @@ type atoms_stddev_pop_fields {
 order by stddev_pop() on columns of table "atom"
 """
 input atoms_stddev_pop_order_by {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type atoms_stddev_samp_fields {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
 }
 
@@ -2021,9 +2951,13 @@ type atoms_stddev_samp_fields {
 order by stddev_samp() on columns of table "atom"
 """
 input atoms_stddev_samp_order_by {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
 }
 
@@ -2031,57 +2965,97 @@ input atoms_stddev_samp_order_by {
 Streaming cursor of the table "atoms"
 """
 input atoms_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: atoms_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input atoms_stream_cursor_value_input {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: numeric
-  """Timestamp when this atom was created."""
+  """
+  Timestamp when this atom was created.
+  """
   created_at: timestamptz
-  """Account that created this atom via smart contract transaction."""
+  """
+  Account that created this atom via smart contract transaction.
+  """
   creator_id: String
-  """Parsed and normalized data URI or value extracted from raw_data."""
+  """
+  Parsed and normalized data URI or value extracted from raw_data.
+  """
   data: String
-  """Optional emoji representation for UI display."""
+  """
+  Optional emoji representation for UI display.
+  """
   emoji: String
-  """URL to image representation, validated by image-guard service."""
+  """
+  URL to image representation, validated by image-guard service.
+  """
   image: String
-  """Human-readable label or title for this atom."""
+  """
+  Human-readable label or title for this atom.
+  """
   label: String
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
-  """Original data URI or value as emitted from the smart contract event."""
+  """
+  Original data URI or value as emitted from the smart contract event.
+  """
   raw_data: String
-  """Current status of metadata resolution (Pending, Resolved, Failed)."""
+  """
+  Current status of metadata resolution (Pending, Resolved, Failed).
+  """
   resolving_status: atom_resolving_status
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: String
-  """Transaction hash of the atom creation event."""
+  """
+  Transaction hash of the atom creation event.
+  """
   transaction_hash: String
   """
   Classification of atom value type (Person, Organization, Thing, Caip10, etc.).
   """
   type: atom_type
-  """Timestamp of last update, automatically maintained by trigger."""
+  """
+  Timestamp of last update, automatically maintained by trigger.
+  """
   updated_at: timestamptz
   """
   Foreign key to polymorphic value table (person, organization, thing, etc.).
   """
   value_id: String
-  """Dedicated vault address for this atom, holds staked assets."""
+  """
+  Dedicated vault address for this atom, holds staked assets.
+  """
   wallet_id: String
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type atoms_sum_fields {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: numeric
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
 }
 
@@ -2089,17 +3063,27 @@ type atoms_sum_fields {
 order by sum() on columns of table "atom"
 """
 input atoms_sum_order_by {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type atoms_var_pop_fields {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
 }
 
@@ -2107,17 +3091,27 @@ type atoms_var_pop_fields {
 order by var_pop() on columns of table "atom"
 """
 input atoms_var_pop_order_by {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type atoms_var_samp_fields {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
 }
 
@@ -2125,17 +3119,27 @@ type atoms_var_samp_fields {
 order by var_samp() on columns of table "atom"
 """
 input atoms_var_samp_order_by {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type atoms_variance_fields {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
 }
 
@@ -2143,9 +3147,13 @@ type atoms_variance_fields {
 order by variance() on columns of table "atom"
 """
 input atoms_variance_order_by {
-  """Block number when this atom was created."""
+  """
+  Block number when this atom was created.
+  """
   block_number: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
 }
 
@@ -2166,19 +3174,33 @@ input bigint_comparison_exp {
   _nin: [bigint!]
 }
 
-"""Book entities following schema.org Book specification for atom values."""
+"""
+Book entities following schema.org Book specification for atom values.
+"""
 type books {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
-  """Description or synopsis of the book."""
+  """
+  Description or synopsis of the book.
+  """
   description: String
-  """Genre or category of the book."""
+  """
+  Genre or category of the book.
+  """
   genre: String
-  """Unique identifier for this book entity."""
+  """
+  Unique identifier for this book entity.
+  """
   id: String!
-  """Title of the book."""
+  """
+  Title of the book.
+  """
   name: String
-  """URL to book information or purchase page."""
+  """
+  URL to book information or purchase page.
+  """
   url: String
 }
 
@@ -2214,35 +3236,61 @@ input books_bool_exp {
   url: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type books_max_fields {
-  """Description or synopsis of the book."""
+  """
+  Description or synopsis of the book.
+  """
   description: String
-  """Genre or category of the book."""
+  """
+  Genre or category of the book.
+  """
   genre: String
-  """Unique identifier for this book entity."""
+  """
+  Unique identifier for this book entity.
+  """
   id: String
-  """Title of the book."""
+  """
+  Title of the book.
+  """
   name: String
-  """URL to book information or purchase page."""
+  """
+  URL to book information or purchase page.
+  """
   url: String
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type books_min_fields {
-  """Description or synopsis of the book."""
+  """
+  Description or synopsis of the book.
+  """
   description: String
-  """Genre or category of the book."""
+  """
+  Genre or category of the book.
+  """
   genre: String
-  """Unique identifier for this book entity."""
+  """
+  Unique identifier for this book entity.
+  """
   id: String
-  """Title of the book."""
+  """
+  Title of the book.
+  """
   name: String
-  """URL to book information or purchase page."""
+  """
+  URL to book information or purchase page.
+  """
   url: String
 }
 
-"""Ordering options when selecting data from "book"."""
+"""
+Ordering options when selecting data from "book".
+"""
 input books_order_by {
   atom: atoms_order_by
   description: order_by
@@ -2256,15 +3304,25 @@ input books_order_by {
 select columns of table "book"
 """
 enum books_select_column {
-  """column name"""
+  """
+  column name
+  """
   description
-  """column name"""
+  """
+  column name
+  """
   genre
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   name
-  """column name"""
+  """
+  column name
+  """
   url
 }
 
@@ -2272,33 +3330,57 @@ enum books_select_column {
 Streaming cursor of the table "books"
 """
 input books_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: books_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input books_stream_cursor_value_input {
-  """Description or synopsis of the book."""
+  """
+  Description or synopsis of the book.
+  """
   description: String
-  """Genre or category of the book."""
+  """
+  Genre or category of the book.
+  """
   genre: String
-  """Unique identifier for this book entity."""
+  """
+  Unique identifier for this book entity.
+  """
   id: String
-  """Title of the book."""
+  """
+  Title of the book.
+  """
   name: String
-  """URL to book information or purchase page."""
+  """
+  URL to book information or purchase page.
+  """
   url: String
 }
 
-"""Binary data storage for atom values containing raw byte arrays."""
+"""
+Binary data storage for atom values containing raw byte arrays.
+"""
 type byte_object {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
-  """Binary data stored as BYTEA."""
+  """
+  Binary data stored as BYTEA.
+  """
   data: bytea!
-  """Unique identifier for this byte object."""
+  """
+  Unique identifier for this byte object.
+  """
   id: String!
 }
 
@@ -2331,19 +3413,29 @@ input byte_object_bool_exp {
   id: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type byte_object_max_fields {
-  """Unique identifier for this byte object."""
+  """
+  Unique identifier for this byte object.
+  """
   id: String
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type byte_object_min_fields {
-  """Unique identifier for this byte object."""
+  """
+  Unique identifier for this byte object.
+  """
   id: String
 }
 
-"""Ordering options when selecting data from "byte_object"."""
+"""
+Ordering options when selecting data from "byte_object".
+"""
 input byte_object_order_by {
   atom: atoms_order_by
   data: order_by
@@ -2354,9 +3446,13 @@ input byte_object_order_by {
 select columns of table "byte_object"
 """
 enum byte_object_select_column {
-  """column name"""
+  """
+  column name
+  """
   data
-  """column name"""
+  """
+  column name
+  """
   id
 }
 
@@ -2364,17 +3460,27 @@ enum byte_object_select_column {
 Streaming cursor of the table "byte_object"
 """
 input byte_object_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: byte_object_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input byte_object_stream_cursor_value_input {
-  """Binary data stored as BYTEA."""
+  """
+  Binary data stored as BYTEA.
+  """
   data: bytea
-  """Unique identifier for this byte object."""
+  """
+  Unique identifier for this byte object.
+  """
   id: String
 }
 
@@ -2404,7 +3510,9 @@ type cached_images_cached_image {
   original_url: String!
   safe: Boolean!
   score(
-    """JSON select path"""
+    """
+    JSON select path
+    """
     path: String
   ): jsonb
   url: String!
@@ -2441,17 +3549,29 @@ input cached_images_cached_image_order_by {
 select columns of table "cached_images.cached_image"
 """
 enum cached_images_cached_image_select_column {
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   model
-  """column name"""
+  """
+  column name
+  """
   original_url
-  """column name"""
+  """
+  column name
+  """
   safe
-  """column name"""
+  """
+  column name
+  """
   score
-  """column name"""
+  """
+  column name
+  """
   url
 }
 
@@ -2459,13 +3579,19 @@ enum cached_images_cached_image_select_column {
 Streaming cursor of the table "cached_images_cached_image"
 """
 input cached_images_cached_image_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: cached_images_cached_image_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input cached_images_cached_image_stream_cursor_value_input {
   created_at: timestamptz
   model: String
@@ -2479,15 +3605,25 @@ input cached_images_cached_image_stream_cursor_value_input {
 Blockchain account identifiers following CAIP-10 standard (namespace:chain_id:address).
 """
 type caip10 {
-  """Account address on the specified blockchain."""
+  """
+  Account address on the specified blockchain.
+  """
   account_address: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Int!
-  """Unique identifier for this CAIP-10 account reference."""
+  """
+  Unique identifier for this CAIP-10 account reference.
+  """
   id: String!
-  """Blockchain namespace (e.g., "eip155" for Ethereum)."""
+  """
+  Blockchain namespace (e.g., "eip155" for Ethereum).
+  """
   namespace: String!
 }
 
@@ -2516,9 +3652,13 @@ type caip10_aggregate_fields {
   variance: caip10_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type caip10_avg_fields {
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Float
 }
 
@@ -2536,31 +3676,53 @@ input caip10_bool_exp {
   namespace: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type caip10_max_fields {
-  """Account address on the specified blockchain."""
+  """
+  Account address on the specified blockchain.
+  """
   account_address: String
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Int
-  """Unique identifier for this CAIP-10 account reference."""
+  """
+  Unique identifier for this CAIP-10 account reference.
+  """
   id: String
-  """Blockchain namespace (e.g., "eip155" for Ethereum)."""
+  """
+  Blockchain namespace (e.g., "eip155" for Ethereum).
+  """
   namespace: String
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type caip10_min_fields {
-  """Account address on the specified blockchain."""
+  """
+  Account address on the specified blockchain.
+  """
   account_address: String
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Int
-  """Unique identifier for this CAIP-10 account reference."""
+  """
+  Unique identifier for this CAIP-10 account reference.
+  """
   id: String
-  """Blockchain namespace (e.g., "eip155" for Ethereum)."""
+  """
+  Blockchain namespace (e.g., "eip155" for Ethereum).
+  """
   namespace: String
 }
 
-"""Ordering options when selecting data from "caip10"."""
+"""
+Ordering options when selecting data from "caip10".
+"""
 input caip10_order_by {
   account_address: order_by
   atom: atoms_order_by
@@ -2573,31 +3735,51 @@ input caip10_order_by {
 select columns of table "caip10"
 """
 enum caip10_select_column {
-  """column name"""
+  """
+  column name
+  """
   account_address
-  """column name"""
+  """
+  column name
+  """
   chain_id
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   namespace
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type caip10_stddev_fields {
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type caip10_stddev_pop_fields {
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type caip10_stddev_samp_fields {
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Float
 }
 
@@ -2605,53 +3787,89 @@ type caip10_stddev_samp_fields {
 Streaming cursor of the table "caip10"
 """
 input caip10_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: caip10_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input caip10_stream_cursor_value_input {
-  """Account address on the specified blockchain."""
+  """
+  Account address on the specified blockchain.
+  """
   account_address: String
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Int
-  """Unique identifier for this CAIP-10 account reference."""
+  """
+  Unique identifier for this CAIP-10 account reference.
+  """
   id: String
-  """Blockchain namespace (e.g., "eip155" for Ethereum)."""
+  """
+  Blockchain namespace (e.g., "eip155" for Ethereum).
+  """
   namespace: String
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type caip10_sum_fields {
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Int
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type caip10_var_pop_fields {
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type caip10_var_samp_fields {
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type caip10_variance_fields {
-  """Chain ID within the namespace (e.g., 1 for Ethereum mainnet)."""
+  """
+  Chain ID within the namespace (e.g., 1 for Ethereum mainnet).
+  """
   chain_id: Float
 }
 
-"""Chainlink oracle price feed data for USD-denominated asset pricing."""
+"""
+Chainlink oracle price feed data for USD-denominated asset pricing.
+"""
 type chainlink_prices {
-  """Block number or timestamp identifier for the price data point."""
+  """
+  Block number or timestamp identifier for the price data point.
+  """
   id: numeric!
-  """USD price value from Chainlink oracle feed."""
+  """
+  USD price value from Chainlink oracle feed.
+  """
   usd: float8
 }
 
@@ -2666,7 +3884,9 @@ input chainlink_prices_bool_exp {
   usd: float8_comparison_exp
 }
 
-"""Ordering options when selecting data from "chainlink_price"."""
+"""
+Ordering options when selecting data from "chainlink_price".
+"""
 input chainlink_prices_order_by {
   id: order_by
   usd: order_by
@@ -2676,9 +3896,13 @@ input chainlink_prices_order_by {
 select columns of table "chainlink_price"
 """
 enum chainlink_prices_select_column {
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   usd
 }
 
@@ -2686,25 +3910,41 @@ enum chainlink_prices_select_column {
 Streaming cursor of the table "chainlink_prices"
 """
 input chainlink_prices_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: chainlink_prices_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input chainlink_prices_stream_cursor_value_input {
-  """Block number or timestamp identifier for the price data point."""
+  """
+  Block number or timestamp identifier for the price data point.
+  """
   id: numeric
-  """USD price value from Chainlink oracle feed."""
+  """
+  USD price value from Chainlink oracle feed.
+  """
   usd: float8
 }
 
-"""ordering argument of a cursor"""
+"""
+ordering argument of a cursor
+"""
 enum cursor_ordering {
-  """ascending ordering of the cursor"""
+  """
+  ascending ordering of the cursor
+  """
   ASC
-  """descending ordering of the cursor"""
+  """
+  descending ordering of the cursor
+  """
   DESC
 }
 
@@ -2712,39 +3952,73 @@ enum cursor_ordering {
 Deposit transactions where users stake assets into vaults and receive shares in return.
 """
 type deposits {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: numeric!
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: numeric!
-  """Timestamp when deposit occurred."""
+  """
+  Timestamp when deposit occurred.
+  """
   created_at: timestamptz!
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric!
-  """Unique identifier for this deposit event."""
+  """
+  Unique identifier for this deposit event.
+  """
   id: String!
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   receiver: accounts
-  """Account that received the shares."""
+  """
+  Account that received the shares.
+  """
   receiver_id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   sender: accounts
-  """Account that initiated the deposit."""
+  """
+  Account that initiated the deposit.
+  """
   sender_id: String!
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: numeric!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
-  """Term ID of the vault receiving the deposit."""
+  """
+  Term ID of the vault receiving the deposit.
+  """
   term_id: String!
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: numeric!
-  """Transaction hash of the deposit event."""
+  """
+  Transaction hash of the deposit event.
+  """
   transaction_hash: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   vault: vaults
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type!
 }
 
@@ -2801,19 +4075,33 @@ input deposits_aggregate_order_by {
   variance: deposits_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type deposits_avg_fields {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: Float
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: Float
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: Float
 }
 
@@ -2821,17 +4109,29 @@ type deposits_avg_fields {
 order by avg() on columns of table "deposit"
 """
 input deposits_avg_order_by {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: order_by
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: order_by
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: order_by
 }
 
@@ -2861,33 +4161,61 @@ input deposits_bool_exp {
   vault_type: vault_type_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type deposits_max_fields {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: numeric
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: numeric
-  """Timestamp when deposit occurred."""
+  """
+  Timestamp when deposit occurred.
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Unique identifier for this deposit event."""
+  """
+  Unique identifier for this deposit event.
+  """
   id: String
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
-  """Account that received the shares."""
+  """
+  Account that received the shares.
+  """
   receiver_id: String
-  """Account that initiated the deposit."""
+  """
+  Account that initiated the deposit.
+  """
   sender_id: String
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: numeric
-  """Term ID of the vault receiving the deposit."""
+  """
+  Term ID of the vault receiving the deposit.
+  """
   term_id: String
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: numeric
-  """Transaction hash of the deposit event."""
+  """
+  Transaction hash of the deposit event.
+  """
   transaction_hash: String
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type
 }
 
@@ -2895,61 +4223,115 @@ type deposits_max_fields {
 order by max() on columns of table "deposit"
 """
 input deposits_max_order_by {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: order_by
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: order_by
-  """Timestamp when deposit occurred."""
+  """
+  Timestamp when deposit occurred.
+  """
   created_at: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Unique identifier for this deposit event."""
+  """
+  Unique identifier for this deposit event.
+  """
   id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Account that received the shares."""
+  """
+  Account that received the shares.
+  """
   receiver_id: order_by
-  """Account that initiated the deposit."""
+  """
+  Account that initiated the deposit.
+  """
   sender_id: order_by
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: order_by
-  """Term ID of the vault receiving the deposit."""
+  """
+  Term ID of the vault receiving the deposit.
+  """
   term_id: order_by
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: order_by
-  """Transaction hash of the deposit event."""
+  """
+  Transaction hash of the deposit event.
+  """
   transaction_hash: order_by
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type deposits_min_fields {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: numeric
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: numeric
-  """Timestamp when deposit occurred."""
+  """
+  Timestamp when deposit occurred.
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Unique identifier for this deposit event."""
+  """
+  Unique identifier for this deposit event.
+  """
   id: String
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
-  """Account that received the shares."""
+  """
+  Account that received the shares.
+  """
   receiver_id: String
-  """Account that initiated the deposit."""
+  """
+  Account that initiated the deposit.
+  """
   sender_id: String
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: numeric
-  """Term ID of the vault receiving the deposit."""
+  """
+  Term ID of the vault receiving the deposit.
+  """
   term_id: String
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: numeric
-  """Transaction hash of the deposit event."""
+  """
+  Transaction hash of the deposit event.
+  """
   transaction_hash: String
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type
 }
 
@@ -2957,35 +4339,63 @@ type deposits_min_fields {
 order by min() on columns of table "deposit"
 """
 input deposits_min_order_by {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: order_by
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: order_by
-  """Timestamp when deposit occurred."""
+  """
+  Timestamp when deposit occurred.
+  """
   created_at: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Unique identifier for this deposit event."""
+  """
+  Unique identifier for this deposit event.
+  """
   id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Account that received the shares."""
+  """
+  Account that received the shares.
+  """
   receiver_id: order_by
-  """Account that initiated the deposit."""
+  """
+  Account that initiated the deposit.
+  """
   sender_id: order_by
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: order_by
-  """Term ID of the vault receiving the deposit."""
+  """
+  Term ID of the vault receiving the deposit.
+  """
   term_id: order_by
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: order_by
-  """Transaction hash of the deposit event."""
+  """
+  Transaction hash of the deposit event.
+  """
   transaction_hash: order_by
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: order_by
 }
 
-"""Ordering options when selecting data from "deposit"."""
+"""
+Ordering options when selecting data from "deposit".
+"""
 input deposits_order_by {
   assets_after_fees: order_by
   block_number: order_by
@@ -3010,47 +4420,87 @@ input deposits_order_by {
 select columns of table "deposit"
 """
 enum deposits_select_column {
-  """column name"""
+  """
+  column name
+  """
   assets_after_fees
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   log_index
-  """column name"""
+  """
+  column name
+  """
   receiver_id
-  """column name"""
+  """
+  column name
+  """
   sender_id
-  """column name"""
+  """
+  column name
+  """
   shares
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   total_shares
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
-  """column name"""
+  """
+  column name
+  """
   vault_type
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type deposits_stddev_fields {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: Float
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: Float
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: Float
 }
 
@@ -3058,33 +4508,59 @@ type deposits_stddev_fields {
 order by stddev() on columns of table "deposit"
 """
 input deposits_stddev_order_by {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: order_by
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: order_by
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type deposits_stddev_pop_fields {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: Float
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: Float
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: Float
 }
 
@@ -3092,33 +4568,59 @@ type deposits_stddev_pop_fields {
 order by stddev_pop() on columns of table "deposit"
 """
 input deposits_stddev_pop_order_by {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: order_by
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: order_by
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type deposits_stddev_samp_fields {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: Float
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: Float
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: Float
 }
 
@@ -3126,17 +4628,29 @@ type deposits_stddev_samp_fields {
 order by stddev_samp() on columns of table "deposit"
 """
 input deposits_stddev_samp_order_by {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: order_by
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: order_by
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: order_by
 }
 
@@ -3144,55 +4658,101 @@ input deposits_stddev_samp_order_by {
 Streaming cursor of the table "deposits"
 """
 input deposits_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: deposits_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input deposits_stream_cursor_value_input {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: numeric
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: numeric
-  """Timestamp when deposit occurred."""
+  """
+  Timestamp when deposit occurred.
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Unique identifier for this deposit event."""
+  """
+  Unique identifier for this deposit event.
+  """
   id: String
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
-  """Account that received the shares."""
+  """
+  Account that received the shares.
+  """
   receiver_id: String
-  """Account that initiated the deposit."""
+  """
+  Account that initiated the deposit.
+  """
   sender_id: String
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: numeric
-  """Term ID of the vault receiving the deposit."""
+  """
+  Term ID of the vault receiving the deposit.
+  """
   term_id: String
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: numeric
-  """Transaction hash of the deposit event."""
+  """
+  Transaction hash of the deposit event.
+  """
   transaction_hash: String
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type deposits_sum_fields {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: numeric
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: numeric
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: numeric
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: numeric
 }
 
@@ -3200,33 +4760,59 @@ type deposits_sum_fields {
 order by sum() on columns of table "deposit"
 """
 input deposits_sum_order_by {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: order_by
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: order_by
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type deposits_var_pop_fields {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: Float
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: Float
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: Float
 }
 
@@ -3234,33 +4820,59 @@ type deposits_var_pop_fields {
 order by var_pop() on columns of table "deposit"
 """
 input deposits_var_pop_order_by {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: order_by
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: order_by
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type deposits_var_samp_fields {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: Float
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: Float
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: Float
 }
 
@@ -3268,33 +4880,59 @@ type deposits_var_samp_fields {
 order by var_samp() on columns of table "deposit"
 """
 input deposits_var_samp_order_by {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: order_by
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: order_by
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type deposits_variance_fields {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: Float
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: Float
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: Float
 }
 
@@ -3302,17 +4940,29 @@ type deposits_variance_fields {
 order by variance() on columns of table "deposit"
 """
 input deposits_variance_order_by {
-  """Asset amount deposited after protocol fees, in wei."""
+  """
+  Asset amount deposited after protocol fees, in wei.
+  """
   assets_after_fees: order_by
-  """Block number when deposit occurred."""
+  """
+  Block number when deposit occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares minted for this deposit."""
+  """
+  Number of shares minted for this deposit.
+  """
   shares: order_by
-  """Total shares in vault after this deposit."""
+  """
+  Total shares in vault after this deposit.
+  """
   total_shares: order_by
 }
 
@@ -3337,38 +4987,70 @@ input event_type_comparison_exp {
 Unified event log of all protocol operations for audit trail and historical analysis.
 """
 type events {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
-  """Reference to atom if event is AtomCreated."""
+  """
+  Reference to atom if event is AtomCreated.
+  """
   atom_id: String
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: numeric!
-  """Timestamp when event occurred."""
+  """
+  Timestamp when event occurred.
+  """
   created_at: timestamptz!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   deposit: deposits
-  """Reference to deposit if event is Deposited."""
+  """
+  Reference to deposit if event is Deposited.
+  """
   deposit_id: String
-  """An object relationship"""
+  """
+  An object relationship
+  """
   fee_transfer: fee_transfers
-  """Reference to fee_transfer if event is FeesTransfered."""
+  """
+  Reference to fee_transfer if event is FeesTransfered.
+  """
   fee_transfer_id: String
-  """Unique identifier for this event."""
+  """
+  Unique identifier for this event.
+  """
   id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   protocol_fee_accrued: protocol_fee_accruals
   protocol_fee_accrued_id: String
-  """An object relationship"""
+  """
+  An object relationship
+  """
   redemption: redemptions
-  """Reference to redemption if event is Redeemed."""
+  """
+  Reference to redemption if event is Redeemed.
+  """
   redemption_id: String
-  """Transaction hash of the event."""
+  """
+  Transaction hash of the event.
+  """
   transaction_hash: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   triple: triples
-  """Reference to triple if event is TripleCreated."""
+  """
+  Reference to triple if event is TripleCreated.
+  """
   triple_id: String
-  """Type of event (AtomCreated, TripleCreated, Deposited, Redeemed, etc.)."""
+  """
+  Type of event (AtomCreated, TripleCreated, Deposited, Redeemed, etc.).
+  """
   type: event_type!
 }
 
@@ -3397,9 +5079,13 @@ type events_aggregate_fields {
   variance: events_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type events_avg_fields {
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: Float
 }
 
@@ -3429,57 +5115,103 @@ input events_bool_exp {
   type: event_type_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type events_max_fields {
-  """Reference to atom if event is AtomCreated."""
+  """
+  Reference to atom if event is AtomCreated.
+  """
   atom_id: String
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: numeric
-  """Timestamp when event occurred."""
+  """
+  Timestamp when event occurred.
+  """
   created_at: timestamptz
-  """Reference to deposit if event is Deposited."""
+  """
+  Reference to deposit if event is Deposited.
+  """
   deposit_id: String
-  """Reference to fee_transfer if event is FeesTransfered."""
+  """
+  Reference to fee_transfer if event is FeesTransfered.
+  """
   fee_transfer_id: String
-  """Unique identifier for this event."""
+  """
+  Unique identifier for this event.
+  """
   id: String
   protocol_fee_accrued_id: String
-  """Reference to redemption if event is Redeemed."""
+  """
+  Reference to redemption if event is Redeemed.
+  """
   redemption_id: String
-  """Transaction hash of the event."""
+  """
+  Transaction hash of the event.
+  """
   transaction_hash: String
-  """Reference to triple if event is TripleCreated."""
+  """
+  Reference to triple if event is TripleCreated.
+  """
   triple_id: String
-  """Type of event (AtomCreated, TripleCreated, Deposited, Redeemed, etc.)."""
+  """
+  Type of event (AtomCreated, TripleCreated, Deposited, Redeemed, etc.).
+  """
   type: event_type
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type events_min_fields {
-  """Reference to atom if event is AtomCreated."""
+  """
+  Reference to atom if event is AtomCreated.
+  """
   atom_id: String
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: numeric
-  """Timestamp when event occurred."""
+  """
+  Timestamp when event occurred.
+  """
   created_at: timestamptz
-  """Reference to deposit if event is Deposited."""
+  """
+  Reference to deposit if event is Deposited.
+  """
   deposit_id: String
-  """Reference to fee_transfer if event is FeesTransfered."""
+  """
+  Reference to fee_transfer if event is FeesTransfered.
+  """
   fee_transfer_id: String
-  """Unique identifier for this event."""
+  """
+  Unique identifier for this event.
+  """
   id: String
   protocol_fee_accrued_id: String
-  """Reference to redemption if event is Redeemed."""
+  """
+  Reference to redemption if event is Redeemed.
+  """
   redemption_id: String
-  """Transaction hash of the event."""
+  """
+  Transaction hash of the event.
+  """
   transaction_hash: String
-  """Reference to triple if event is TripleCreated."""
+  """
+  Reference to triple if event is TripleCreated.
+  """
   triple_id: String
-  """Type of event (AtomCreated, TripleCreated, Deposited, Redeemed, etc.)."""
+  """
+  Type of event (AtomCreated, TripleCreated, Deposited, Redeemed, etc.).
+  """
   type: event_type
 }
 
-"""Ordering options when selecting data from "event"."""
+"""
+Ordering options when selecting data from "event".
+"""
 input events_order_by {
   atom: atoms_order_by
   atom_id: order_by
@@ -3504,45 +5236,79 @@ input events_order_by {
 select columns of table "event"
 """
 enum events_select_column {
-  """column name"""
+  """
+  column name
+  """
   atom_id
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   deposit_id
-  """column name"""
+  """
+  column name
+  """
   fee_transfer_id
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   protocol_fee_accrued_id
-  """column name"""
+  """
+  column name
+  """
   redemption_id
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
-  """column name"""
+  """
+  column name
+  """
   triple_id
-  """column name"""
+  """
+  column name
+  """
   type
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type events_stddev_fields {
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type events_stddev_pop_fields {
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type events_stddev_samp_fields {
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: Float
 }
 
@@ -3550,58 +5316,100 @@ type events_stddev_samp_fields {
 Streaming cursor of the table "events"
 """
 input events_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: events_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input events_stream_cursor_value_input {
-  """Reference to atom if event is AtomCreated."""
+  """
+  Reference to atom if event is AtomCreated.
+  """
   atom_id: String
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: numeric
-  """Timestamp when event occurred."""
+  """
+  Timestamp when event occurred.
+  """
   created_at: timestamptz
-  """Reference to deposit if event is Deposited."""
+  """
+  Reference to deposit if event is Deposited.
+  """
   deposit_id: String
-  """Reference to fee_transfer if event is FeesTransfered."""
+  """
+  Reference to fee_transfer if event is FeesTransfered.
+  """
   fee_transfer_id: String
-  """Unique identifier for this event."""
+  """
+  Unique identifier for this event.
+  """
   id: String
   protocol_fee_accrued_id: String
-  """Reference to redemption if event is Redeemed."""
+  """
+  Reference to redemption if event is Redeemed.
+  """
   redemption_id: String
-  """Transaction hash of the event."""
+  """
+  Transaction hash of the event.
+  """
   transaction_hash: String
-  """Reference to triple if event is TripleCreated."""
+  """
+  Reference to triple if event is TripleCreated.
+  """
   triple_id: String
-  """Type of event (AtomCreated, TripleCreated, Deposited, Redeemed, etc.)."""
+  """
+  Type of event (AtomCreated, TripleCreated, Deposited, Redeemed, etc.).
+  """
   type: event_type
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type events_sum_fields {
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: numeric
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type events_var_pop_fields {
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type events_var_samp_fields {
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type events_variance_fields {
-  """Block number when event occurred."""
+  """
+  Block number when event occurred.
+  """
   block_number: Float
 }
 
@@ -3609,23 +5417,41 @@ type events_variance_fields {
 Protocol fee transfers between accounts, emitted during deposit and redemption operations.
 """
 type fee_transfers {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: numeric!
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: numeric!
-  """Timestamp when fee was transferred."""
+  """
+  Timestamp when fee was transferred.
+  """
   created_at: timestamptz!
-  """Unique identifier for this fee transfer event."""
+  """
+  Unique identifier for this fee transfer event.
+  """
   id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   receiver: accounts
-  """Account that received the fee (typically protocol vault)."""
+  """
+  Account that received the fee (typically protocol vault).
+  """
   receiver_id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   sender: accounts
-  """Account that paid the fee."""
+  """
+  Account that paid the fee.
+  """
   sender_id: String!
-  """Transaction hash of the fee transfer event."""
+  """
+  Transaction hash of the fee transfer event.
+  """
   transaction_hash: String!
 }
 
@@ -3682,11 +5508,17 @@ input fee_transfers_aggregate_order_by {
   variance: fee_transfers_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type fee_transfers_avg_fields {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: Float
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: Float
 }
 
@@ -3694,9 +5526,13 @@ type fee_transfers_avg_fields {
 order by avg() on columns of table "fee_transfer"
 """
 input fee_transfers_avg_order_by {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: order_by
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: order_by
 }
 
@@ -3718,21 +5554,37 @@ input fee_transfers_bool_exp {
   transaction_hash: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type fee_transfers_max_fields {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: numeric
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: numeric
-  """Timestamp when fee was transferred."""
+  """
+  Timestamp when fee was transferred.
+  """
   created_at: timestamptz
-  """Unique identifier for this fee transfer event."""
+  """
+  Unique identifier for this fee transfer event.
+  """
   id: String
-  """Account that received the fee (typically protocol vault)."""
+  """
+  Account that received the fee (typically protocol vault).
+  """
   receiver_id: String
-  """Account that paid the fee."""
+  """
+  Account that paid the fee.
+  """
   sender_id: String
-  """Transaction hash of the fee transfer event."""
+  """
+  Transaction hash of the fee transfer event.
+  """
   transaction_hash: String
 }
 
@@ -3740,37 +5592,67 @@ type fee_transfers_max_fields {
 order by max() on columns of table "fee_transfer"
 """
 input fee_transfers_max_order_by {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: order_by
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: order_by
-  """Timestamp when fee was transferred."""
+  """
+  Timestamp when fee was transferred.
+  """
   created_at: order_by
-  """Unique identifier for this fee transfer event."""
+  """
+  Unique identifier for this fee transfer event.
+  """
   id: order_by
-  """Account that received the fee (typically protocol vault)."""
+  """
+  Account that received the fee (typically protocol vault).
+  """
   receiver_id: order_by
-  """Account that paid the fee."""
+  """
+  Account that paid the fee.
+  """
   sender_id: order_by
-  """Transaction hash of the fee transfer event."""
+  """
+  Transaction hash of the fee transfer event.
+  """
   transaction_hash: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type fee_transfers_min_fields {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: numeric
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: numeric
-  """Timestamp when fee was transferred."""
+  """
+  Timestamp when fee was transferred.
+  """
   created_at: timestamptz
-  """Unique identifier for this fee transfer event."""
+  """
+  Unique identifier for this fee transfer event.
+  """
   id: String
-  """Account that received the fee (typically protocol vault)."""
+  """
+  Account that received the fee (typically protocol vault).
+  """
   receiver_id: String
-  """Account that paid the fee."""
+  """
+  Account that paid the fee.
+  """
   sender_id: String
-  """Transaction hash of the fee transfer event."""
+  """
+  Transaction hash of the fee transfer event.
+  """
   transaction_hash: String
 }
 
@@ -3778,23 +5660,39 @@ type fee_transfers_min_fields {
 order by min() on columns of table "fee_transfer"
 """
 input fee_transfers_min_order_by {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: order_by
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: order_by
-  """Timestamp when fee was transferred."""
+  """
+  Timestamp when fee was transferred.
+  """
   created_at: order_by
-  """Unique identifier for this fee transfer event."""
+  """
+  Unique identifier for this fee transfer event.
+  """
   id: order_by
-  """Account that received the fee (typically protocol vault)."""
+  """
+  Account that received the fee (typically protocol vault).
+  """
   receiver_id: order_by
-  """Account that paid the fee."""
+  """
+  Account that paid the fee.
+  """
   sender_id: order_by
-  """Transaction hash of the fee transfer event."""
+  """
+  Transaction hash of the fee transfer event.
+  """
   transaction_hash: order_by
 }
 
-"""Ordering options when selecting data from "fee_transfer"."""
+"""
+Ordering options when selecting data from "fee_transfer".
+"""
 input fee_transfers_order_by {
   amount: order_by
   block_number: order_by
@@ -3811,27 +5709,47 @@ input fee_transfers_order_by {
 select columns of table "fee_transfer"
 """
 enum fee_transfers_select_column {
-  """column name"""
+  """
+  column name
+  """
   amount
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   receiver_id
-  """column name"""
+  """
+  column name
+  """
   sender_id
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type fee_transfers_stddev_fields {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: Float
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: Float
 }
 
@@ -3839,17 +5757,27 @@ type fee_transfers_stddev_fields {
 order by stddev() on columns of table "fee_transfer"
 """
 input fee_transfers_stddev_order_by {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: order_by
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type fee_transfers_stddev_pop_fields {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: Float
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: Float
 }
 
@@ -3857,17 +5785,27 @@ type fee_transfers_stddev_pop_fields {
 order by stddev_pop() on columns of table "fee_transfer"
 """
 input fee_transfers_stddev_pop_order_by {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: order_by
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type fee_transfers_stddev_samp_fields {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: Float
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: Float
 }
 
@@ -3875,9 +5813,13 @@ type fee_transfers_stddev_samp_fields {
 order by stddev_samp() on columns of table "fee_transfer"
 """
 input fee_transfers_stddev_samp_order_by {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: order_by
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: order_by
 }
 
@@ -3885,35 +5827,61 @@ input fee_transfers_stddev_samp_order_by {
 Streaming cursor of the table "fee_transfers"
 """
 input fee_transfers_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: fee_transfers_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input fee_transfers_stream_cursor_value_input {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: numeric
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: numeric
-  """Timestamp when fee was transferred."""
+  """
+  Timestamp when fee was transferred.
+  """
   created_at: timestamptz
-  """Unique identifier for this fee transfer event."""
+  """
+  Unique identifier for this fee transfer event.
+  """
   id: String
-  """Account that received the fee (typically protocol vault)."""
+  """
+  Account that received the fee (typically protocol vault).
+  """
   receiver_id: String
-  """Account that paid the fee."""
+  """
+  Account that paid the fee.
+  """
   sender_id: String
-  """Transaction hash of the fee transfer event."""
+  """
+  Transaction hash of the fee transfer event.
+  """
   transaction_hash: String
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type fee_transfers_sum_fields {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: numeric
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: numeric
 }
 
@@ -3921,17 +5889,27 @@ type fee_transfers_sum_fields {
 order by sum() on columns of table "fee_transfer"
 """
 input fee_transfers_sum_order_by {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: order_by
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type fee_transfers_var_pop_fields {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: Float
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: Float
 }
 
@@ -3939,17 +5917,27 @@ type fee_transfers_var_pop_fields {
 order by var_pop() on columns of table "fee_transfer"
 """
 input fee_transfers_var_pop_order_by {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: order_by
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type fee_transfers_var_samp_fields {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: Float
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: Float
 }
 
@@ -3957,17 +5945,27 @@ type fee_transfers_var_samp_fields {
 order by var_samp() on columns of table "fee_transfer"
 """
 input fee_transfers_var_samp_order_by {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: order_by
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type fee_transfers_variance_fields {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: Float
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: Float
 }
 
@@ -3975,9 +5973,13 @@ type fee_transfers_variance_fields {
 order by variance() on columns of table "fee_transfer"
 """
 input fee_transfers_variance_order_by {
-  """Fee amount transferred in wei."""
+  """
+  Fee amount transferred in wei.
+  """
   amount: order_by
-  """Block number when fee was transferred."""
+  """
+  Block number when fee was transferred.
+  """
   block_number: order_by
 }
 
@@ -4068,14 +6070,22 @@ input get_vault_leaderboard_args {
 Generic JSON storage for atom values that do not fit other typed schemas.
 """
 type json_objects {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
-  """JSONB data containing arbitrary structured content."""
+  """
+  JSONB data containing arbitrary structured content.
+  """
   data(
-    """JSON select path"""
+    """
+    JSON select path
+    """
     path: String
   ): jsonb!
-  """Unique identifier for this JSON object."""
+  """
+  Unique identifier for this JSON object.
+  """
   id: String!
 }
 
@@ -4108,19 +6118,29 @@ input json_objects_bool_exp {
   id: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type json_objects_max_fields {
-  """Unique identifier for this JSON object."""
+  """
+  Unique identifier for this JSON object.
+  """
   id: String
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type json_objects_min_fields {
-  """Unique identifier for this JSON object."""
+  """
+  Unique identifier for this JSON object.
+  """
   id: String
 }
 
-"""Ordering options when selecting data from "json_object"."""
+"""
+Ordering options when selecting data from "json_object".
+"""
 input json_objects_order_by {
   atom: atoms_order_by
   data: order_by
@@ -4131,9 +6151,13 @@ input json_objects_order_by {
 select columns of table "json_object"
 """
 enum json_objects_select_column {
-  """column name"""
+  """
+  column name
+  """
   data
-  """column name"""
+  """
+  column name
+  """
   id
 }
 
@@ -4141,17 +6165,27 @@ enum json_objects_select_column {
 Streaming cursor of the table "json_objects"
 """
 input json_objects_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: json_objects_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input json_objects_stream_cursor_value_input {
-  """JSONB data containing arbitrary structured content."""
+  """
+  JSONB data containing arbitrary structured content.
+  """
   data: jsonb
-  """Unique identifier for this JSON object."""
+  """
+  Unique identifier for this JSON object.
+  """
   id: String
 }
 
@@ -4166,18 +6200,28 @@ Boolean expression to compare columns of type "jsonb". All fields are combined w
 """
 input jsonb_comparison_exp {
   _cast: jsonb_cast_exp
-  """is the column contained in the given json value"""
+  """
+  is the column contained in the given json value
+  """
   _contained_in: jsonb
-  """does the column contain the given json value at the top level"""
+  """
+  does the column contain the given json value at the top level
+  """
   _contains: jsonb
   _eq: jsonb
   _gt: jsonb
   _gte: jsonb
-  """does the string exist as a top-level key in the column"""
+  """
+  does the string exist as a top-level key in the column
+  """
   _has_key: String
-  """do all of these strings exist as top-level keys in the column"""
+  """
+  do all of these strings exist as top-level keys in the column
+  """
   _has_keys_all: [String!]
-  """do any of these strings exist as top-level keys in the column"""
+  """
+  do any of these strings exist as top-level keys in the column
+  """
   _has_keys_any: [String!]
   _in: [jsonb!]
   _is_null: Boolean
@@ -4187,21 +6231,33 @@ input jsonb_comparison_exp {
   _nin: [jsonb!]
 }
 
-"""mutation root"""
+"""
+mutation root
+"""
 type mutation_root {
-  """Uploads and pins Organization to IPFS"""
+  """
+  Uploads and pins Organization to IPFS
+  """
   pinOrganization(organization: PinOrganizationInput!): PinOutput
-  """Uploads and pins Person to IPFS"""
+  """
+  Uploads and pins Person to IPFS
+  """
   pinPerson(person: PinPersonInput!): PinOutput
-  """Uploads and pins Thing to IPFS"""
+  """
+  Uploads and pins Thing to IPFS
+  """
   pinThing(thing: PinThingInput!): PinOutput
   """
   Uploads and classifies an image file using image-guard. Accepts base64-encoded image data. Note: The original /upload endpoint requires multipart/form-data which Hasura actions cannot construct directly. This mutation uses upload_image_from_url with a data URL workaround. For direct file uploads, use the image-guard API directly or create a wrapper endpoint.
   """
   uploadImage(image: UploadImageInput!): UploadImageFromUrlOutput
-  """Uploads and classifies an image from a URL using image-guard"""
+  """
+  Uploads and classifies an image from a URL using image-guard
+  """
   uploadImageFromUrl(image: UploadImageFromUrlInput!): UploadImageFromUrlOutput
-  """Uploads JSON to IPFS using image-guard"""
+  """
+  Uploads JSON to IPFS using image-guard
+  """
   uploadJsonToIpfs(json: jsonb!): UploadJsonToIpfsOutput
 }
 
@@ -4222,19 +6278,33 @@ input numeric_comparison_exp {
   _nin: [numeric!]
 }
 
-"""column ordering options"""
+"""
+column ordering options
+"""
 enum order_by {
-  """in ascending order, nulls last"""
+  """
+  in ascending order, nulls last
+  """
   asc
-  """in ascending order, nulls first"""
+  """
+  in ascending order, nulls first
+  """
   asc_nulls_first
-  """in ascending order, nulls last"""
+  """
+  in ascending order, nulls last
+  """
   asc_nulls_last
-  """in descending order, nulls first"""
+  """
+  in descending order, nulls first
+  """
   desc
-  """in descending order, nulls first"""
+  """
+  in descending order, nulls first
+  """
   desc_nulls_first
-  """in descending order, nulls last"""
+  """
+  in descending order, nulls last
+  """
   desc_nulls_last
 }
 
@@ -4242,19 +6312,33 @@ enum order_by {
 Organization entities following schema.org Organization specification for atom values.
 """
 type organizations {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
-  """Description or mission of the organization."""
+  """
+  Description or mission of the organization.
+  """
   description: String
-  """Contact email for the organization."""
+  """
+  Contact email for the organization.
+  """
   email: String
-  """Unique identifier for this organization entity."""
+  """
+  Unique identifier for this organization entity.
+  """
   id: String!
-  """Logo or image URL for the organization."""
+  """
+  Logo or image URL for the organization.
+  """
   image: String
-  """Name of the organization."""
+  """
+  Name of the organization.
+  """
   name: String
-  """Organization website URL."""
+  """
+  Organization website URL.
+  """
   url: String
 }
 
@@ -4291,39 +6375,69 @@ input organizations_bool_exp {
   url: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type organizations_max_fields {
-  """Description or mission of the organization."""
+  """
+  Description or mission of the organization.
+  """
   description: String
-  """Contact email for the organization."""
+  """
+  Contact email for the organization.
+  """
   email: String
-  """Unique identifier for this organization entity."""
+  """
+  Unique identifier for this organization entity.
+  """
   id: String
-  """Logo or image URL for the organization."""
+  """
+  Logo or image URL for the organization.
+  """
   image: String
-  """Name of the organization."""
+  """
+  Name of the organization.
+  """
   name: String
-  """Organization website URL."""
+  """
+  Organization website URL.
+  """
   url: String
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type organizations_min_fields {
-  """Description or mission of the organization."""
+  """
+  Description or mission of the organization.
+  """
   description: String
-  """Contact email for the organization."""
+  """
+  Contact email for the organization.
+  """
   email: String
-  """Unique identifier for this organization entity."""
+  """
+  Unique identifier for this organization entity.
+  """
   id: String
-  """Logo or image URL for the organization."""
+  """
+  Logo or image URL for the organization.
+  """
   image: String
-  """Name of the organization."""
+  """
+  Name of the organization.
+  """
   name: String
-  """Organization website URL."""
+  """
+  Organization website URL.
+  """
   url: String
 }
 
-"""Ordering options when selecting data from "organization"."""
+"""
+Ordering options when selecting data from "organization".
+"""
 input organizations_order_by {
   atom: atoms_order_by
   description: order_by
@@ -4338,17 +6452,29 @@ input organizations_order_by {
 select columns of table "organization"
 """
 enum organizations_select_column {
-  """column name"""
+  """
+  column name
+  """
   description
-  """column name"""
+  """
+  column name
+  """
   email
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   image
-  """column name"""
+  """
+  column name
+  """
   name
-  """column name"""
+  """
+  column name
+  """
   url
 }
 
@@ -4356,25 +6482,43 @@ enum organizations_select_column {
 Streaming cursor of the table "organizations"
 """
 input organizations_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: organizations_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input organizations_stream_cursor_value_input {
-  """Description or mission of the organization."""
+  """
+  Description or mission of the organization.
+  """
   description: String
-  """Contact email for the organization."""
+  """
+  Contact email for the organization.
+  """
   email: String
-  """Unique identifier for this organization entity."""
+  """
+  Unique identifier for this organization entity.
+  """
   id: String
-  """Logo or image URL for the organization."""
+  """
+  Logo or image URL for the organization.
+  """
   image: String
-  """Name of the organization."""
+  """
+  Name of the organization.
+  """
   name: String
-  """Organization website URL."""
+  """
+  Organization website URL.
+  """
   url: String
 }
 
@@ -4382,22 +6526,38 @@ input organizations_stream_cursor_value_input {
 Person entities following schema.org Person specification for atom values.
 """
 type persons {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
   cached_image: cached_images_cached_image
-  """Bio or description of the person."""
+  """
+  Bio or description of the person.
+  """
   description: String
-  """Email address of the person."""
+  """
+  Email address of the person.
+  """
   email: String
-  """Unique identifier for this person entity."""
+  """
+  Unique identifier for this person entity.
+  """
   id: String!
-  """External identifier (ENS name, DID, etc.) for the person."""
+  """
+  External identifier (ENS name, DID, etc.) for the person.
+  """
   identifier: String
-  """Profile image URL for the person."""
+  """
+  Profile image URL for the person.
+  """
   image: String
-  """Full name of the person."""
+  """
+  Full name of the person.
+  """
   name: String
-  """Personal website or homepage URL."""
+  """
+  Personal website or homepage URL.
+  """
   url: String
 }
 
@@ -4435,43 +6595,77 @@ input persons_bool_exp {
   url: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type persons_max_fields {
-  """Bio or description of the person."""
+  """
+  Bio or description of the person.
+  """
   description: String
-  """Email address of the person."""
+  """
+  Email address of the person.
+  """
   email: String
-  """Unique identifier for this person entity."""
+  """
+  Unique identifier for this person entity.
+  """
   id: String
-  """External identifier (ENS name, DID, etc.) for the person."""
+  """
+  External identifier (ENS name, DID, etc.) for the person.
+  """
   identifier: String
-  """Profile image URL for the person."""
+  """
+  Profile image URL for the person.
+  """
   image: String
-  """Full name of the person."""
+  """
+  Full name of the person.
+  """
   name: String
-  """Personal website or homepage URL."""
+  """
+  Personal website or homepage URL.
+  """
   url: String
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type persons_min_fields {
-  """Bio or description of the person."""
+  """
+  Bio or description of the person.
+  """
   description: String
-  """Email address of the person."""
+  """
+  Email address of the person.
+  """
   email: String
-  """Unique identifier for this person entity."""
+  """
+  Unique identifier for this person entity.
+  """
   id: String
-  """External identifier (ENS name, DID, etc.) for the person."""
+  """
+  External identifier (ENS name, DID, etc.) for the person.
+  """
   identifier: String
-  """Profile image URL for the person."""
+  """
+  Profile image URL for the person.
+  """
   image: String
-  """Full name of the person."""
+  """
+  Full name of the person.
+  """
   name: String
-  """Personal website or homepage URL."""
+  """
+  Personal website or homepage URL.
+  """
   url: String
 }
 
-"""Ordering options when selecting data from "person"."""
+"""
+Ordering options when selecting data from "person".
+"""
 input persons_order_by {
   atom: atoms_order_by
   description: order_by
@@ -4487,19 +6681,33 @@ input persons_order_by {
 select columns of table "person"
 """
 enum persons_select_column {
-  """column name"""
+  """
+  column name
+  """
   description
-  """column name"""
+  """
+  column name
+  """
   email
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   identifier
-  """column name"""
+  """
+  column name
+  """
   image
-  """column name"""
+  """
+  column name
+  """
   name
-  """column name"""
+  """
+  column name
+  """
   url
 }
 
@@ -4507,27 +6715,47 @@ enum persons_select_column {
 Streaming cursor of the table "persons"
 """
 input persons_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: persons_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input persons_stream_cursor_value_input {
-  """Bio or description of the person."""
+  """
+  Bio or description of the person.
+  """
   description: String
-  """Email address of the person."""
+  """
+  Email address of the person.
+  """
   email: String
-  """Unique identifier for this person entity."""
+  """
+  Unique identifier for this person entity.
+  """
   id: String
-  """External identifier (ENS name, DID, etc.) for the person."""
+  """
+  External identifier (ENS name, DID, etc.) for the person.
+  """
   identifier: String
-  """Profile image URL for the person."""
+  """
+  Profile image URL for the person.
+  """
   image: String
-  """Full name of the person."""
+  """
+  Full name of the person.
+  """
   name: String
-  """Personal website or homepage URL."""
+  """
+  Personal website or homepage URL.
+  """
   url: String
 }
 
@@ -4583,7 +6811,10 @@ aggregate fields of "pnl_leaderboard_entry"
 """
 type pnl_leaderboard_entry_aggregate_fields {
   avg: pnl_leaderboard_entry_avg_fields
-  count(columns: [pnl_leaderboard_entry_select_column!], distinct: Boolean): Int!
+  count(
+    columns: [pnl_leaderboard_entry_select_column!]
+    distinct: Boolean
+  ): Int!
   max: pnl_leaderboard_entry_max_fields
   min: pnl_leaderboard_entry_min_fields
   stddev: pnl_leaderboard_entry_stddev_fields
@@ -4595,7 +6826,9 @@ type pnl_leaderboard_entry_aggregate_fields {
   variance: pnl_leaderboard_entry_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type pnl_leaderboard_entry_avg_fields {
   active_position_count: Float
   best_trade_pnl_formatted: Float
@@ -4675,7 +6908,9 @@ input pnl_leaderboard_entry_bool_exp {
   worst_trade_pnl_raw: numeric_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type pnl_leaderboard_entry_max_fields {
   account_id: String
   account_image: String
@@ -4715,7 +6950,9 @@ type pnl_leaderboard_entry_max_fields {
   worst_trade_pnl_raw: numeric
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type pnl_leaderboard_entry_min_fields {
   account_id: String
   account_image: String
@@ -4755,7 +6992,9 @@ type pnl_leaderboard_entry_min_fields {
   worst_trade_pnl_raw: numeric
 }
 
-"""Ordering options when selecting data from "pnl_leaderboard_entry"."""
+"""
+Ordering options when selecting data from "pnl_leaderboard_entry".
+"""
 input pnl_leaderboard_entry_order_by {
   account_id: order_by
   account_image: order_by
@@ -4799,81 +7038,155 @@ input pnl_leaderboard_entry_order_by {
 select columns of table "pnl_leaderboard_entry"
 """
 enum pnl_leaderboard_entry_select_column {
-  """column name"""
+  """
+  column name
+  """
   account_id
-  """column name"""
+  """
+  column name
+  """
   account_image
-  """column name"""
+  """
+  column name
+  """
   account_label
-  """column name"""
+  """
+  column name
+  """
   active_position_count
-  """column name"""
+  """
+  column name
+  """
   best_trade_pnl_formatted
-  """column name"""
+  """
+  column name
+  """
   best_trade_pnl_raw
-  """column name"""
+  """
+  column name
+  """
   current_equity_value_formatted
-  """column name"""
+  """
+  column name
+  """
   current_equity_value_raw
-  """column name"""
+  """
+  column name
+  """
   first_position_at
-  """column name"""
+  """
+  column name
+  """
   last_activity_at
-  """column name"""
+  """
+  column name
+  """
   losing_positions
-  """column name"""
+  """
+  column name
+  """
   pnl_change_formatted
-  """column name"""
+  """
+  column name
+  """
   pnl_change_raw
-  """column name"""
+  """
+  column name
+  """
   pnl_pct
-  """column name"""
+  """
+  column name
+  """
   rank
-  """column name"""
+  """
+  column name
+  """
   realized_pnl_formatted
-  """column name"""
+  """
+  column name
+  """
   realized_pnl_pct
-  """column name"""
+  """
+  column name
+  """
   realized_pnl_raw
-  """column name"""
+  """
+  column name
+  """
   redeemable_assets_formatted
-  """column name"""
+  """
+  column name
+  """
   redeemable_assets_raw
-  """column name"""
+  """
+  column name
+  """
   total_deposits_formatted
-  """column name"""
+  """
+  column name
+  """
   total_deposits_raw
-  """column name"""
+  """
+  column name
+  """
   total_pnl_formatted
-  """column name"""
+  """
+  column name
+  """
   total_pnl_raw
-  """column name"""
+  """
+  column name
+  """
   total_position_count
-  """column name"""
+  """
+  column name
+  """
   total_redemptions_formatted
-  """column name"""
+  """
+  column name
+  """
   total_redemptions_raw
-  """column name"""
+  """
+  column name
+  """
   total_volume_formatted
-  """column name"""
+  """
+  column name
+  """
   total_volume_raw
-  """column name"""
+  """
+  column name
+  """
   unrealized_pnl_formatted
-  """column name"""
+  """
+  column name
+  """
   unrealized_pnl_pct
-  """column name"""
+  """
+  column name
+  """
   unrealized_pnl_raw
-  """column name"""
+  """
+  column name
+  """
   win_rate
-  """column name"""
+  """
+  column name
+  """
   winning_positions
-  """column name"""
+  """
+  column name
+  """
   worst_trade_pnl_formatted
-  """column name"""
+  """
+  column name
+  """
   worst_trade_pnl_raw
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type pnl_leaderboard_entry_stddev_fields {
   active_position_count: Float
   best_trade_pnl_formatted: Float
@@ -4908,7 +7221,9 @@ type pnl_leaderboard_entry_stddev_fields {
   worst_trade_pnl_raw: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type pnl_leaderboard_entry_stddev_pop_fields {
   active_position_count: Float
   best_trade_pnl_formatted: Float
@@ -4943,7 +7258,9 @@ type pnl_leaderboard_entry_stddev_pop_fields {
   worst_trade_pnl_raw: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type pnl_leaderboard_entry_stddev_samp_fields {
   active_position_count: Float
   best_trade_pnl_formatted: Float
@@ -4982,13 +7299,19 @@ type pnl_leaderboard_entry_stddev_samp_fields {
 Streaming cursor of the table "pnl_leaderboard_entry"
 """
 input pnl_leaderboard_entry_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: pnl_leaderboard_entry_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input pnl_leaderboard_entry_stream_cursor_value_input {
   account_id: String
   account_image: String
@@ -5028,7 +7351,9 @@ input pnl_leaderboard_entry_stream_cursor_value_input {
   worst_trade_pnl_raw: numeric
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type pnl_leaderboard_entry_sum_fields {
   active_position_count: bigint
   best_trade_pnl_formatted: numeric
@@ -5063,7 +7388,9 @@ type pnl_leaderboard_entry_sum_fields {
   worst_trade_pnl_raw: numeric
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type pnl_leaderboard_entry_var_pop_fields {
   active_position_count: Float
   best_trade_pnl_formatted: Float
@@ -5098,7 +7425,9 @@ type pnl_leaderboard_entry_var_pop_fields {
   worst_trade_pnl_raw: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type pnl_leaderboard_entry_var_samp_fields {
   active_position_count: Float
   best_trade_pnl_formatted: Float
@@ -5133,7 +7462,9 @@ type pnl_leaderboard_entry_var_samp_fields {
   worst_trade_pnl_raw: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type pnl_leaderboard_entry_variance_fields {
   active_position_count: Float
   best_trade_pnl_formatted: Float
@@ -5198,7 +7529,10 @@ aggregate fields of "pnl_leaderboard_stats"
 """
 type pnl_leaderboard_stats_aggregate_fields {
   avg: pnl_leaderboard_stats_avg_fields
-  count(columns: [pnl_leaderboard_stats_select_column!], distinct: Boolean): Int!
+  count(
+    columns: [pnl_leaderboard_stats_select_column!]
+    distinct: Boolean
+  ): Int!
   max: pnl_leaderboard_stats_max_fields
   min: pnl_leaderboard_stats_min_fields
   stddev: pnl_leaderboard_stats_stddev_fields
@@ -5210,7 +7544,9 @@ type pnl_leaderboard_stats_aggregate_fields {
   variance: pnl_leaderboard_stats_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type pnl_leaderboard_stats_avg_fields {
   avg_pnl_formatted: Float
   avg_pnl_raw: Float
@@ -5251,7 +7587,9 @@ input pnl_leaderboard_stats_bool_exp {
   unprofitable_traders: bigint_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type pnl_leaderboard_stats_max_fields {
   avg_pnl_formatted: numeric
   avg_pnl_raw: numeric
@@ -5269,7 +7607,9 @@ type pnl_leaderboard_stats_max_fields {
   unprofitable_traders: bigint
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type pnl_leaderboard_stats_min_fields {
   avg_pnl_formatted: numeric
   avg_pnl_raw: numeric
@@ -5287,7 +7627,9 @@ type pnl_leaderboard_stats_min_fields {
   unprofitable_traders: bigint
 }
 
-"""Ordering options when selecting data from "pnl_leaderboard_stats"."""
+"""
+Ordering options when selecting data from "pnl_leaderboard_stats".
+"""
 input pnl_leaderboard_stats_order_by {
   avg_pnl_formatted: order_by
   avg_pnl_raw: order_by
@@ -5309,37 +7651,67 @@ input pnl_leaderboard_stats_order_by {
 select columns of table "pnl_leaderboard_stats"
 """
 enum pnl_leaderboard_stats_select_column {
-  """column name"""
+  """
+  column name
+  """
   avg_pnl_formatted
-  """column name"""
+  """
+  column name
+  """
   avg_pnl_raw
-  """column name"""
+  """
+  column name
+  """
   avg_volume_formatted
-  """column name"""
+  """
+  column name
+  """
   avg_volume_raw
-  """column name"""
+  """
+  column name
+  """
   median_pnl_formatted
-  """column name"""
+  """
+  column name
+  """
   median_pnl_raw
-  """column name"""
+  """
+  column name
+  """
   profitable_pct
-  """column name"""
+  """
+  column name
+  """
   profitable_traders
-  """column name"""
+  """
+  column name
+  """
   total_pnl_sum_formatted
-  """column name"""
+  """
+  column name
+  """
   total_pnl_sum_raw
-  """column name"""
+  """
+  column name
+  """
   total_traders
-  """column name"""
+  """
+  column name
+  """
   total_volume_formatted
-  """column name"""
+  """
+  column name
+  """
   total_volume_raw
-  """column name"""
+  """
+  column name
+  """
   unprofitable_traders
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type pnl_leaderboard_stats_stddev_fields {
   avg_pnl_formatted: Float
   avg_pnl_raw: Float
@@ -5357,7 +7729,9 @@ type pnl_leaderboard_stats_stddev_fields {
   unprofitable_traders: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type pnl_leaderboard_stats_stddev_pop_fields {
   avg_pnl_formatted: Float
   avg_pnl_raw: Float
@@ -5375,7 +7749,9 @@ type pnl_leaderboard_stats_stddev_pop_fields {
   unprofitable_traders: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type pnl_leaderboard_stats_stddev_samp_fields {
   avg_pnl_formatted: Float
   avg_pnl_raw: Float
@@ -5397,13 +7773,19 @@ type pnl_leaderboard_stats_stddev_samp_fields {
 Streaming cursor of the table "pnl_leaderboard_stats"
 """
 input pnl_leaderboard_stats_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: pnl_leaderboard_stats_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input pnl_leaderboard_stats_stream_cursor_value_input {
   avg_pnl_formatted: numeric
   avg_pnl_raw: numeric
@@ -5421,7 +7803,9 @@ input pnl_leaderboard_stats_stream_cursor_value_input {
   unprofitable_traders: bigint
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type pnl_leaderboard_stats_sum_fields {
   avg_pnl_formatted: numeric
   avg_pnl_raw: numeric
@@ -5439,7 +7823,9 @@ type pnl_leaderboard_stats_sum_fields {
   unprofitable_traders: bigint
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type pnl_leaderboard_stats_var_pop_fields {
   avg_pnl_formatted: Float
   avg_pnl_raw: Float
@@ -5457,7 +7843,9 @@ type pnl_leaderboard_stats_var_pop_fields {
   unprofitable_traders: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type pnl_leaderboard_stats_var_samp_fields {
   avg_pnl_formatted: Float
   avg_pnl_raw: Float
@@ -5475,7 +7863,9 @@ type pnl_leaderboard_stats_var_samp_fields {
   unprofitable_traders: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type pnl_leaderboard_stats_variance_fields {
   avg_pnl_formatted: Float
   avg_pnl_raw: Float
@@ -5497,7 +7887,9 @@ type pnl_leaderboard_stats_variance_fields {
 columns and relationships of "position_change_daily"
 """
 type position_change_daily {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   account: accounts
   account_id: String
   assets_in_period: numeric
@@ -5505,11 +7897,15 @@ type position_change_daily {
   bucket: timestamptz
   curve_id: numeric
   shares_delta_period: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String
   transaction_count: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   vault: vaults
 }
 
@@ -5533,7 +7929,9 @@ input position_change_daily_bool_exp {
   vault: vaults_bool_exp
 }
 
-"""Ordering options when selecting data from "position_change_daily"."""
+"""
+Ordering options when selecting data from "position_change_daily".
+"""
 input position_change_daily_order_by {
   account: accounts_order_by
   account_id: order_by
@@ -5552,21 +7950,37 @@ input position_change_daily_order_by {
 select columns of table "position_change_daily"
 """
 enum position_change_daily_select_column {
-  """column name"""
+  """
+  column name
+  """
   account_id
-  """column name"""
+  """
+  column name
+  """
   assets_in_period
-  """column name"""
+  """
+  column name
+  """
   assets_out_period
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   shares_delta_period
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   transaction_count
 }
 
@@ -5574,13 +7988,19 @@ enum position_change_daily_select_column {
 Streaming cursor of the table "position_change_daily"
 """
 input position_change_daily_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: position_change_daily_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input position_change_daily_stream_cursor_value_input {
   account_id: String
   assets_in_period: numeric
@@ -5596,7 +8016,9 @@ input position_change_daily_stream_cursor_value_input {
 columns and relationships of "position_change_hourly"
 """
 type position_change_hourly {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   account: accounts
   account_id: String
   assets_in_period: numeric
@@ -5604,11 +8026,15 @@ type position_change_hourly {
   bucket: timestamptz
   curve_id: numeric
   shares_delta_period: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String
   transaction_count: bigint
-  """An object relationship"""
+  """
+  An object relationship
+  """
   vault: vaults
 }
 
@@ -5632,7 +8058,9 @@ input position_change_hourly_bool_exp {
   vault: vaults_bool_exp
 }
 
-"""Ordering options when selecting data from "position_change_hourly"."""
+"""
+Ordering options when selecting data from "position_change_hourly".
+"""
 input position_change_hourly_order_by {
   account: accounts_order_by
   account_id: order_by
@@ -5651,21 +8079,37 @@ input position_change_hourly_order_by {
 select columns of table "position_change_hourly"
 """
 enum position_change_hourly_select_column {
-  """column name"""
+  """
+  column name
+  """
   account_id
-  """column name"""
+  """
+  column name
+  """
   assets_in_period
-  """column name"""
+  """
+  column name
+  """
   assets_out_period
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   shares_delta_period
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   transaction_count
 }
 
@@ -5673,13 +8117,19 @@ enum position_change_hourly_select_column {
 Streaming cursor of the table "position_change_hourly"
 """
 input position_change_hourly_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: position_change_hourly_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input position_change_hourly_stream_cursor_value_input {
   account_id: String
   assets_in_period: numeric
@@ -5695,7 +8145,9 @@ input position_change_hourly_stream_cursor_value_input {
 columns and relationships of "position_change"
 """
 type position_changes {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   account: accounts
   account_id: String!
   assets_in: numeric!
@@ -5708,11 +8160,15 @@ type position_changes {
   id: bigint!
   log_index: bigint!
   shares_delta: numeric!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String!
   transaction_hash: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   vault: vaults
 }
 
@@ -5741,7 +8197,9 @@ type position_changes_aggregate_fields {
   variance: position_changes_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type position_changes_avg_fields {
   assets_in: Float
   assets_out: Float
@@ -5777,7 +8235,9 @@ input position_changes_bool_exp {
   vault: vaults_bool_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type position_changes_max_fields {
   account_id: String
   assets_in: numeric
@@ -5794,7 +8254,9 @@ type position_changes_max_fields {
   transaction_hash: String
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type position_changes_min_fields {
   account_id: String
   assets_in: numeric
@@ -5811,7 +8273,9 @@ type position_changes_min_fields {
   transaction_hash: String
 }
 
-"""Ordering options when selecting data from "position_change"."""
+"""
+Ordering options when selecting data from "position_change".
+"""
 input position_changes_order_by {
   account: accounts_order_by
   account_id: order_by
@@ -5835,35 +8299,63 @@ input position_changes_order_by {
 select columns of table "position_change"
 """
 enum position_changes_select_column {
-  """column name"""
+  """
+  column name
+  """
   account_id
-  """column name"""
+  """
+  column name
+  """
   assets_in
-  """column name"""
+  """
+  column name
+  """
   assets_out
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   event_id
-  """column name"""
+  """
+  column name
+  """
   event_type
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   log_index
-  """column name"""
+  """
+  column name
+  """
   shares_delta
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type position_changes_stddev_fields {
   assets_in: Float
   assets_out: Float
@@ -5874,7 +8366,9 @@ type position_changes_stddev_fields {
   shares_delta: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type position_changes_stddev_pop_fields {
   assets_in: Float
   assets_out: Float
@@ -5885,7 +8379,9 @@ type position_changes_stddev_pop_fields {
   shares_delta: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type position_changes_stddev_samp_fields {
   assets_in: Float
   assets_out: Float
@@ -5900,13 +8396,19 @@ type position_changes_stddev_samp_fields {
 Streaming cursor of the table "position_changes"
 """
 input position_changes_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: position_changes_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input position_changes_stream_cursor_value_input {
   account_id: String
   assets_in: numeric
@@ -5923,7 +8425,9 @@ input position_changes_stream_cursor_value_input {
   transaction_hash: String
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type position_changes_sum_fields {
   assets_in: numeric
   assets_out: numeric
@@ -5934,7 +8438,9 @@ type position_changes_sum_fields {
   shares_delta: numeric
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type position_changes_var_pop_fields {
   assets_in: Float
   assets_out: Float
@@ -5945,7 +8451,9 @@ type position_changes_var_pop_fields {
   shares_delta: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type position_changes_var_samp_fields {
   assets_in: Float
   assets_out: Float
@@ -5956,7 +8464,9 @@ type position_changes_var_samp_fields {
   shares_delta: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type position_changes_variance_fields {
   assets_in: Float
   assets_out: Float
@@ -5971,39 +8481,69 @@ type position_changes_variance_fields {
 User positions in vaults representing staked assets and shares held across different curves.
 """
 type positions {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   account: accounts
-  """Account that holds this position."""
+  """
+  Account that holds this position.
+  """
   account_id: String!
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: bigint!
-  """Timestamp when position was created."""
+  """
+  Timestamp when position was created.
+  """
   created_at: timestamptz!
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric!
-  """Unique identifier for this position."""
+  """
+  Unique identifier for this position.
+  """
   id: String!
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: bigint!
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: numeric!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
-  """Term ID of the vault for this position."""
+  """
+  Term ID of the vault for this position.
+  """
   term_id: String!
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: numeric!
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: numeric!
-  """Transaction hash of most recent position update."""
+  """
+  Transaction hash of most recent position update.
+  """
   transaction_hash: String!
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: bigint!
-  """Timestamp of last update to this position."""
+  """
+  Timestamp of last update to this position.
+  """
   updated_at: timestamptz!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   vault: vaults
 }
 
@@ -6060,23 +8600,37 @@ input positions_aggregate_order_by {
   variance: positions_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type positions_avg_fields {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: Float
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: Float
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: Float
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: Float
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: Float
 }
 
@@ -6084,21 +8638,33 @@ type positions_avg_fields {
 order by avg() on columns of table "position"
 """
 input positions_avg_order_by {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: order_by
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: order_by
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: order_by
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: order_by
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: order_by
 }
 
@@ -6131,35 +8697,61 @@ input positions_from_following_args {
   address: String
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type positions_max_fields {
-  """Account that holds this position."""
+  """
+  Account that holds this position.
+  """
   account_id: String
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: bigint
-  """Timestamp when position was created."""
+  """
+  Timestamp when position was created.
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Unique identifier for this position."""
+  """
+  Unique identifier for this position.
+  """
   id: String
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: bigint
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: numeric
-  """Term ID of the vault for this position."""
+  """
+  Term ID of the vault for this position.
+  """
   term_id: String
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: numeric
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: numeric
-  """Transaction hash of most recent position update."""
+  """
+  Transaction hash of most recent position update.
+  """
   transaction_hash: String
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: bigint
-  """Timestamp of last update to this position."""
+  """
+  Timestamp of last update to this position.
+  """
   updated_at: timestamptz
 }
 
@@ -6167,65 +8759,115 @@ type positions_max_fields {
 order by max() on columns of table "position"
 """
 input positions_max_order_by {
-  """Account that holds this position."""
+  """
+  Account that holds this position.
+  """
   account_id: order_by
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: order_by
-  """Timestamp when position was created."""
+  """
+  Timestamp when position was created.
+  """
   created_at: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Unique identifier for this position."""
+  """
+  Unique identifier for this position.
+  """
   id: order_by
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: order_by
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: order_by
-  """Term ID of the vault for this position."""
+  """
+  Term ID of the vault for this position.
+  """
   term_id: order_by
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: order_by
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: order_by
-  """Transaction hash of most recent position update."""
+  """
+  Transaction hash of most recent position update.
+  """
   transaction_hash: order_by
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: order_by
-  """Timestamp of last update to this position."""
+  """
+  Timestamp of last update to this position.
+  """
   updated_at: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type positions_min_fields {
-  """Account that holds this position."""
+  """
+  Account that holds this position.
+  """
   account_id: String
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: bigint
-  """Timestamp when position was created."""
+  """
+  Timestamp when position was created.
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Unique identifier for this position."""
+  """
+  Unique identifier for this position.
+  """
   id: String
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: bigint
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: numeric
-  """Term ID of the vault for this position."""
+  """
+  Term ID of the vault for this position.
+  """
   term_id: String
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: numeric
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: numeric
-  """Transaction hash of most recent position update."""
+  """
+  Transaction hash of most recent position update.
+  """
   transaction_hash: String
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: bigint
-  """Timestamp of last update to this position."""
+  """
+  Timestamp of last update to this position.
+  """
   updated_at: timestamptz
 }
 
@@ -6233,37 +8875,63 @@ type positions_min_fields {
 order by min() on columns of table "position"
 """
 input positions_min_order_by {
-  """Account that holds this position."""
+  """
+  Account that holds this position.
+  """
   account_id: order_by
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: order_by
-  """Timestamp when position was created."""
+  """
+  Timestamp when position was created.
+  """
   created_at: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Unique identifier for this position."""
+  """
+  Unique identifier for this position.
+  """
   id: order_by
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: order_by
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: order_by
-  """Term ID of the vault for this position."""
+  """
+  Term ID of the vault for this position.
+  """
   term_id: order_by
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: order_by
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: order_by
-  """Transaction hash of most recent position update."""
+  """
+  Transaction hash of most recent position update.
+  """
   transaction_hash: order_by
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: order_by
-  """Timestamp of last update to this position."""
+  """
+  Timestamp of last update to this position.
+  """
   updated_at: order_by
 }
 
-"""Ordering options when selecting data from "position"."""
+"""
+Ordering options when selecting data from "position".
+"""
 input positions_order_by {
   account: accounts_order_by
   account_id: order_by
@@ -6287,51 +8955,91 @@ input positions_order_by {
 select columns of table "position"
 """
 enum positions_select_column {
-  """column name"""
+  """
+  column name
+  """
   account_id
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   log_index
-  """column name"""
+  """
+  column name
+  """
   shares
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   total_deposit_assets_after_total_fees
-  """column name"""
+  """
+  column name
+  """
   total_redeem_assets_for_receiver
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
-  """column name"""
+  """
+  column name
+  """
   transaction_index
-  """column name"""
+  """
+  column name
+  """
   updated_at
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type positions_stddev_fields {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: Float
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: Float
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: Float
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: Float
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: Float
 }
 
@@ -6339,41 +9047,67 @@ type positions_stddev_fields {
 order by stddev() on columns of table "position"
 """
 input positions_stddev_order_by {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: order_by
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: order_by
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: order_by
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: order_by
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type positions_stddev_pop_fields {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: Float
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: Float
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: Float
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: Float
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: Float
 }
 
@@ -6381,41 +9115,67 @@ type positions_stddev_pop_fields {
 order by stddev_pop() on columns of table "position"
 """
 input positions_stddev_pop_order_by {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: order_by
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: order_by
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: order_by
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: order_by
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type positions_stddev_samp_fields {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: Float
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: Float
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: Float
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: Float
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: Float
 }
 
@@ -6423,21 +9183,33 @@ type positions_stddev_samp_fields {
 order by stddev_samp() on columns of table "position"
 """
 input positions_stddev_samp_order_by {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: order_by
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: order_by
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: order_by
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: order_by
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: order_by
 }
 
@@ -6445,61 +9217,105 @@ input positions_stddev_samp_order_by {
 Streaming cursor of the table "positions"
 """
 input positions_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: positions_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input positions_stream_cursor_value_input {
-  """Account that holds this position."""
+  """
+  Account that holds this position.
+  """
   account_id: String
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: bigint
-  """Timestamp when position was created."""
+  """
+  Timestamp when position was created.
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Unique identifier for this position."""
+  """
+  Unique identifier for this position.
+  """
   id: String
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: bigint
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: numeric
-  """Term ID of the vault for this position."""
+  """
+  Term ID of the vault for this position.
+  """
   term_id: String
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: numeric
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: numeric
-  """Transaction hash of most recent position update."""
+  """
+  Transaction hash of most recent position update.
+  """
   transaction_hash: String
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: bigint
-  """Timestamp of last update to this position."""
+  """
+  Timestamp of last update to this position.
+  """
   updated_at: timestamptz
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type positions_sum_fields {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: bigint
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: bigint
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: numeric
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: numeric
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: numeric
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: bigint
 }
 
@@ -6507,41 +9323,67 @@ type positions_sum_fields {
 order by sum() on columns of table "position"
 """
 input positions_sum_order_by {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: order_by
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: order_by
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: order_by
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: order_by
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type positions_var_pop_fields {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: Float
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: Float
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: Float
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: Float
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: Float
 }
 
@@ -6549,41 +9391,67 @@ type positions_var_pop_fields {
 order by var_pop() on columns of table "position"
 """
 input positions_var_pop_order_by {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: order_by
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: order_by
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: order_by
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: order_by
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type positions_var_samp_fields {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: Float
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: Float
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: Float
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: Float
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: Float
 }
 
@@ -6591,41 +9459,67 @@ type positions_var_samp_fields {
 order by var_samp() on columns of table "position"
 """
 input positions_var_samp_order_by {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: order_by
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: order_by
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: order_by
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: order_by
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type positions_variance_fields {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: Float
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: Float
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: Float
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: Float
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: Float
 }
 
@@ -6633,21 +9527,33 @@ type positions_variance_fields {
 order by variance() on columns of table "position"
 """
 input positions_variance_order_by {
-  """Block number of most recent position update."""
+  """
+  Block number of most recent position update.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Log index of most recent position update."""
+  """
+  Log index of most recent position update.
+  """
   log_index: order_by
-  """Current number of shares held in this position."""
+  """
+  Current number of shares held in this position.
+  """
   shares: order_by
   """
   Cumulative assets deposited after fees, for profit/loss calculation, in wei.
   """
   total_deposit_assets_after_total_fees: order_by
-  """Cumulative assets redeemed, for profit/loss calculation, in wei."""
+  """
+  Cumulative assets redeemed, for profit/loss calculation, in wei.
+  """
   total_redeem_assets_for_receiver: order_by
-  """Transaction index for event ordering."""
+  """
+  Transaction index for event ordering.
+  """
   transaction_index: order_by
 }
 
@@ -6655,7 +9561,9 @@ input positions_variance_order_by {
 columns and relationships of "position_with_value"
 """
 type positions_with_value {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   account: accounts
   account_id: String
   block_number: bigint
@@ -6667,7 +9575,9 @@ type positions_with_value {
   pnl_pct: numeric
   redeemable_assets: numeric
   shares: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String
   theoretical_value: numeric
@@ -6676,7 +9586,9 @@ type positions_with_value {
   transaction_hash: String
   transaction_index: bigint
   updated_at: timestamptz
-  """An object relationship"""
+  """
+  An object relationship
+  """
   vault: vaults
 }
 
@@ -6705,7 +9617,9 @@ type positions_with_value_aggregate_fields {
   variance: positions_with_value_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type positions_with_value_avg_fields {
   block_number: Float
   curve_id: Float
@@ -6749,7 +9663,9 @@ input positions_with_value_bool_exp {
   vault: vaults_bool_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type positions_with_value_max_fields {
   account_id: String
   block_number: bigint
@@ -6770,7 +9686,9 @@ type positions_with_value_max_fields {
   updated_at: timestamptz
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type positions_with_value_min_fields {
   account_id: String
   block_number: bigint
@@ -6791,7 +9709,9 @@ type positions_with_value_min_fields {
   updated_at: timestamptz
 }
 
-"""Ordering options when selecting data from "position_with_value"."""
+"""
+Ordering options when selecting data from "position_with_value".
+"""
 input positions_with_value_order_by {
   account: accounts_order_by
   account_id: order_by
@@ -6819,43 +9739,79 @@ input positions_with_value_order_by {
 select columns of table "position_with_value"
 """
 enum positions_with_value_select_column {
-  """column name"""
+  """
+  column name
+  """
   account_id
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   log_index
-  """column name"""
+  """
+  column name
+  """
   pnl
-  """column name"""
+  """
+  column name
+  """
   pnl_pct
-  """column name"""
+  """
+  column name
+  """
   redeemable_assets
-  """column name"""
+  """
+  column name
+  """
   shares
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   theoretical_value
-  """column name"""
+  """
+  column name
+  """
   total_deposit_assets_after_total_fees
-  """column name"""
+  """
+  column name
+  """
   total_redeem_assets_for_receiver
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
-  """column name"""
+  """
+  column name
+  """
   transaction_index
-  """column name"""
+  """
+  column name
+  """
   updated_at
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type positions_with_value_stddev_fields {
   block_number: Float
   curve_id: Float
@@ -6870,7 +9826,9 @@ type positions_with_value_stddev_fields {
   transaction_index: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type positions_with_value_stddev_pop_fields {
   block_number: Float
   curve_id: Float
@@ -6885,7 +9843,9 @@ type positions_with_value_stddev_pop_fields {
   transaction_index: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type positions_with_value_stddev_samp_fields {
   block_number: Float
   curve_id: Float
@@ -6904,13 +9864,19 @@ type positions_with_value_stddev_samp_fields {
 Streaming cursor of the table "positions_with_value"
 """
 input positions_with_value_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: positions_with_value_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input positions_with_value_stream_cursor_value_input {
   account_id: String
   block_number: bigint
@@ -6931,7 +9897,9 @@ input positions_with_value_stream_cursor_value_input {
   updated_at: timestamptz
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type positions_with_value_sum_fields {
   block_number: bigint
   curve_id: numeric
@@ -6946,7 +9914,9 @@ type positions_with_value_sum_fields {
   transaction_index: bigint
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type positions_with_value_var_pop_fields {
   block_number: Float
   curve_id: Float
@@ -6961,7 +9931,9 @@ type positions_with_value_var_pop_fields {
   transaction_index: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type positions_with_value_var_samp_fields {
   block_number: Float
   curve_id: Float
@@ -6976,7 +9948,9 @@ type positions_with_value_var_samp_fields {
   transaction_index: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type positions_with_value_variance_fields {
   block_number: Float
   curve_id: Float
@@ -6995,46 +9969,84 @@ type positions_with_value_variance_fields {
 Denormalized aggregate of triples grouped by (predicate, object) for efficient querying.
 """
 type predicate_objects {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   object: atoms
-  """Object atom ID."""
+  """
+  Object atom ID.
+  """
   object_id: String!
   opposer_count: bigint!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   predicate: atoms
-  """Predicate atom ID."""
+  """
+  Predicate atom ID.
+  """
   predicate_id: String!
   supporter_count: bigint!
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: numeric!
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Int!
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Int!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   triples(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): [triples!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   triples_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): triples_aggregate!
 }
@@ -7092,15 +10104,23 @@ input predicate_objects_aggregate_order_by {
   variance: predicate_objects_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type predicate_objects_avg_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Float
 }
 
@@ -7110,11 +10130,17 @@ order by avg() on columns of table "predicate_object"
 input predicate_objects_avg_order_by {
   opposer_count: order_by
   supporter_count: order_by
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: order_by
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: order_by
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: order_by
 }
 
@@ -7138,19 +10164,31 @@ input predicate_objects_bool_exp {
   triples_aggregate: triples_aggregate_bool_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type predicate_objects_max_fields {
-  """Object atom ID."""
+  """
+  Object atom ID.
+  """
   object_id: String
   opposer_count: bigint
-  """Predicate atom ID."""
+  """
+  Predicate atom ID.
+  """
   predicate_id: String
   supporter_count: bigint
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: numeric
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Int
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Int
 }
 
@@ -7158,33 +10196,55 @@ type predicate_objects_max_fields {
 order by max() on columns of table "predicate_object"
 """
 input predicate_objects_max_order_by {
-  """Object atom ID."""
+  """
+  Object atom ID.
+  """
   object_id: order_by
   opposer_count: order_by
-  """Predicate atom ID."""
+  """
+  Predicate atom ID.
+  """
   predicate_id: order_by
   supporter_count: order_by
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: order_by
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: order_by
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type predicate_objects_min_fields {
-  """Object atom ID."""
+  """
+  Object atom ID.
+  """
   object_id: String
   opposer_count: bigint
-  """Predicate atom ID."""
+  """
+  Predicate atom ID.
+  """
   predicate_id: String
   supporter_count: bigint
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: numeric
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Int
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Int
 }
 
@@ -7192,21 +10252,33 @@ type predicate_objects_min_fields {
 order by min() on columns of table "predicate_object"
 """
 input predicate_objects_min_order_by {
-  """Object atom ID."""
+  """
+  Object atom ID.
+  """
   object_id: order_by
   opposer_count: order_by
-  """Predicate atom ID."""
+  """
+  Predicate atom ID.
+  """
   predicate_id: order_by
   supporter_count: order_by
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: order_by
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: order_by
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: order_by
 }
 
-"""Ordering options when selecting data from "predicate_object"."""
+"""
+Ordering options when selecting data from "predicate_object".
+"""
 input predicate_objects_order_by {
   object: atoms_order_by
   object_id: order_by
@@ -7224,31 +10296,53 @@ input predicate_objects_order_by {
 select columns of table "predicate_object"
 """
 enum predicate_objects_select_column {
-  """column name"""
+  """
+  column name
+  """
   object_id
-  """column name"""
+  """
+  column name
+  """
   opposer_count
-  """column name"""
+  """
+  column name
+  """
   predicate_id
-  """column name"""
+  """
+  column name
+  """
   supporter_count
-  """column name"""
+  """
+  column name
+  """
   total_market_cap
-  """column name"""
+  """
+  column name
+  """
   total_position_count
-  """column name"""
+  """
+  column name
+  """
   triple_count
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type predicate_objects_stddev_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Float
 }
 
@@ -7258,23 +10352,37 @@ order by stddev() on columns of table "predicate_object"
 input predicate_objects_stddev_order_by {
   opposer_count: order_by
   supporter_count: order_by
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: order_by
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: order_by
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type predicate_objects_stddev_pop_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Float
 }
 
@@ -7284,23 +10392,37 @@ order by stddev_pop() on columns of table "predicate_object"
 input predicate_objects_stddev_pop_order_by {
   opposer_count: order_by
   supporter_count: order_by
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: order_by
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: order_by
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type predicate_objects_stddev_samp_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Float
 }
 
@@ -7310,11 +10432,17 @@ order by stddev_samp() on columns of table "predicate_object"
 input predicate_objects_stddev_samp_order_by {
   opposer_count: order_by
   supporter_count: order_by
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: order_by
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: order_by
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: order_by
 }
 
@@ -7322,37 +10450,61 @@ input predicate_objects_stddev_samp_order_by {
 Streaming cursor of the table "predicate_objects"
 """
 input predicate_objects_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: predicate_objects_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input predicate_objects_stream_cursor_value_input {
-  """Object atom ID."""
+  """
+  Object atom ID.
+  """
   object_id: String
   opposer_count: bigint
-  """Predicate atom ID."""
+  """
+  Predicate atom ID.
+  """
   predicate_id: String
   supporter_count: bigint
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: numeric
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Int
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Int
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type predicate_objects_sum_fields {
   opposer_count: bigint
   supporter_count: bigint
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: numeric
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Int
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Int
 }
 
@@ -7362,23 +10514,37 @@ order by sum() on columns of table "predicate_object"
 input predicate_objects_sum_order_by {
   opposer_count: order_by
   supporter_count: order_by
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: order_by
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: order_by
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type predicate_objects_var_pop_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Float
 }
 
@@ -7388,23 +10554,37 @@ order by var_pop() on columns of table "predicate_object"
 input predicate_objects_var_pop_order_by {
   opposer_count: order_by
   supporter_count: order_by
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: order_by
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: order_by
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type predicate_objects_var_samp_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Float
 }
 
@@ -7414,23 +10594,37 @@ order by var_samp() on columns of table "predicate_object"
 input predicate_objects_var_samp_order_by {
   opposer_count: order_by
   supporter_count: order_by
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: order_by
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: order_by
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type predicate_objects_variance_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: Float
 }
 
@@ -7440,11 +10634,17 @@ order by variance() on columns of table "predicate_object"
 input predicate_objects_variance_order_by {
   opposer_count: order_by
   supporter_count: order_by
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: order_by
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: order_by
-  """Number of triples with this (predicate, object) combination."""
+  """
+  Number of triples with this (predicate, object) combination.
+  """
   triple_count: order_by
 }
 
@@ -7457,7 +10657,9 @@ type protocol_fee_accruals {
   created_at: timestamptz!
   epoch: numeric!
   id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   sender: accounts
   sender_id: String!
   transaction_hash: String!
@@ -7476,7 +10678,10 @@ aggregate fields of "protocol_fee_accrued"
 """
 type protocol_fee_accruals_aggregate_fields {
   avg: protocol_fee_accruals_avg_fields
-  count(columns: [protocol_fee_accruals_select_column!], distinct: Boolean): Int!
+  count(
+    columns: [protocol_fee_accruals_select_column!]
+    distinct: Boolean
+  ): Int!
   max: protocol_fee_accruals_max_fields
   min: protocol_fee_accruals_min_fields
   stddev: protocol_fee_accruals_stddev_fields
@@ -7488,7 +10693,9 @@ type protocol_fee_accruals_aggregate_fields {
   variance: protocol_fee_accruals_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type protocol_fee_accruals_avg_fields {
   amount: Float
   block_number: Float
@@ -7512,7 +10719,9 @@ input protocol_fee_accruals_bool_exp {
   transaction_hash: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type protocol_fee_accruals_max_fields {
   amount: numeric
   block_number: numeric
@@ -7523,7 +10732,9 @@ type protocol_fee_accruals_max_fields {
   transaction_hash: String
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type protocol_fee_accruals_min_fields {
   amount: numeric
   block_number: numeric
@@ -7534,7 +10745,9 @@ type protocol_fee_accruals_min_fields {
   transaction_hash: String
 }
 
-"""Ordering options when selecting data from "protocol_fee_accrued"."""
+"""
+Ordering options when selecting data from "protocol_fee_accrued".
+"""
 input protocol_fee_accruals_order_by {
   amount: order_by
   block_number: order_by
@@ -7550,37 +10763,57 @@ input protocol_fee_accruals_order_by {
 select columns of table "protocol_fee_accrued"
 """
 enum protocol_fee_accruals_select_column {
-  """column name"""
+  """
+  column name
+  """
   amount
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   epoch
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   sender_id
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type protocol_fee_accruals_stddev_fields {
   amount: Float
   block_number: Float
   epoch: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type protocol_fee_accruals_stddev_pop_fields {
   amount: Float
   block_number: Float
   epoch: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type protocol_fee_accruals_stddev_samp_fields {
   amount: Float
   block_number: Float
@@ -7591,13 +10824,19 @@ type protocol_fee_accruals_stddev_samp_fields {
 Streaming cursor of the table "protocol_fee_accruals"
 """
 input protocol_fee_accruals_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: protocol_fee_accruals_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input protocol_fee_accruals_stream_cursor_value_input {
   amount: numeric
   block_number: numeric
@@ -7608,28 +10847,36 @@ input protocol_fee_accruals_stream_cursor_value_input {
   transaction_hash: String
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type protocol_fee_accruals_sum_fields {
   amount: numeric
   block_number: numeric
   epoch: numeric
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type protocol_fee_accruals_var_pop_fields {
   amount: Float
   block_number: Float
   epoch: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type protocol_fee_accruals_var_samp_fields {
   amount: Float
   block_number: Float
   epoch: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type protocol_fee_accruals_variance_fields {
   amount: Float
   block_number: Float
@@ -7637,372 +10884,648 @@ type protocol_fee_accruals_variance_fields {
 }
 
 type query_root {
-  """fetch data from the table: "account" using primary key columns"""
+  """
+  fetch data from the table: "account" using primary key columns
+  """
   account(
-    """Account address (Ethereum address or atom wallet address)."""
+    """
+    Account address (Ethereum address or atom wallet address).
+    """
     id: String!
   ): accounts
   """
   fetch data from the table: "account_pnl_rank"
   """
   account_pnl_rank(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [account_pnl_rank_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [account_pnl_rank_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: account_pnl_rank_bool_exp
   ): [account_pnl_rank!]!
   """
   fetch aggregated fields from the table: "account_pnl_rank"
   """
   account_pnl_rank_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [account_pnl_rank_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [account_pnl_rank_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: account_pnl_rank_bool_exp
   ): account_pnl_rank_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   accounts(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [accounts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [accounts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: accounts_bool_exp
   ): [accounts!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   accounts_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [accounts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [accounts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: accounts_bool_exp
   ): accounts_aggregate!
-  """fetch data from the table: "atom" using primary key columns"""
+  """
+  fetch data from the table: "atom" using primary key columns
+  """
   atom(
-    """Unique identifier linking to the term registry."""
+    """
+    Unique identifier linking to the term registry.
+    """
     term_id: String!
   ): atoms
-  """fetch data from the table: "atom_value" using primary key columns"""
+  """
+  fetch data from the table: "atom_value" using primary key columns
+  """
   atom_value(
-    """Unique identifier matching the atom value_id."""
+    """
+    Unique identifier matching the atom value_id.
+    """
     id: String!
   ): atom_values
   """
   fetch data from the table: "atom_value"
   """
   atom_values(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [atom_values_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [atom_values_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atom_values_bool_exp
   ): [atom_values!]!
   """
   fetch aggregated fields from the table: "atom_value"
   """
   atom_values_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [atom_values_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [atom_values_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atom_values_bool_exp
   ): atom_values_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   atoms(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [atoms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [atoms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atoms_bool_exp
   ): [atoms!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   atoms_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [atoms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [atoms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atoms_bool_exp
   ): atoms_aggregate!
-  """fetch data from the table: "book" using primary key columns"""
+  """
+  fetch data from the table: "book" using primary key columns
+  """
   book(
-    """Unique identifier for this book entity."""
+    """
+    Unique identifier for this book entity.
+    """
     id: String!
   ): books
   """
   fetch data from the table: "book"
   """
   books(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [books_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [books_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: books_bool_exp
   ): [books!]!
   """
   fetch aggregated fields from the table: "book"
   """
   books_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [books_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [books_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: books_bool_exp
   ): books_aggregate!
   """
   fetch data from the table: "byte_object"
   """
   byte_object(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [byte_object_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [byte_object_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: byte_object_bool_exp
   ): [byte_object!]!
   """
   fetch aggregated fields from the table: "byte_object"
   """
   byte_object_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [byte_object_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [byte_object_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: byte_object_bool_exp
   ): byte_object_aggregate!
-  """fetch data from the table: "byte_object" using primary key columns"""
+  """
+  fetch data from the table: "byte_object" using primary key columns
+  """
   byte_object_by_pk(
-    """Unique identifier for this byte object."""
+    """
+    Unique identifier for this byte object.
+    """
     id: String!
   ): byte_object
   """
   fetch data from the table: "cached_images.cached_image"
   """
   cached_images_cached_image(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [cached_images_cached_image_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [cached_images_cached_image_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: cached_images_cached_image_bool_exp
   ): [cached_images_cached_image!]!
   """
   fetch data from the table: "cached_images.cached_image" using primary key columns
   """
   cached_images_cached_image_by_pk(url: String!): cached_images_cached_image
-  """fetch data from the table: "caip10" using primary key columns"""
+  """
+  fetch data from the table: "caip10" using primary key columns
+  """
   caip10(
-    """Unique identifier for this CAIP-10 account reference."""
+    """
+    Unique identifier for this CAIP-10 account reference.
+    """
     id: String!
   ): caip10
   """
   fetch aggregated fields from the table: "caip10"
   """
   caip10_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [caip10_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [caip10_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: caip10_bool_exp
   ): caip10_aggregate!
   """
   fetch data from the table: "caip10"
   """
   caip10s(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [caip10_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [caip10_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: caip10_bool_exp
   ): [caip10!]!
-  """fetch data from the table: "chainlink_price" using primary key columns"""
+  """
+  fetch data from the table: "chainlink_price" using primary key columns
+  """
   chainlink_price(
-    """Block number or timestamp identifier for the price data point."""
+    """
+    Block number or timestamp identifier for the price data point.
+    """
     id: numeric!
   ): chainlink_prices
   """
   fetch data from the table: "chainlink_price"
   """
   chainlink_prices(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [chainlink_prices_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [chainlink_prices_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: chainlink_prices_bool_exp
   ): [chainlink_prices!]!
-  """fetch data from the table: "deposit" using primary key columns"""
+  """
+  fetch data from the table: "deposit" using primary key columns
+  """
   deposit(
-    """Unique identifier for this deposit event."""
+    """
+    Unique identifier for this deposit event.
+    """
     id: String!
   ): deposits
-  """An array relationship"""
+  """
+  An array relationship
+  """
   deposits(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): [deposits!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   deposits_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): deposits_aggregate!
-  """fetch data from the table: "event" using primary key columns"""
+  """
+  fetch data from the table: "event" using primary key columns
+  """
   event(
-    """Unique identifier for this event."""
+    """
+    Unique identifier for this event.
+    """
     id: String!
   ): events
   """
   fetch data from the table: "event"
   """
   events(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [events_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [events_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: events_bool_exp
   ): [events!]!
   """
   fetch aggregated fields from the table: "event"
   """
   events_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [events_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [events_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: events_bool_exp
   ): events_aggregate!
-  """fetch data from the table: "fee_transfer" using primary key columns"""
+  """
+  fetch data from the table: "fee_transfer" using primary key columns
+  """
   fee_transfer(
-    """Unique identifier for this fee transfer event."""
+    """
+    Unique identifier for this fee transfer event.
+    """
     id: String!
   ): fee_transfers
-  """An array relationship"""
+  """
+  An array relationship
+  """
   fee_transfers(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [fee_transfers_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [fee_transfers_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: fee_transfers_bool_exp
   ): [fee_transfers!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   fee_transfers_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [fee_transfers_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [fee_transfers_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: fee_transfers_bool_exp
   ): fee_transfers_aggregate!
   """
@@ -8013,15 +11536,25 @@ type query_root {
     input parameters for function "following"
     """
     args: following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [accounts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [accounts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: accounts_bool_exp
   ): [accounts!]!
   """
@@ -8032,32 +11565,62 @@ type query_root {
     input parameters for function "following_aggregate"
     """
     args: following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [accounts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [accounts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: accounts_bool_exp
   ): accounts_aggregate!
-  """Fetches account-level PnL chart data"""
+  """
+  Fetches account-level PnL chart data
+  """
   getAccountPnlChart(input: GetAccountPnlChartInput!): AccountPnlChartOutput
-  """Fetches current account PnL snapshot"""
-  getAccountPnlCurrent(input: GetAccountPnlCurrentInput!): AccountPnlSnapshotOutput
-  """Fetches realized PnL breakdown for an account"""
-  getAccountPnlRealized(input: GetAccountPnlRealizedInput!): AccountPnlRealizedOutput
-  """Fetches chart data (JSON) for a term/curve combination"""
+  """
+  Fetches current account PnL snapshot
+  """
+  getAccountPnlCurrent(
+    input: GetAccountPnlCurrentInput!
+  ): AccountPnlSnapshotOutput
+  """
+  Fetches realized PnL breakdown for an account
+  """
+  getAccountPnlRealized(
+    input: GetAccountPnlRealizedInput!
+  ): AccountPnlRealizedOutput
+  """
+  Fetches chart data (JSON) for a term/curve combination
+  """
   getChartJson(input: GetChartJsonInput!): ChartDataOutput
-  """Fetches raw share price chart data (JSON) from share_price_change"""
+  """
+  Fetches raw share price chart data (JSON) from share_price_change
+  """
   getChartRawJson(input: GetChartJsonInput!): ChartDataOutput
-  """Fetches raw share price chart SVG from share_price_change"""
+  """
+  Fetches raw share price chart SVG from share_price_change
+  """
   getChartRawSvg(input: GetChartSvgInput!): ChartSvgOutput
-  """Fetches chart SVG for a term/curve combination"""
+  """
+  Fetches chart SVG for a term/curve combination
+  """
   getChartSvg(input: GetChartSvgInput!): ChartSvgOutput
-  """Fetches position PnL chart data"""
+  """
+  Fetches position PnL chart data
+  """
   getPositionPnlChart(input: GetPositionPnlChartInput!): PositionPnlChartOutput
   """
   execute function "get_account_pnl_rank" which returns "account_pnl_rank"
@@ -8067,15 +11630,25 @@ type query_root {
     input parameters for function "get_account_pnl_rank"
     """
     args: get_account_pnl_rank_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [account_pnl_rank_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [account_pnl_rank_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: account_pnl_rank_bool_exp
   ): [account_pnl_rank!]!
   """
@@ -8086,15 +11659,25 @@ type query_root {
     input parameters for function "get_account_pnl_rank_aggregate"
     """
     args: get_account_pnl_rank_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [account_pnl_rank_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [account_pnl_rank_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: account_pnl_rank_bool_exp
   ): account_pnl_rank_aggregate!
   """
@@ -8105,15 +11688,25 @@ type query_root {
     input parameters for function "get_pnl_leaderboard"
     """
     args: get_pnl_leaderboard_args
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): [pnl_leaderboard_entry!]!
   """
@@ -8124,25 +11717,39 @@ type query_root {
     input parameters for function "get_pnl_leaderboard_aggregate"
     """
     args: get_pnl_leaderboard_args
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): pnl_leaderboard_entry_aggregate!
   """
   PnL leaderboard for a period - proxied through chart-api with Redis caching
   """
-  get_pnl_leaderboard_period(args: get_pnl_leaderboard_period_args!): [PnlLeaderboardEntryOutput!]
+  get_pnl_leaderboard_period(
+    args: get_pnl_leaderboard_period_args!
+  ): [PnlLeaderboardEntryOutput!]
   """
   PnL leaderboard for a period with min deposit threshold - filters out low-stake positions
   """
-  get_pnl_leaderboard_period_min_threshold(args: get_pnl_leaderboard_period_min_threshold_args!): [PnlLeaderboardEntryOutput!]
+  get_pnl_leaderboard_period_min_threshold(
+    args: get_pnl_leaderboard_period_min_threshold_args!
+  ): [PnlLeaderboardEntryOutput!]
   """
   execute function "get_pnl_leaderboard_stats" which returns "pnl_leaderboard_stats"
   """
@@ -8151,15 +11758,25 @@ type query_root {
     input parameters for function "get_pnl_leaderboard_stats"
     """
     args: get_pnl_leaderboard_stats_args
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_stats_bool_exp
   ): [pnl_leaderboard_stats!]!
   """
@@ -8170,15 +11787,25 @@ type query_root {
     input parameters for function "get_pnl_leaderboard_stats_aggregate"
     """
     args: get_pnl_leaderboard_stats_args
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_stats_bool_exp
   ): pnl_leaderboard_stats_aggregate!
   """
@@ -8189,15 +11816,25 @@ type query_root {
     input parameters for function "get_vault_leaderboard"
     """
     args: get_vault_leaderboard_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): [pnl_leaderboard_entry!]!
   """
@@ -8208,271 +11845,461 @@ type query_root {
     input parameters for function "get_vault_leaderboard_aggregate"
     """
     args: get_vault_leaderboard_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): pnl_leaderboard_entry_aggregate!
-  """fetch data from the table: "json_object" using primary key columns"""
+  """
+  fetch data from the table: "json_object" using primary key columns
+  """
   json_object(
-    """Unique identifier for this JSON object."""
+    """
+    Unique identifier for this JSON object.
+    """
     id: String!
   ): json_objects
   """
   fetch data from the table: "json_object"
   """
   json_objects(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [json_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [json_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: json_objects_bool_exp
   ): [json_objects!]!
   """
   fetch aggregated fields from the table: "json_object"
   """
   json_objects_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [json_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [json_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: json_objects_bool_exp
   ): json_objects_aggregate!
-  """fetch data from the table: "organization" using primary key columns"""
+  """
+  fetch data from the table: "organization" using primary key columns
+  """
   organization(
-    """Unique identifier for this organization entity."""
+    """
+    Unique identifier for this organization entity.
+    """
     id: String!
   ): organizations
   """
   fetch data from the table: "organization"
   """
   organizations(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [organizations_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [organizations_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: organizations_bool_exp
   ): [organizations!]!
   """
   fetch aggregated fields from the table: "organization"
   """
   organizations_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [organizations_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [organizations_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: organizations_bool_exp
   ): organizations_aggregate!
-  """fetch data from the table: "person" using primary key columns"""
+  """
+  fetch data from the table: "person" using primary key columns
+  """
   person(
-    """Unique identifier for this person entity."""
+    """
+    Unique identifier for this person entity.
+    """
     id: String!
   ): persons
   """
   fetch data from the table: "person"
   """
   persons(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [persons_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [persons_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: persons_bool_exp
   ): [persons!]!
   """
   fetch aggregated fields from the table: "person"
   """
   persons_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [persons_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [persons_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: persons_bool_exp
   ): persons_aggregate!
   """
   fetch data from the table: "pnl_leaderboard_entry"
   """
   pnl_leaderboard_entry(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): [pnl_leaderboard_entry!]!
   """
   fetch aggregated fields from the table: "pnl_leaderboard_entry"
   """
   pnl_leaderboard_entry_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): pnl_leaderboard_entry_aggregate!
   """
   fetch data from the table: "pnl_leaderboard_stats"
   """
   pnl_leaderboard_stats(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_stats_bool_exp
   ): [pnl_leaderboard_stats!]!
   """
   fetch aggregated fields from the table: "pnl_leaderboard_stats"
   """
   pnl_leaderboard_stats_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_stats_bool_exp
   ): pnl_leaderboard_stats_aggregate!
-  """fetch data from the table: "position" using primary key columns"""
+  """
+  fetch data from the table: "position" using primary key columns
+  """
   position(
-    """Unique identifier for this position."""
+    """
+    Unique identifier for this position.
+    """
     id: String!
   ): positions
   """
   fetch data from the table: "position_change_daily"
   """
   position_change_daily(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [position_change_daily_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [position_change_daily_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: position_change_daily_bool_exp
   ): [position_change_daily!]!
   """
   fetch data from the table: "position_change_hourly"
   """
   position_change_hourly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [position_change_hourly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [position_change_hourly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: position_change_hourly_bool_exp
   ): [position_change_hourly!]!
   """
   fetch data from the table: "position_change"
   """
   position_changes(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [position_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [position_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: position_changes_bool_exp
   ): [position_changes!]!
   """
   fetch aggregated fields from the table: "position_change"
   """
   position_changes_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [position_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [position_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: position_changes_bool_exp
   ): position_changes_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   positions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   positions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
   """
@@ -8483,15 +12310,25 @@ type query_root {
     input parameters for function "positions_from_following"
     """
     args: positions_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
   """
@@ -8502,149 +12339,251 @@ type query_root {
     input parameters for function "positions_from_following_aggregate"
     """
     args: positions_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
   """
   fetch data from the table: "position_with_value"
   """
   positions_with_value(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_with_value_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_with_value_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_with_value_bool_exp
   ): [positions_with_value!]!
   """
   fetch aggregated fields from the table: "position_with_value"
   """
   positions_with_value_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_with_value_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_with_value_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_with_value_bool_exp
   ): positions_with_value_aggregate!
   """
   fetch data from the table: "predicate_object"
   """
   predicate_objects(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [predicate_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [predicate_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: predicate_objects_bool_exp
   ): [predicate_objects!]!
   """
   fetch aggregated fields from the table: "predicate_object"
   """
   predicate_objects_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [predicate_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [predicate_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: predicate_objects_bool_exp
   ): predicate_objects_aggregate!
   """
   fetch data from the table: "predicate_object" using primary key columns
   """
   predicate_objects_by_pk(
-    """Object atom ID."""
+    """
+    Object atom ID.
+    """
     object_id: String!
-    """Predicate atom ID."""
+    """
+    Predicate atom ID.
+    """
     predicate_id: String!
   ): predicate_objects
   """
   fetch data from the table: "protocol_fee_accrued"
   """
   protocol_fee_accruals(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [protocol_fee_accruals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [protocol_fee_accruals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: protocol_fee_accruals_bool_exp
   ): [protocol_fee_accruals!]!
   """
   fetch aggregated fields from the table: "protocol_fee_accrued"
   """
   protocol_fee_accruals_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [protocol_fee_accruals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [protocol_fee_accruals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: protocol_fee_accruals_bool_exp
   ): protocol_fee_accruals_aggregate!
   """
   fetch data from the table: "protocol_fee_accrued" using primary key columns
   """
   protocol_fee_accrued(id: String!): protocol_fee_accruals
-  """fetch data from the table: "redemption" using primary key columns"""
+  """
+  fetch data from the table: "redemption" using primary key columns
+  """
   redemption(
-    """Unique identifier for this redemption event."""
+    """
+    Unique identifier for this redemption event.
+    """
     id: String!
   ): redemptions
-  """An array relationship"""
+  """
+  An array relationship
+  """
   redemptions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): [redemptions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   redemptions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): redemptions_aggregate!
   """
@@ -8655,15 +12594,25 @@ type query_root {
     input parameters for function "search_positions_on_subject"
     """
     args: search_positions_on_subject_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
   """
@@ -8674,15 +12623,25 @@ type query_root {
     input parameters for function "search_positions_on_subject_aggregate"
     """
     args: search_positions_on_subject_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
   """
@@ -8693,15 +12652,25 @@ type query_root {
     input parameters for function "search_term"
     """
     args: search_term_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): [terms!]!
   """
@@ -8712,15 +12681,25 @@ type query_root {
     input parameters for function "search_term_aggregate"
     """
     args: search_term_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): terms_aggregate!
   """
@@ -8731,15 +12710,25 @@ type query_root {
     input parameters for function "search_term_from_following"
     """
     args: search_term_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): [terms!]!
   """
@@ -8750,15 +12739,25 @@ type query_root {
     input parameters for function "search_term_from_following_aggregate"
     """
     args: search_term_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): terms_aggregate!
   """
@@ -8769,15 +12768,25 @@ type query_root {
     input parameters for function "search_term_tsvector"
     """
     args: search_term_tsvector_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): [terms!]!
   """
@@ -8788,18 +12797,30 @@ type query_root {
     input parameters for function "search_term_tsvector_aggregate"
     """
     args: search_term_tsvector_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): terms_aggregate!
-  """fetch data from the table: "season2_epoch" using primary key columns"""
+  """
+  fetch data from the table: "season2_epoch" using primary key columns
+  """
   season2_epoch(epoch: Int!): season2_epochs
   """
   fetch data from the table: "season2_epoch_price" using primary key columns
@@ -8809,90 +12830,154 @@ type query_root {
   fetch data from the table: "season2_epoch_price"
   """
   season2_epoch_prices(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_epoch_prices_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_epoch_prices_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epoch_prices_bool_exp
   ): [season2_epoch_prices!]!
   """
   fetch aggregated fields from the table: "season2_epoch_price"
   """
   season2_epoch_prices_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_epoch_prices_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_epoch_prices_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epoch_prices_bool_exp
   ): season2_epoch_prices_aggregate!
   """
   fetch data from the table: "season2_epoch"
   """
   season2_epochs(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_epochs_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_epochs_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epochs_bool_exp
   ): [season2_epochs!]!
   """
   fetch aggregated fields from the table: "season2_epoch"
   """
   season2_epochs_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_epochs_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_epochs_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epochs_bool_exp
   ): season2_epochs_aggregate!
   """
   fetch data from the table: "season2_iq_ledger" using primary key columns
   """
   season2_iq_ledger(id: bigint!): season2_iq_ledger_entries
-  """An array relationship"""
+  """
+  An array relationship
+  """
   season2_iq_ledger_entries(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_iq_ledger_entries_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_iq_ledger_entries_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_iq_ledger_entries_bool_exp
   ): [season2_iq_ledger_entries!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   season2_iq_ledger_entries_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_iq_ledger_entries_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_iq_ledger_entries_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_iq_ledger_entries_bool_exp
   ): season2_iq_ledger_entries_aggregate!
   """
@@ -8903,228 +12988,406 @@ type query_root {
   fetch data from the table: "season2_leaderboard_payout"
   """
   season2_leaderboard_payouts(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_leaderboard_payouts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_leaderboard_payouts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_leaderboard_payouts_bool_exp
   ): [season2_leaderboard_payouts!]!
   """
   fetch aggregated fields from the table: "season2_leaderboard_payout"
   """
   season2_leaderboard_payouts_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_leaderboard_payouts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_leaderboard_payouts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_leaderboard_payouts_bool_exp
   ): season2_leaderboard_payouts_aggregate!
   """
   fetch data from the table: "season2_trust_price_snapshot" using primary key columns
   """
-  season2_trust_price_snapshot(snapshot_at: timestamptz!): season2_trust_price_snapshots
+  season2_trust_price_snapshot(
+    snapshot_at: timestamptz!
+  ): season2_trust_price_snapshots
   """
   fetch data from the table: "season2_trust_price_snapshot"
   """
   season2_trust_price_snapshots(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_trust_price_snapshots_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_trust_price_snapshots_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_trust_price_snapshots_bool_exp
   ): [season2_trust_price_snapshots!]!
   """
   fetch aggregated fields from the table: "season2_trust_price_snapshot"
   """
   season2_trust_price_snapshots_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_trust_price_snapshots_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_trust_price_snapshots_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_trust_price_snapshots_bool_exp
   ): season2_trust_price_snapshots_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_daily(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_daily_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_daily_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_daily_bool_exp
   ): [share_price_change_stats_daily!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_hourly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_hourly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_hourly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_hourly_bool_exp
   ): [share_price_change_stats_hourly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_monthly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_monthly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_monthly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_monthly_bool_exp
   ): [share_price_change_stats_monthly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_weekly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_weekly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_weekly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_weekly_bool_exp
   ): [share_price_change_stats_weekly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_changes(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_changes_bool_exp
   ): [share_price_changes!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   share_price_changes_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_changes_bool_exp
   ): share_price_changes_aggregate!
   """
   fetch data from the table: "signal_stats_daily"
   """
   signal_stats_daily(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signal_stats_daily_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signal_stats_daily_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_daily_bool_exp
   ): [signal_stats_daily!]!
   """
   fetch data from the table: "signal_stats_hourly"
   """
   signal_stats_hourly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signal_stats_hourly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signal_stats_hourly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_hourly_bool_exp
   ): [signal_stats_hourly!]!
   """
   fetch data from the table: "signal_stats_monthly"
   """
   signal_stats_monthly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signal_stats_monthly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signal_stats_monthly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_monthly_bool_exp
   ): [signal_stats_monthly!]!
   """
   fetch data from the table: "signal_stats_weekly"
   """
   signal_stats_weekly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signal_stats_weekly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signal_stats_weekly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_weekly_bool_exp
   ): [signal_stats_weekly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   signals(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): [signals!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   signals_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): signals_aggregate!
   """
@@ -9135,15 +13398,25 @@ type query_root {
     input parameters for function "signals_from_following"
     """
     args: signals_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): [signals!]!
   """
@@ -9154,393 +13427,677 @@ type query_root {
     input parameters for function "signals_from_following_aggregate"
     """
     args: signals_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): signals_aggregate!
-  """fetch data from the table: "stats" using primary key columns"""
+  """
+  fetch data from the table: "stats" using primary key columns
+  """
   stat(
-    """Primary key, always 0 for singleton pattern."""
+    """
+    Primary key, always 0 for singleton pattern.
+    """
     id: Int!
   ): stats
-  """fetch data from the table: "stats_hour" using primary key columns"""
+  """
+  fetch data from the table: "stats_hour" using primary key columns
+  """
   statHour(
-    """Auto-incrementing primary key."""
+    """
+    Auto-incrementing primary key.
+    """
     id: Int!
   ): statHours
   """
   fetch data from the table: "stats_hour"
   """
   statHours(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [statHours_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [statHours_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: statHours_bool_exp
   ): [statHours!]!
   """
   fetch data from the table: "stats"
   """
   stats(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: stats_bool_exp
   ): [stats!]!
   """
   fetch aggregated fields from the table: "stats"
   """
   stats_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: stats_bool_exp
   ): stats_aggregate!
   """
   fetch data from the table: "subject_predicate"
   """
   subject_predicates(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [subject_predicates_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [subject_predicates_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: subject_predicates_bool_exp
   ): [subject_predicates!]!
   """
   fetch aggregated fields from the table: "subject_predicate"
   """
   subject_predicates_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [subject_predicates_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [subject_predicates_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: subject_predicates_bool_exp
   ): subject_predicates_aggregate!
   """
   fetch data from the table: "subject_predicate" using primary key columns
   """
   subject_predicates_by_pk(
-    """Predicate atom ID."""
+    """
+    Predicate atom ID.
+    """
     predicate_id: String!
-    """Subject atom ID."""
+    """
+    Subject atom ID.
+    """
     subject_id: String!
   ): subject_predicates
-  """fetch data from the table: "term" using primary key columns"""
+  """
+  fetch data from the table: "term" using primary key columns
+  """
   term(
-    """Unique term identifier (vault ID for atoms/triples)."""
+    """
+    Unique term identifier (vault ID for atoms/triples).
+    """
     id: String!
   ): terms
   """
   fetch data from the table: "term_total_state_change_stats_daily"
   """
   term_total_state_change_stats_daily(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_daily_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_daily_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_daily_bool_exp
   ): [term_total_state_change_stats_daily!]!
   """
   fetch data from the table: "term_total_state_change_stats_hourly"
   """
   term_total_state_change_stats_hourly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_hourly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_hourly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_hourly_bool_exp
   ): [term_total_state_change_stats_hourly!]!
   """
   fetch data from the table: "term_total_state_change_stats_monthly"
   """
   term_total_state_change_stats_monthly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_monthly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_monthly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_monthly_bool_exp
   ): [term_total_state_change_stats_monthly!]!
   """
   fetch data from the table: "term_total_state_change_stats_weekly"
   """
   term_total_state_change_stats_weekly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_weekly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_weekly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_weekly_bool_exp
   ): [term_total_state_change_stats_weekly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   term_total_state_changes(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_changes_bool_exp
   ): [term_total_state_changes!]!
   """
   fetch data from the table: "term"
   """
   terms(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): [terms!]!
   """
   fetch aggregated fields from the table: "term"
   """
   terms_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): terms_aggregate!
-  """fetch data from the table: "text_object" using primary key columns"""
+  """
+  fetch data from the table: "text_object" using primary key columns
+  """
   text_object(
-    """Unique identifier for this text object."""
+    """
+    Unique identifier for this text object.
+    """
     id: String!
   ): text_objects
   """
   fetch data from the table: "text_object"
   """
   text_objects(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [text_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [text_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: text_objects_bool_exp
   ): [text_objects!]!
   """
   fetch aggregated fields from the table: "text_object"
   """
   text_objects_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [text_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [text_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: text_objects_bool_exp
   ): text_objects_aggregate!
-  """fetch data from the table: "thing" using primary key columns"""
+  """
+  fetch data from the table: "thing" using primary key columns
+  """
   thing(
-    """Unique identifier for this thing entity."""
+    """
+    Unique identifier for this thing entity.
+    """
     id: String!
   ): things
   """
   fetch data from the table: "thing"
   """
   things(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [things_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [things_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: things_bool_exp
   ): [things!]!
   """
   fetch aggregated fields from the table: "thing"
   """
   things_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [things_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [things_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: things_bool_exp
   ): things_aggregate!
-  """fetch data from the table: "triple" using primary key columns"""
+  """
+  fetch data from the table: "triple" using primary key columns
+  """
   triple(
-    """Unique identifier linking to the term registry."""
+    """
+    Unique identifier linking to the term registry.
+    """
     term_id: String!
   ): triples
-  """fetch data from the table: "triple_term" using primary key columns"""
+  """
+  fetch data from the table: "triple_term" using primary key columns
+  """
   triple_term(
-    """Triple term ID this aggregated data represents."""
+    """
+    Triple term ID this aggregated data represents.
+    """
     term_id: String!
   ): triple_term
   """
   fetch data from the table: "triple_term"
   """
   triple_terms(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triple_term_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triple_term_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triple_term_bool_exp
   ): [triple_term!]!
-  """fetch data from the table: "triple_vault" using primary key columns"""
+  """
+  fetch data from the table: "triple_vault" using primary key columns
+  """
   triple_vault(
-    """Bonding curve ID for this vault."""
+    """
+    Bonding curve ID for this vault.
+    """
     curve_id: numeric!
-    """Triple term ID this aggregated vault data represents."""
+    """
+    Triple term ID this aggregated vault data represents.
+    """
     term_id: String!
   ): triple_vault
   """
   fetch data from the table: "triple_vault"
   """
   triple_vaults(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triple_vault_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triple_vault_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triple_vault_bool_exp
   ): [triple_vault!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   triples(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): [triples!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   triples_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): triples_aggregate!
-  """fetch data from the table: "vault" using primary key columns"""
+  """
+  fetch data from the table: "vault" using primary key columns
+  """
   vault(
-    """Bonding curve configuration ID determining pricing curve."""
+    """
+    Bonding curve configuration ID determining pricing curve.
+    """
     curve_id: numeric!
-    """Term ID this vault backs (atom or triple)."""
+    """
+    Term ID this vault backs (atom or triple).
+    """
     term_id: String!
   ): vaults
-  """An array relationship"""
+  """
+  An array relationship
+  """
   vaults(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [vaults_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [vaults_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: vaults_bool_exp
   ): [vaults!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   vaults_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [vaults_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [vaults_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: vaults_bool_exp
   ): vaults_aggregate!
 }
@@ -9549,41 +14106,77 @@ type query_root {
 Redemption transactions where users burn shares and receive assets back from vaults.
 """
 type redemptions {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: numeric!
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: numeric!
-  """Timestamp when redemption occurred."""
+  """
+  Timestamp when redemption occurred.
+  """
   created_at: timestamptz!
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric!
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: numeric!
-  """Unique identifier for this redemption event."""
+  """
+  Unique identifier for this redemption event.
+  """
   id: String!
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   receiver: accounts
-  """Account that received the redeemed assets."""
+  """
+  Account that received the redeemed assets.
+  """
   receiver_id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   sender: accounts
-  """Account that initiated the redemption."""
+  """
+  Account that initiated the redemption.
+  """
   sender_id: String!
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: numeric!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
-  """Term ID of the vault being redeemed from."""
+  """
+  Term ID of the vault being redeemed from.
+  """
   term_id: String!
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: numeric!
-  """Transaction hash of the redemption event."""
+  """
+  Transaction hash of the redemption event.
+  """
   transaction_hash: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   vault: vaults
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type!
 }
 
@@ -9640,21 +14233,37 @@ input redemptions_aggregate_order_by {
   variance: redemptions_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type redemptions_avg_fields {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: Float
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: Float
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: Float
 }
 
@@ -9662,19 +14271,33 @@ type redemptions_avg_fields {
 order by avg() on columns of table "redemption"
 """
 input redemptions_avg_order_by {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: order_by
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: order_by
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: order_by
 }
 
@@ -9705,35 +14328,65 @@ input redemptions_bool_exp {
   vault_type: vault_type_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type redemptions_max_fields {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: numeric
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: numeric
-  """Timestamp when redemption occurred."""
+  """
+  Timestamp when redemption occurred.
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: numeric
-  """Unique identifier for this redemption event."""
+  """
+  Unique identifier for this redemption event.
+  """
   id: String
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
-  """Account that received the redeemed assets."""
+  """
+  Account that received the redeemed assets.
+  """
   receiver_id: String
-  """Account that initiated the redemption."""
+  """
+  Account that initiated the redemption.
+  """
   sender_id: String
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: numeric
-  """Term ID of the vault being redeemed from."""
+  """
+  Term ID of the vault being redeemed from.
+  """
   term_id: String
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: numeric
-  """Transaction hash of the redemption event."""
+  """
+  Transaction hash of the redemption event.
+  """
   transaction_hash: String
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type
 }
 
@@ -9741,65 +14394,123 @@ type redemptions_max_fields {
 order by max() on columns of table "redemption"
 """
 input redemptions_max_order_by {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: order_by
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: order_by
-  """Timestamp when redemption occurred."""
+  """
+  Timestamp when redemption occurred.
+  """
   created_at: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: order_by
-  """Unique identifier for this redemption event."""
+  """
+  Unique identifier for this redemption event.
+  """
   id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Account that received the redeemed assets."""
+  """
+  Account that received the redeemed assets.
+  """
   receiver_id: order_by
-  """Account that initiated the redemption."""
+  """
+  Account that initiated the redemption.
+  """
   sender_id: order_by
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: order_by
-  """Term ID of the vault being redeemed from."""
+  """
+  Term ID of the vault being redeemed from.
+  """
   term_id: order_by
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: order_by
-  """Transaction hash of the redemption event."""
+  """
+  Transaction hash of the redemption event.
+  """
   transaction_hash: order_by
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type redemptions_min_fields {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: numeric
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: numeric
-  """Timestamp when redemption occurred."""
+  """
+  Timestamp when redemption occurred.
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: numeric
-  """Unique identifier for this redemption event."""
+  """
+  Unique identifier for this redemption event.
+  """
   id: String
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
-  """Account that received the redeemed assets."""
+  """
+  Account that received the redeemed assets.
+  """
   receiver_id: String
-  """Account that initiated the redemption."""
+  """
+  Account that initiated the redemption.
+  """
   sender_id: String
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: numeric
-  """Term ID of the vault being redeemed from."""
+  """
+  Term ID of the vault being redeemed from.
+  """
   term_id: String
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: numeric
-  """Transaction hash of the redemption event."""
+  """
+  Transaction hash of the redemption event.
+  """
   transaction_hash: String
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type
 }
 
@@ -9807,37 +14518,67 @@ type redemptions_min_fields {
 order by min() on columns of table "redemption"
 """
 input redemptions_min_order_by {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: order_by
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: order_by
-  """Timestamp when redemption occurred."""
+  """
+  Timestamp when redemption occurred.
+  """
   created_at: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: order_by
-  """Unique identifier for this redemption event."""
+  """
+  Unique identifier for this redemption event.
+  """
   id: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Account that received the redeemed assets."""
+  """
+  Account that received the redeemed assets.
+  """
   receiver_id: order_by
-  """Account that initiated the redemption."""
+  """
+  Account that initiated the redemption.
+  """
   sender_id: order_by
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: order_by
-  """Term ID of the vault being redeemed from."""
+  """
+  Term ID of the vault being redeemed from.
+  """
   term_id: order_by
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: order_by
-  """Transaction hash of the redemption event."""
+  """
+  Transaction hash of the redemption event.
+  """
   transaction_hash: order_by
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: order_by
 }
 
-"""Ordering options when selecting data from "redemption"."""
+"""
+Ordering options when selecting data from "redemption".
+"""
 input redemptions_order_by {
   assets: order_by
   block_number: order_by
@@ -9863,51 +14604,95 @@ input redemptions_order_by {
 select columns of table "redemption"
 """
 enum redemptions_select_column {
-  """column name"""
+  """
+  column name
+  """
   assets
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   fees
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   log_index
-  """column name"""
+  """
+  column name
+  """
   receiver_id
-  """column name"""
+  """
+  column name
+  """
   sender_id
-  """column name"""
+  """
+  column name
+  """
   shares
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   total_shares
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
-  """column name"""
+  """
+  column name
+  """
   vault_type
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type redemptions_stddev_fields {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: Float
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: Float
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: Float
 }
 
@@ -9915,37 +14700,67 @@ type redemptions_stddev_fields {
 order by stddev() on columns of table "redemption"
 """
 input redemptions_stddev_order_by {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: order_by
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: order_by
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type redemptions_stddev_pop_fields {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: Float
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: Float
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: Float
 }
 
@@ -9953,37 +14768,67 @@ type redemptions_stddev_pop_fields {
 order by stddev_pop() on columns of table "redemption"
 """
 input redemptions_stddev_pop_order_by {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: order_by
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: order_by
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type redemptions_stddev_samp_fields {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: Float
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: Float
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: Float
 }
 
@@ -9991,19 +14836,33 @@ type redemptions_stddev_samp_fields {
 order by stddev_samp() on columns of table "redemption"
 """
 input redemptions_stddev_samp_order_by {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: order_by
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: order_by
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: order_by
 }
 
@@ -10011,59 +14870,109 @@ input redemptions_stddev_samp_order_by {
 Streaming cursor of the table "redemptions"
 """
 input redemptions_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: redemptions_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input redemptions_stream_cursor_value_input {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: numeric
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: numeric
-  """Timestamp when redemption occurred."""
+  """
+  Timestamp when redemption occurred.
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: numeric
-  """Unique identifier for this redemption event."""
+  """
+  Unique identifier for this redemption event.
+  """
   id: String
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
-  """Account that received the redeemed assets."""
+  """
+  Account that received the redeemed assets.
+  """
   receiver_id: String
-  """Account that initiated the redemption."""
+  """
+  Account that initiated the redemption.
+  """
   sender_id: String
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: numeric
-  """Term ID of the vault being redeemed from."""
+  """
+  Term ID of the vault being redeemed from.
+  """
   term_id: String
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: numeric
-  """Transaction hash of the redemption event."""
+  """
+  Transaction hash of the redemption event.
+  """
   transaction_hash: String
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type redemptions_sum_fields {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: numeric
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: numeric
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: numeric
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: bigint
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: numeric
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: numeric
 }
 
@@ -10071,37 +14980,67 @@ type redemptions_sum_fields {
 order by sum() on columns of table "redemption"
 """
 input redemptions_sum_order_by {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: order_by
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: order_by
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type redemptions_var_pop_fields {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: Float
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: Float
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: Float
 }
 
@@ -10109,37 +15048,67 @@ type redemptions_var_pop_fields {
 order by var_pop() on columns of table "redemption"
 """
 input redemptions_var_pop_order_by {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: order_by
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: order_by
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type redemptions_var_samp_fields {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: Float
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: Float
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: Float
 }
 
@@ -10147,37 +15116,67 @@ type redemptions_var_samp_fields {
 order by var_samp() on columns of table "redemption"
 """
 input redemptions_var_samp_order_by {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: order_by
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: order_by
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type redemptions_variance_fields {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: Float
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: Float
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: Float
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: Float
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: Float
 }
 
@@ -10185,19 +15184,33 @@ type redemptions_variance_fields {
 order by variance() on columns of table "redemption"
 """
 input redemptions_variance_order_by {
-  """Asset amount returned before fees, in wei."""
+  """
+  Asset amount returned before fees, in wei.
+  """
   assets: order_by
-  """Block number when redemption occurred."""
+  """
+  Block number when redemption occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Protocol fees charged for this redemption, in wei."""
+  """
+  Protocol fees charged for this redemption, in wei.
+  """
   fees: order_by
-  """Log index within the transaction for event ordering."""
+  """
+  Log index within the transaction for event ordering.
+  """
   log_index: order_by
-  """Number of shares burned for this redemption."""
+  """
+  Number of shares burned for this redemption.
+  """
   shares: order_by
-  """Total shares in vault after this redemption."""
+  """
+  Total shares in vault after this redemption.
+  """
   total_shares: order_by
 }
 
@@ -10226,7 +15239,9 @@ type season2_epoch_prices {
   average_price_usd: numeric!
   computed_at: timestamptz!
   epoch: Int!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   season2_epoch: season2_epochs
   snapshot_count: Int!
   updated_at: timestamptz!
@@ -10285,7 +15300,9 @@ input season2_epoch_prices_aggregate_order_by {
   variance: season2_epoch_prices_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type season2_epoch_prices_avg_fields {
   average_price_usd: Float
   epoch: Float
@@ -10316,7 +15333,9 @@ input season2_epoch_prices_bool_exp {
   updated_at: timestamptz_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type season2_epoch_prices_max_fields {
   average_price_usd: numeric
   computed_at: timestamptz
@@ -10336,7 +15355,9 @@ input season2_epoch_prices_max_order_by {
   updated_at: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type season2_epoch_prices_min_fields {
   average_price_usd: numeric
   computed_at: timestamptz
@@ -10356,7 +15377,9 @@ input season2_epoch_prices_min_order_by {
   updated_at: order_by
 }
 
-"""Ordering options when selecting data from "season2_epoch_price"."""
+"""
+Ordering options when selecting data from "season2_epoch_price".
+"""
 input season2_epoch_prices_order_by {
   average_price_usd: order_by
   computed_at: order_by
@@ -10370,19 +15393,31 @@ input season2_epoch_prices_order_by {
 select columns of table "season2_epoch_price"
 """
 enum season2_epoch_prices_select_column {
-  """column name"""
+  """
+  column name
+  """
   average_price_usd
-  """column name"""
+  """
+  column name
+  """
   computed_at
-  """column name"""
+  """
+  column name
+  """
   epoch
-  """column name"""
+  """
+  column name
+  """
   snapshot_count
-  """column name"""
+  """
+  column name
+  """
   updated_at
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type season2_epoch_prices_stddev_fields {
   average_price_usd: Float
   epoch: Float
@@ -10398,7 +15433,9 @@ input season2_epoch_prices_stddev_order_by {
   snapshot_count: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type season2_epoch_prices_stddev_pop_fields {
   average_price_usd: Float
   epoch: Float
@@ -10414,7 +15451,9 @@ input season2_epoch_prices_stddev_pop_order_by {
   snapshot_count: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type season2_epoch_prices_stddev_samp_fields {
   average_price_usd: Float
   epoch: Float
@@ -10434,13 +15473,19 @@ input season2_epoch_prices_stddev_samp_order_by {
 Streaming cursor of the table "season2_epoch_prices"
 """
 input season2_epoch_prices_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: season2_epoch_prices_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input season2_epoch_prices_stream_cursor_value_input {
   average_price_usd: numeric
   computed_at: timestamptz
@@ -10449,7 +15494,9 @@ input season2_epoch_prices_stream_cursor_value_input {
   updated_at: timestamptz
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type season2_epoch_prices_sum_fields {
   average_price_usd: numeric
   epoch: Int
@@ -10465,7 +15512,9 @@ input season2_epoch_prices_sum_order_by {
   snapshot_count: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type season2_epoch_prices_var_pop_fields {
   average_price_usd: Float
   epoch: Float
@@ -10481,7 +15530,9 @@ input season2_epoch_prices_var_pop_order_by {
   snapshot_count: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type season2_epoch_prices_var_samp_fields {
   average_price_usd: Float
   epoch: Float
@@ -10497,7 +15548,9 @@ input season2_epoch_prices_var_samp_order_by {
   snapshot_count: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type season2_epoch_prices_variance_fields {
   average_price_usd: Float
   epoch: Float
@@ -10520,57 +15573,105 @@ type season2_epochs {
   created_at: timestamptz!
   end_at: timestamptz!
   epoch: Int!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   epoch_price(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_epoch_prices_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_epoch_prices_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epoch_prices_bool_exp
   ): [season2_epoch_prices!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   epoch_price_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_epoch_prices_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_epoch_prices_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epoch_prices_bool_exp
   ): season2_epoch_prices_aggregate!
   finalized_at: timestamptz
-  """An array relationship"""
+  """
+  An array relationship
+  """
   iq_ledger_entries(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_iq_ledger_entries_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_iq_ledger_entries_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_iq_ledger_entries_bool_exp
   ): [season2_iq_ledger_entries!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   iq_ledger_entries_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_iq_ledger_entries_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_iq_ledger_entries_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_iq_ledger_entries_bool_exp
   ): season2_iq_ledger_entries_aggregate!
   is_final: Boolean!
@@ -10606,7 +15707,9 @@ type season2_epochs_aggregate_fields {
   variance: season2_epochs_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type season2_epochs_avg_fields {
   epoch: Float
 }
@@ -10634,7 +15737,9 @@ input season2_epochs_bool_exp {
   updated_at: timestamptz_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type season2_epochs_max_fields {
   created_at: timestamptz
   end_at: timestamptz
@@ -10646,7 +15751,9 @@ type season2_epochs_max_fields {
   updated_at: timestamptz
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type season2_epochs_min_fields {
   created_at: timestamptz
   end_at: timestamptz
@@ -10658,7 +15765,9 @@ type season2_epochs_min_fields {
   updated_at: timestamptz
 }
 
-"""Ordering options when selecting data from "season2_epoch"."""
+"""
+Ordering options when selecting data from "season2_epoch".
+"""
 input season2_epochs_order_by {
   created_at: order_by
   end_at: order_by
@@ -10678,39 +15787,65 @@ input season2_epochs_order_by {
 select columns of table "season2_epoch"
 """
 enum season2_epochs_select_column {
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   end_at
-  """column name"""
+  """
+  column name
+  """
   epoch
-  """column name"""
+  """
+  column name
+  """
   finalized_at
-  """column name"""
+  """
+  column name
+  """
   is_final
-  """column name"""
+  """
+  column name
+  """
   last_settlement_force
-  """column name"""
+  """
+  column name
+  """
   settle_after
-  """column name"""
+  """
+  column name
+  """
   settled_at
-  """column name"""
+  """
+  column name
+  """
   start_at
-  """column name"""
+  """
+  column name
+  """
   updated_at
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type season2_epochs_stddev_fields {
   epoch: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type season2_epochs_stddev_pop_fields {
   epoch: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type season2_epochs_stddev_samp_fields {
   epoch: Float
 }
@@ -10719,13 +15854,19 @@ type season2_epochs_stddev_samp_fields {
 Streaming cursor of the table "season2_epochs"
 """
 input season2_epochs_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: season2_epochs_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input season2_epochs_stream_cursor_value_input {
   created_at: timestamptz
   end_at: timestamptz
@@ -10739,22 +15880,30 @@ input season2_epochs_stream_cursor_value_input {
   updated_at: timestamptz
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type season2_epochs_sum_fields {
   epoch: Int
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type season2_epochs_var_pop_fields {
   epoch: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type season2_epochs_var_samp_fields {
   epoch: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type season2_epochs_variance_fields {
   epoch: Float
 }
@@ -10763,7 +15912,9 @@ type season2_epochs_variance_fields {
 columns and relationships of "season2_iq_ledger"
 """
 type season2_iq_ledger_entries {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   account: accounts
   account_id: String!
   created_at: timestamptz!
@@ -10772,10 +15923,14 @@ type season2_iq_ledger_entries {
   id: bigint!
   iq_points: numeric!
   metadata(
-    """JSON select path"""
+    """
+    JSON select path
+    """
     path: String
   ): jsonb!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   season2_epoch: season2_epochs
   source_id: String!
   updated_at: timestamptz!
@@ -10805,7 +15960,10 @@ aggregate fields of "season2_iq_ledger"
 """
 type season2_iq_ledger_entries_aggregate_fields {
   avg: season2_iq_ledger_entries_avg_fields
-  count(columns: [season2_iq_ledger_entries_select_column!], distinct: Boolean): Int!
+  count(
+    columns: [season2_iq_ledger_entries_select_column!]
+    distinct: Boolean
+  ): Int!
   max: season2_iq_ledger_entries_max_fields
   min: season2_iq_ledger_entries_min_fields
   stddev: season2_iq_ledger_entries_stddev_fields
@@ -10834,7 +15992,9 @@ input season2_iq_ledger_entries_aggregate_order_by {
   variance: season2_iq_ledger_entries_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type season2_iq_ledger_entries_avg_fields {
   epoch: Float
   id: Float
@@ -10870,7 +16030,9 @@ input season2_iq_ledger_entries_bool_exp {
   updated_at: timestamptz_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type season2_iq_ledger_entries_max_fields {
   account_id: String
   created_at: timestamptz
@@ -10896,7 +16058,9 @@ input season2_iq_ledger_entries_max_order_by {
   updated_at: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type season2_iq_ledger_entries_min_fields {
   account_id: String
   created_at: timestamptz
@@ -10922,7 +16086,9 @@ input season2_iq_ledger_entries_min_order_by {
   updated_at: order_by
 }
 
-"""Ordering options when selecting data from "season2_iq_ledger"."""
+"""
+Ordering options when selecting data from "season2_iq_ledger".
+"""
 input season2_iq_ledger_entries_order_by {
   account: accounts_order_by
   account_id: order_by
@@ -10941,27 +16107,47 @@ input season2_iq_ledger_entries_order_by {
 select columns of table "season2_iq_ledger"
 """
 enum season2_iq_ledger_entries_select_column {
-  """column name"""
+  """
+  column name
+  """
   account_id
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   entry_type
-  """column name"""
+  """
+  column name
+  """
   epoch
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   iq_points
-  """column name"""
+  """
+  column name
+  """
   metadata
-  """column name"""
+  """
+  column name
+  """
   source_id
-  """column name"""
+  """
+  column name
+  """
   updated_at
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type season2_iq_ledger_entries_stddev_fields {
   epoch: Float
   id: Float
@@ -10977,7 +16163,9 @@ input season2_iq_ledger_entries_stddev_order_by {
   iq_points: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type season2_iq_ledger_entries_stddev_pop_fields {
   epoch: Float
   id: Float
@@ -10993,7 +16181,9 @@ input season2_iq_ledger_entries_stddev_pop_order_by {
   iq_points: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type season2_iq_ledger_entries_stddev_samp_fields {
   epoch: Float
   id: Float
@@ -11013,13 +16203,19 @@ input season2_iq_ledger_entries_stddev_samp_order_by {
 Streaming cursor of the table "season2_iq_ledger_entries"
 """
 input season2_iq_ledger_entries_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: season2_iq_ledger_entries_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input season2_iq_ledger_entries_stream_cursor_value_input {
   account_id: String
   created_at: timestamptz
@@ -11032,7 +16228,9 @@ input season2_iq_ledger_entries_stream_cursor_value_input {
   updated_at: timestamptz
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type season2_iq_ledger_entries_sum_fields {
   epoch: Int
   id: bigint
@@ -11048,7 +16246,9 @@ input season2_iq_ledger_entries_sum_order_by {
   iq_points: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type season2_iq_ledger_entries_var_pop_fields {
   epoch: Float
   id: Float
@@ -11064,7 +16264,9 @@ input season2_iq_ledger_entries_var_pop_order_by {
   iq_points: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type season2_iq_ledger_entries_var_samp_fields {
   epoch: Float
   id: Float
@@ -11080,7 +16282,9 @@ input season2_iq_ledger_entries_var_samp_order_by {
   iq_points: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type season2_iq_ledger_entries_variance_fields {
   epoch: Float
   id: Float
@@ -11117,7 +16321,10 @@ aggregate fields of "season2_leaderboard_payout"
 """
 type season2_leaderboard_payouts_aggregate_fields {
   avg: season2_leaderboard_payouts_avg_fields
-  count(columns: [season2_leaderboard_payouts_select_column!], distinct: Boolean): Int!
+  count(
+    columns: [season2_leaderboard_payouts_select_column!]
+    distinct: Boolean
+  ): Int!
   max: season2_leaderboard_payouts_max_fields
   min: season2_leaderboard_payouts_min_fields
   stddev: season2_leaderboard_payouts_stddev_fields
@@ -11129,7 +16336,9 @@ type season2_leaderboard_payouts_aggregate_fields {
   variance: season2_leaderboard_payouts_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type season2_leaderboard_payouts_avg_fields {
   iq_points: Float
   rank: Float
@@ -11146,13 +16355,17 @@ input season2_leaderboard_payouts_bool_exp {
   rank: Int_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type season2_leaderboard_payouts_max_fields {
   iq_points: numeric
   rank: Int
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type season2_leaderboard_payouts_min_fields {
   iq_points: numeric
   rank: Int
@@ -11170,25 +16383,35 @@ input season2_leaderboard_payouts_order_by {
 select columns of table "season2_leaderboard_payout"
 """
 enum season2_leaderboard_payouts_select_column {
-  """column name"""
+  """
+  column name
+  """
   iq_points
-  """column name"""
+  """
+  column name
+  """
   rank
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type season2_leaderboard_payouts_stddev_fields {
   iq_points: Float
   rank: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type season2_leaderboard_payouts_stddev_pop_fields {
   iq_points: Float
   rank: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type season2_leaderboard_payouts_stddev_samp_fields {
   iq_points: Float
   rank: Float
@@ -11198,37 +16421,51 @@ type season2_leaderboard_payouts_stddev_samp_fields {
 Streaming cursor of the table "season2_leaderboard_payouts"
 """
 input season2_leaderboard_payouts_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: season2_leaderboard_payouts_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input season2_leaderboard_payouts_stream_cursor_value_input {
   iq_points: numeric
   rank: Int
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type season2_leaderboard_payouts_sum_fields {
   iq_points: numeric
   rank: Int
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type season2_leaderboard_payouts_var_pop_fields {
   iq_points: Float
   rank: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type season2_leaderboard_payouts_var_samp_fields {
   iq_points: Float
   rank: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type season2_leaderboard_payouts_variance_fields {
   iq_points: Float
   rank: Float
@@ -11259,7 +16496,10 @@ aggregate fields of "season2_trust_price_snapshot"
 """
 type season2_trust_price_snapshots_aggregate_fields {
   avg: season2_trust_price_snapshots_avg_fields
-  count(columns: [season2_trust_price_snapshots_select_column!], distinct: Boolean): Int!
+  count(
+    columns: [season2_trust_price_snapshots_select_column!]
+    distinct: Boolean
+  ): Int!
   max: season2_trust_price_snapshots_max_fields
   min: season2_trust_price_snapshots_min_fields
   stddev: season2_trust_price_snapshots_stddev_fields
@@ -11271,7 +16511,9 @@ type season2_trust_price_snapshots_aggregate_fields {
   variance: season2_trust_price_snapshots_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type season2_trust_price_snapshots_avg_fields {
   price_usd: Float
 }
@@ -11291,7 +16533,9 @@ input season2_trust_price_snapshots_bool_exp {
   updated_at: timestamptz_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type season2_trust_price_snapshots_max_fields {
   created_at: timestamptz
   price_usd: numeric
@@ -11301,7 +16545,9 @@ type season2_trust_price_snapshots_max_fields {
   updated_at: timestamptz
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type season2_trust_price_snapshots_min_fields {
   created_at: timestamptz
   price_usd: numeric
@@ -11327,31 +16573,49 @@ input season2_trust_price_snapshots_order_by {
 select columns of table "season2_trust_price_snapshot"
 """
 enum season2_trust_price_snapshots_select_column {
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   price_usd
-  """column name"""
+  """
+  column name
+  """
   snapshot_at
-  """column name"""
+  """
+  column name
+  """
   source
-  """column name"""
+  """
+  column name
+  """
   source_ref
-  """column name"""
+  """
+  column name
+  """
   updated_at
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type season2_trust_price_snapshots_stddev_fields {
   price_usd: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type season2_trust_price_snapshots_stddev_pop_fields {
   price_usd: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type season2_trust_price_snapshots_stddev_samp_fields {
   price_usd: Float
 }
@@ -11360,13 +16624,19 @@ type season2_trust_price_snapshots_stddev_samp_fields {
 Streaming cursor of the table "season2_trust_price_snapshots"
 """
 input season2_trust_price_snapshots_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: season2_trust_price_snapshots_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input season2_trust_price_snapshots_stream_cursor_value_input {
   created_at: timestamptz
   price_usd: numeric
@@ -11376,27 +16646,37 @@ input season2_trust_price_snapshots_stream_cursor_value_input {
   updated_at: timestamptz
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type season2_trust_price_snapshots_sum_fields {
   price_usd: numeric
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type season2_trust_price_snapshots_var_pop_fields {
   price_usd: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type season2_trust_price_snapshots_var_samp_fields {
   price_usd: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type season2_trust_price_snapshots_variance_fields {
   price_usd: Float
 }
 
-"""Daily share price statistics rolled up from hourly stats."""
+"""
+Daily share price statistics rolled up from hourly stats.
+"""
 type share_price_change_stats_daily {
   bucket: timestamptz
   change_count: numeric
@@ -11404,7 +16684,9 @@ type share_price_change_stats_daily {
   difference: numeric
   first_share_price: numeric
   last_share_price: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String
 }
@@ -11498,19 +16780,33 @@ input share_price_change_stats_daily_order_by {
 select columns of table "share_price_change_stats_daily"
 """
 enum share_price_change_stats_daily_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   change_count
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   difference
-  """column name"""
+  """
+  column name
+  """
   first_share_price
-  """column name"""
+  """
+  column name
+  """
   last_share_price
-  """column name"""
+  """
+  column name
+  """
   term_id
 }
 
@@ -11551,13 +16847,19 @@ input share_price_change_stats_daily_stddev_samp_order_by {
 Streaming cursor of the table "share_price_change_stats_daily"
 """
 input share_price_change_stats_daily_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: share_price_change_stats_daily_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input share_price_change_stats_daily_stream_cursor_value_input {
   bucket: timestamptz
   change_count: numeric
@@ -11622,7 +16924,9 @@ type share_price_change_stats_hourly {
   difference: numeric
   first_share_price: numeric
   last_share_price: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String
 }
@@ -11716,19 +17020,33 @@ input share_price_change_stats_hourly_order_by {
 select columns of table "share_price_change_stats_hourly"
 """
 enum share_price_change_stats_hourly_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   change_count
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   difference
-  """column name"""
+  """
+  column name
+  """
   first_share_price
-  """column name"""
+  """
+  column name
+  """
   last_share_price
-  """column name"""
+  """
+  column name
+  """
   term_id
 }
 
@@ -11769,13 +17087,19 @@ input share_price_change_stats_hourly_stddev_samp_order_by {
 Streaming cursor of the table "share_price_change_stats_hourly"
 """
 input share_price_change_stats_hourly_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: share_price_change_stats_hourly_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input share_price_change_stats_hourly_stream_cursor_value_input {
   bucket: timestamptz
   change_count: bigint
@@ -11830,7 +17154,9 @@ input share_price_change_stats_hourly_variance_order_by {
   last_share_price: order_by
 }
 
-"""Monthly share price statistics rolled up from daily stats."""
+"""
+Monthly share price statistics rolled up from daily stats.
+"""
 type share_price_change_stats_monthly {
   bucket: timestamptz
   change_count: numeric
@@ -11838,7 +17164,9 @@ type share_price_change_stats_monthly {
   difference: numeric
   first_share_price: numeric
   last_share_price: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String
 }
@@ -11932,19 +17260,33 @@ input share_price_change_stats_monthly_order_by {
 select columns of table "share_price_change_stats_monthly"
 """
 enum share_price_change_stats_monthly_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   change_count
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   difference
-  """column name"""
+  """
+  column name
+  """
   first_share_price
-  """column name"""
+  """
+  column name
+  """
   last_share_price
-  """column name"""
+  """
+  column name
+  """
   term_id
 }
 
@@ -11985,13 +17327,19 @@ input share_price_change_stats_monthly_stddev_samp_order_by {
 Streaming cursor of the table "share_price_change_stats_monthly"
 """
 input share_price_change_stats_monthly_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: share_price_change_stats_monthly_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input share_price_change_stats_monthly_stream_cursor_value_input {
   bucket: timestamptz
   change_count: numeric
@@ -12046,7 +17394,9 @@ input share_price_change_stats_monthly_variance_order_by {
   last_share_price: order_by
 }
 
-"""Weekly share price statistics rolled up from daily stats."""
+"""
+Weekly share price statistics rolled up from daily stats.
+"""
 type share_price_change_stats_weekly {
   bucket: timestamptz
   change_count: numeric
@@ -12054,7 +17404,9 @@ type share_price_change_stats_weekly {
   difference: numeric
   first_share_price: numeric
   last_share_price: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String
 }
@@ -12148,19 +17500,33 @@ input share_price_change_stats_weekly_order_by {
 select columns of table "share_price_change_stats_weekly"
 """
 enum share_price_change_stats_weekly_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   change_count
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   difference
-  """column name"""
+  """
+  column name
+  """
   first_share_price
-  """column name"""
+  """
+  column name
+  """
   last_share_price
-  """column name"""
+  """
+  column name
+  """
   term_id
 }
 
@@ -12201,13 +17567,19 @@ input share_price_change_stats_weekly_stddev_samp_order_by {
 Streaming cursor of the table "share_price_change_stats_weekly"
 """
 input share_price_change_stats_weekly_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: share_price_change_stats_weekly_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input share_price_change_stats_weekly_stream_cursor_value_input {
   bucket: timestamptz
   change_count: numeric
@@ -12266,33 +17638,61 @@ input share_price_change_stats_weekly_variance_order_by {
 TimescaleDB hypertable tracking vault share price changes over time for historical analysis.
 """
 type share_price_changes {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: numeric!
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: bigint!
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric!
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: bigint!
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: bigint!
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: numeric!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
-  """Term ID of the vault."""
+  """
+  Term ID of the vault.
+  """
   term_id: String!
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: numeric!
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: numeric!
-  """Transaction hash that caused the price change."""
+  """
+  Transaction hash that caused the price change.
+  """
   transaction_hash: String!
-  """Timestamp when this record was created (TimescaleDB partition column)."""
+  """
+  Timestamp when this record was created (TimescaleDB partition column).
+  """
   updated_at: timestamptz!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   vault: vaults
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type!
 }
 
@@ -12349,23 +17749,41 @@ input share_price_changes_aggregate_order_by {
   variance: share_price_changes_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type share_price_changes_avg_fields {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: Float
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: Float
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: Float
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: Float
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: Float
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: Float
 }
 
@@ -12373,21 +17791,37 @@ type share_price_changes_avg_fields {
 order by avg() on columns of table "share_price_change"
 """
 input share_price_changes_avg_order_by {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: order_by
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: order_by
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: order_by
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: order_by
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: order_by
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: order_by
 }
 
@@ -12414,31 +17848,57 @@ input share_price_changes_bool_exp {
   vault_type: vault_type_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type share_price_changes_max_fields {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: numeric
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: bigint
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: bigint
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: bigint
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: numeric
-  """Term ID of the vault."""
+  """
+  Term ID of the vault.
+  """
   term_id: String
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: numeric
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: numeric
-  """Transaction hash that caused the price change."""
+  """
+  Transaction hash that caused the price change.
+  """
   transaction_hash: String
-  """Timestamp when this record was created (TimescaleDB partition column)."""
+  """
+  Timestamp when this record was created (TimescaleDB partition column).
+  """
   updated_at: timestamptz
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type
 }
 
@@ -12446,57 +17906,107 @@ type share_price_changes_max_fields {
 order by max() on columns of table "share_price_change"
 """
 input share_price_changes_max_order_by {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: order_by
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: order_by
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: order_by
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: order_by
-  """Term ID of the vault."""
+  """
+  Term ID of the vault.
+  """
   term_id: order_by
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: order_by
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: order_by
-  """Transaction hash that caused the price change."""
+  """
+  Transaction hash that caused the price change.
+  """
   transaction_hash: order_by
-  """Timestamp when this record was created (TimescaleDB partition column)."""
+  """
+  Timestamp when this record was created (TimescaleDB partition column).
+  """
   updated_at: order_by
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type share_price_changes_min_fields {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: numeric
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: bigint
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: bigint
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: bigint
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: numeric
-  """Term ID of the vault."""
+  """
+  Term ID of the vault.
+  """
   term_id: String
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: numeric
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: numeric
-  """Transaction hash that caused the price change."""
+  """
+  Transaction hash that caused the price change.
+  """
   transaction_hash: String
-  """Timestamp when this record was created (TimescaleDB partition column)."""
+  """
+  Timestamp when this record was created (TimescaleDB partition column).
+  """
   updated_at: timestamptz
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type
 }
 
@@ -12504,33 +18014,59 @@ type share_price_changes_min_fields {
 order by min() on columns of table "share_price_change"
 """
 input share_price_changes_min_order_by {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: order_by
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: order_by
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: order_by
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: order_by
-  """Term ID of the vault."""
+  """
+  Term ID of the vault.
+  """
   term_id: order_by
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: order_by
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: order_by
-  """Transaction hash that caused the price change."""
+  """
+  Transaction hash that caused the price change.
+  """
   transaction_hash: order_by
-  """Timestamp when this record was created (TimescaleDB partition column)."""
+  """
+  Timestamp when this record was created (TimescaleDB partition column).
+  """
   updated_at: order_by
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: order_by
 }
 
-"""Ordering options when selecting data from "share_price_change"."""
+"""
+Ordering options when selecting data from "share_price_change".
+"""
 input share_price_changes_order_by {
   block_number: order_by
   block_timestamp: order_by
@@ -12552,49 +18088,91 @@ input share_price_changes_order_by {
 select columns of table "share_price_change"
 """
 enum share_price_changes_select_column {
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   block_timestamp
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   log_index
-  """column name"""
+  """
+  column name
+  """
   share_price
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   total_assets
-  """column name"""
+  """
+  column name
+  """
   total_shares
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
-  """column name"""
+  """
+  column name
+  """
   updated_at
-  """column name"""
+  """
+  column name
+  """
   vault_type
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type share_price_changes_stddev_fields {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: Float
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: Float
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: Float
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: Float
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: Float
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: Float
 }
 
@@ -12602,41 +18180,75 @@ type share_price_changes_stddev_fields {
 order by stddev() on columns of table "share_price_change"
 """
 input share_price_changes_stddev_order_by {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: order_by
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: order_by
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: order_by
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: order_by
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: order_by
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type share_price_changes_stddev_pop_fields {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: Float
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: Float
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: Float
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: Float
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: Float
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: Float
 }
 
@@ -12644,41 +18256,75 @@ type share_price_changes_stddev_pop_fields {
 order by stddev_pop() on columns of table "share_price_change"
 """
 input share_price_changes_stddev_pop_order_by {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: order_by
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: order_by
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: order_by
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: order_by
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: order_by
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type share_price_changes_stddev_samp_fields {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: Float
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: Float
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: Float
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: Float
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: Float
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: Float
 }
 
@@ -12686,21 +18332,37 @@ type share_price_changes_stddev_samp_fields {
 order by stddev_samp() on columns of table "share_price_change"
 """
 input share_price_changes_stddev_samp_order_by {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: order_by
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: order_by
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: order_by
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: order_by
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: order_by
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: order_by
 }
 
@@ -12708,57 +18370,105 @@ input share_price_changes_stddev_samp_order_by {
 Streaming cursor of the table "share_price_changes"
 """
 input share_price_changes_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: share_price_changes_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input share_price_changes_stream_cursor_value_input {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: numeric
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: bigint
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: bigint
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: bigint
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: numeric
-  """Term ID of the vault."""
+  """
+  Term ID of the vault.
+  """
   term_id: String
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: numeric
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: numeric
-  """Transaction hash that caused the price change."""
+  """
+  Transaction hash that caused the price change.
+  """
   transaction_hash: String
-  """Timestamp when this record was created (TimescaleDB partition column)."""
+  """
+  Timestamp when this record was created (TimescaleDB partition column).
+  """
   updated_at: timestamptz
-  """Type of vault (Atom, Triple, CounterTriple)."""
+  """
+  Type of vault (Atom, Triple, CounterTriple).
+  """
   vault_type: vault_type
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type share_price_changes_sum_fields {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: numeric
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: bigint
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: bigint
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: bigint
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: numeric
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: numeric
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: numeric
 }
 
@@ -12766,41 +18476,75 @@ type share_price_changes_sum_fields {
 order by sum() on columns of table "share_price_change"
 """
 input share_price_changes_sum_order_by {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: order_by
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: order_by
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: order_by
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: order_by
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: order_by
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type share_price_changes_var_pop_fields {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: Float
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: Float
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: Float
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: Float
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: Float
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: Float
 }
 
@@ -12808,41 +18552,75 @@ type share_price_changes_var_pop_fields {
 order by var_pop() on columns of table "share_price_change"
 """
 input share_price_changes_var_pop_order_by {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: order_by
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: order_by
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: order_by
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: order_by
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: order_by
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type share_price_changes_var_samp_fields {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: Float
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: Float
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: Float
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: Float
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: Float
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: Float
 }
 
@@ -12850,41 +18628,75 @@ type share_price_changes_var_samp_fields {
 order by var_samp() on columns of table "share_price_change"
 """
 input share_price_changes_var_samp_order_by {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: order_by
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: order_by
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: order_by
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: order_by
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: order_by
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type share_price_changes_variance_fields {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: Float
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: Float
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: Float
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: Float
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: Float
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: Float
 }
 
@@ -12892,21 +18704,37 @@ type share_price_changes_variance_fields {
 order by variance() on columns of table "share_price_change"
 """
 input share_price_changes_variance_order_by {
-  """Block number when price changed."""
+  """
+  Block number when price changed.
+  """
   block_number: order_by
-  """Block timestamp in Unix epoch seconds."""
+  """
+  Block timestamp in Unix epoch seconds.
+  """
   block_timestamp: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: order_by
-  """Log index within the transaction."""
+  """
+  Log index within the transaction.
+  """
   log_index: order_by
-  """Share price at this point in time, in wei."""
+  """
+  Share price at this point in time, in wei.
+  """
   share_price: order_by
-  """Total assets in vault at this point, in wei."""
+  """
+  Total assets in vault at this point, in wei.
+  """
   total_assets: order_by
-  """Total shares in vault at this point."""
+  """
+  Total shares in vault at this point.
+  """
   total_shares: order_by
 }
 
@@ -12917,7 +18745,9 @@ type signal_stats_daily {
   bucket: timestamptz
   count: numeric
   curve_id: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String
   volume: numeric
@@ -12938,7 +18768,9 @@ input signal_stats_daily_bool_exp {
   volume: numeric_comparison_exp
 }
 
-"""Ordering options when selecting data from "signal_stats_daily"."""
+"""
+Ordering options when selecting data from "signal_stats_daily".
+"""
 input signal_stats_daily_order_by {
   bucket: order_by
   count: order_by
@@ -12952,15 +18784,25 @@ input signal_stats_daily_order_by {
 select columns of table "signal_stats_daily"
 """
 enum signal_stats_daily_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   count
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   volume
 }
 
@@ -12968,13 +18810,19 @@ enum signal_stats_daily_select_column {
 Streaming cursor of the table "signal_stats_daily"
 """
 input signal_stats_daily_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: signal_stats_daily_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input signal_stats_daily_stream_cursor_value_input {
   bucket: timestamptz
   count: numeric
@@ -12990,7 +18838,9 @@ type signal_stats_hourly {
   bucket: timestamptz
   count: bigint
   curve_id: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String
   volume: numeric
@@ -13011,7 +18861,9 @@ input signal_stats_hourly_bool_exp {
   volume: numeric_comparison_exp
 }
 
-"""Ordering options when selecting data from "signal_stats_hourly"."""
+"""
+Ordering options when selecting data from "signal_stats_hourly".
+"""
 input signal_stats_hourly_order_by {
   bucket: order_by
   count: order_by
@@ -13025,15 +18877,25 @@ input signal_stats_hourly_order_by {
 select columns of table "signal_stats_hourly"
 """
 enum signal_stats_hourly_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   count
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   volume
 }
 
@@ -13041,13 +18903,19 @@ enum signal_stats_hourly_select_column {
 Streaming cursor of the table "signal_stats_hourly"
 """
 input signal_stats_hourly_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: signal_stats_hourly_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input signal_stats_hourly_stream_cursor_value_input {
   bucket: timestamptz
   count: bigint
@@ -13063,7 +18931,9 @@ type signal_stats_monthly {
   bucket: timestamptz
   count: numeric
   curve_id: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String
   volume: numeric
@@ -13084,7 +18954,9 @@ input signal_stats_monthly_bool_exp {
   volume: numeric_comparison_exp
 }
 
-"""Ordering options when selecting data from "signal_stats_monthly"."""
+"""
+Ordering options when selecting data from "signal_stats_monthly".
+"""
 input signal_stats_monthly_order_by {
   bucket: order_by
   count: order_by
@@ -13098,15 +18970,25 @@ input signal_stats_monthly_order_by {
 select columns of table "signal_stats_monthly"
 """
 enum signal_stats_monthly_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   count
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   volume
 }
 
@@ -13114,13 +18996,19 @@ enum signal_stats_monthly_select_column {
 Streaming cursor of the table "signal_stats_monthly"
 """
 input signal_stats_monthly_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: signal_stats_monthly_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input signal_stats_monthly_stream_cursor_value_input {
   bucket: timestamptz
   count: numeric
@@ -13136,7 +19024,9 @@ type signal_stats_weekly {
   bucket: timestamptz
   count: numeric
   curve_id: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
   term_id: String
   volume: numeric
@@ -13157,7 +19047,9 @@ input signal_stats_weekly_bool_exp {
   volume: numeric_comparison_exp
 }
 
-"""Ordering options when selecting data from "signal_stats_weekly"."""
+"""
+Ordering options when selecting data from "signal_stats_weekly".
+"""
 input signal_stats_weekly_order_by {
   bucket: order_by
   count: order_by
@@ -13171,15 +19063,25 @@ input signal_stats_weekly_order_by {
 select columns of table "signal_stats_weekly"
 """
 enum signal_stats_weekly_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   count
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   volume
 }
 
@@ -13187,13 +19089,19 @@ enum signal_stats_weekly_select_column {
 Streaming cursor of the table "signal_stats_weekly"
 """
 input signal_stats_weekly_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: signal_stats_weekly_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input signal_stats_weekly_stream_cursor_value_input {
   bucket: timestamptz
   count: numeric
@@ -13206,41 +19114,73 @@ input signal_stats_weekly_stream_cursor_value_input {
 TimescaleDB hypertable tracking deposit and redemption events over time for analytics and charting.
 """
 type signals {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   account: accounts
-  """Account that created this signal."""
+  """
+  Account that created this signal.
+  """
   account_id: String!
-  """Atom ID if signal is for an atom vault."""
+  """
+  Atom ID if signal is for an atom vault.
+  """
   atom_id: String
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: numeric!
-  """Timestamp when signal occurred (TimescaleDB partition column)."""
+  """
+  Timestamp when signal occurred (TimescaleDB partition column).
+  """
   created_at: timestamptz!
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric!
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
   """
   delta: numeric!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   deposit: deposits
-  """Reference to deposit if this is a deposit signal."""
+  """
+  Reference to deposit if this is a deposit signal.
+  """
   deposit_id: String
-  """Unique identifier for this signal event."""
+  """
+  Unique identifier for this signal event.
+  """
   id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   redemption: redemptions
-  """Reference to redemption if this is a redemption signal."""
+  """
+  Reference to redemption if this is a redemption signal.
+  """
   redemption_id: String
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
-  """Term ID of the vault for this signal."""
+  """
+  Term ID of the vault for this signal.
+  """
   term_id: String!
-  """Transaction hash of the signal event."""
+  """
+  Transaction hash of the signal event.
+  """
   transaction_hash: String!
-  """Triple ID if signal is for a triple vault."""
+  """
+  Triple ID if signal is for a triple vault.
+  """
   triple_id: String
-  """An object relationship"""
+  """
+  An object relationship
+  """
   vault: vaults
 }
 
@@ -13297,11 +19237,17 @@ input signals_aggregate_order_by {
   variance: signals_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type signals_avg_fields {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13313,9 +19259,13 @@ type signals_avg_fields {
 order by avg() on columns of table "signal"
 """
 input signals_avg_order_by {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13353,33 +19303,57 @@ input signals_from_following_args {
   address: String
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type signals_max_fields {
-  """Account that created this signal."""
+  """
+  Account that created this signal.
+  """
   account_id: String
-  """Atom ID if signal is for an atom vault."""
+  """
+  Atom ID if signal is for an atom vault.
+  """
   atom_id: String
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: numeric
-  """Timestamp when signal occurred (TimescaleDB partition column)."""
+  """
+  Timestamp when signal occurred (TimescaleDB partition column).
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
   """
   delta: numeric
-  """Reference to deposit if this is a deposit signal."""
+  """
+  Reference to deposit if this is a deposit signal.
+  """
   deposit_id: String
-  """Unique identifier for this signal event."""
+  """
+  Unique identifier for this signal event.
+  """
   id: String
-  """Reference to redemption if this is a redemption signal."""
+  """
+  Reference to redemption if this is a redemption signal.
+  """
   redemption_id: String
-  """Term ID of the vault for this signal."""
+  """
+  Term ID of the vault for this signal.
+  """
   term_id: String
-  """Transaction hash of the signal event."""
+  """
+  Transaction hash of the signal event.
+  """
   transaction_hash: String
-  """Triple ID if signal is for a triple vault."""
+  """
+  Triple ID if signal is for a triple vault.
+  """
   triple_id: String
 }
 
@@ -13387,61 +19361,107 @@ type signals_max_fields {
 order by max() on columns of table "signal"
 """
 input signals_max_order_by {
-  """Account that created this signal."""
+  """
+  Account that created this signal.
+  """
   account_id: order_by
-  """Atom ID if signal is for an atom vault."""
+  """
+  Atom ID if signal is for an atom vault.
+  """
   atom_id: order_by
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: order_by
-  """Timestamp when signal occurred (TimescaleDB partition column)."""
+  """
+  Timestamp when signal occurred (TimescaleDB partition column).
+  """
   created_at: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
   """
   delta: order_by
-  """Reference to deposit if this is a deposit signal."""
+  """
+  Reference to deposit if this is a deposit signal.
+  """
   deposit_id: order_by
-  """Unique identifier for this signal event."""
+  """
+  Unique identifier for this signal event.
+  """
   id: order_by
-  """Reference to redemption if this is a redemption signal."""
+  """
+  Reference to redemption if this is a redemption signal.
+  """
   redemption_id: order_by
-  """Term ID of the vault for this signal."""
+  """
+  Term ID of the vault for this signal.
+  """
   term_id: order_by
-  """Transaction hash of the signal event."""
+  """
+  Transaction hash of the signal event.
+  """
   transaction_hash: order_by
-  """Triple ID if signal is for a triple vault."""
+  """
+  Triple ID if signal is for a triple vault.
+  """
   triple_id: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type signals_min_fields {
-  """Account that created this signal."""
+  """
+  Account that created this signal.
+  """
   account_id: String
-  """Atom ID if signal is for an atom vault."""
+  """
+  Atom ID if signal is for an atom vault.
+  """
   atom_id: String
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: numeric
-  """Timestamp when signal occurred (TimescaleDB partition column)."""
+  """
+  Timestamp when signal occurred (TimescaleDB partition column).
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
   """
   delta: numeric
-  """Reference to deposit if this is a deposit signal."""
+  """
+  Reference to deposit if this is a deposit signal.
+  """
   deposit_id: String
-  """Unique identifier for this signal event."""
+  """
+  Unique identifier for this signal event.
+  """
   id: String
-  """Reference to redemption if this is a redemption signal."""
+  """
+  Reference to redemption if this is a redemption signal.
+  """
   redemption_id: String
-  """Term ID of the vault for this signal."""
+  """
+  Term ID of the vault for this signal.
+  """
   term_id: String
-  """Transaction hash of the signal event."""
+  """
+  Transaction hash of the signal event.
+  """
   transaction_hash: String
-  """Triple ID if signal is for a triple vault."""
+  """
+  Triple ID if signal is for a triple vault.
+  """
   triple_id: String
 }
 
@@ -13449,35 +19469,59 @@ type signals_min_fields {
 order by min() on columns of table "signal"
 """
 input signals_min_order_by {
-  """Account that created this signal."""
+  """
+  Account that created this signal.
+  """
   account_id: order_by
-  """Atom ID if signal is for an atom vault."""
+  """
+  Atom ID if signal is for an atom vault.
+  """
   atom_id: order_by
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: order_by
-  """Timestamp when signal occurred (TimescaleDB partition column)."""
+  """
+  Timestamp when signal occurred (TimescaleDB partition column).
+  """
   created_at: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
   """
   delta: order_by
-  """Reference to deposit if this is a deposit signal."""
+  """
+  Reference to deposit if this is a deposit signal.
+  """
   deposit_id: order_by
-  """Unique identifier for this signal event."""
+  """
+  Unique identifier for this signal event.
+  """
   id: order_by
-  """Reference to redemption if this is a redemption signal."""
+  """
+  Reference to redemption if this is a redemption signal.
+  """
   redemption_id: order_by
-  """Term ID of the vault for this signal."""
+  """
+  Term ID of the vault for this signal.
+  """
   term_id: order_by
-  """Transaction hash of the signal event."""
+  """
+  Transaction hash of the signal event.
+  """
   transaction_hash: order_by
-  """Triple ID if signal is for a triple vault."""
+  """
+  Triple ID if signal is for a triple vault.
+  """
   triple_id: order_by
 }
 
-"""Ordering options when selecting data from "signal"."""
+"""
+Ordering options when selecting data from "signal".
+"""
 input signals_order_by {
   account: accounts_order_by
   account_id: order_by
@@ -13502,37 +19546,67 @@ input signals_order_by {
 select columns of table "signal"
 """
 enum signals_select_column {
-  """column name"""
+  """
+  column name
+  """
   account_id
-  """column name"""
+  """
+  column name
+  """
   atom_id
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   delta
-  """column name"""
+  """
+  column name
+  """
   deposit_id
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   redemption_id
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
-  """column name"""
+  """
+  column name
+  """
   triple_id
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type signals_stddev_fields {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13544,9 +19618,13 @@ type signals_stddev_fields {
 order by stddev() on columns of table "signal"
 """
 input signals_stddev_order_by {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13554,11 +19632,17 @@ input signals_stddev_order_by {
   delta: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type signals_stddev_pop_fields {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13570,9 +19654,13 @@ type signals_stddev_pop_fields {
 order by stddev_pop() on columns of table "signal"
 """
 input signals_stddev_pop_order_by {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13580,11 +19668,17 @@ input signals_stddev_pop_order_by {
   delta: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type signals_stddev_samp_fields {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13596,9 +19690,13 @@ type signals_stddev_samp_fields {
 order by stddev_samp() on columns of table "signal"
 """
 input signals_stddev_samp_order_by {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13610,47 +19708,81 @@ input signals_stddev_samp_order_by {
 Streaming cursor of the table "signals"
 """
 input signals_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: signals_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input signals_stream_cursor_value_input {
-  """Account that created this signal."""
+  """
+  Account that created this signal.
+  """
   account_id: String
-  """Atom ID if signal is for an atom vault."""
+  """
+  Atom ID if signal is for an atom vault.
+  """
   atom_id: String
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: numeric
-  """Timestamp when signal occurred (TimescaleDB partition column)."""
+  """
+  Timestamp when signal occurred (TimescaleDB partition column).
+  """
   created_at: timestamptz
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
   """
   delta: numeric
-  """Reference to deposit if this is a deposit signal."""
+  """
+  Reference to deposit if this is a deposit signal.
+  """
   deposit_id: String
-  """Unique identifier for this signal event."""
+  """
+  Unique identifier for this signal event.
+  """
   id: String
-  """Reference to redemption if this is a redemption signal."""
+  """
+  Reference to redemption if this is a redemption signal.
+  """
   redemption_id: String
-  """Term ID of the vault for this signal."""
+  """
+  Term ID of the vault for this signal.
+  """
   term_id: String
-  """Transaction hash of the signal event."""
+  """
+  Transaction hash of the signal event.
+  """
   transaction_hash: String
-  """Triple ID if signal is for a triple vault."""
+  """
+  Triple ID if signal is for a triple vault.
+  """
   triple_id: String
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type signals_sum_fields {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: numeric
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: numeric
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13662,9 +19794,13 @@ type signals_sum_fields {
 order by sum() on columns of table "signal"
 """
 input signals_sum_order_by {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13672,11 +19808,17 @@ input signals_sum_order_by {
   delta: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type signals_var_pop_fields {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13688,9 +19830,13 @@ type signals_var_pop_fields {
 order by var_pop() on columns of table "signal"
 """
 input signals_var_pop_order_by {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13698,11 +19844,17 @@ input signals_var_pop_order_by {
   delta: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type signals_var_samp_fields {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13714,9 +19866,13 @@ type signals_var_samp_fields {
 order by var_samp() on columns of table "signal"
 """
 input signals_var_samp_order_by {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13724,11 +19880,17 @@ input signals_var_samp_order_by {
   delta: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type signals_variance_fields {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: Float
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: Float
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13740,9 +19902,13 @@ type signals_variance_fields {
 order by variance() on columns of table "signal"
 """
 input signals_variance_order_by {
-  """Block number when signal occurred."""
+  """
+  Block number when signal occurred.
+  """
   block_number: order_by
-  """Bonding curve ID of the vault."""
+  """
+  Bonding curve ID of the vault.
+  """
   curve_id: order_by
   """
   Change in assets (positive for deposits, negative for redemptions), in wei.
@@ -13754,23 +19920,41 @@ input signals_variance_order_by {
 Hourly snapshots of protocol statistics for historical tracking and analytics.
 """
 type statHours {
-  """Snapshot of contract balance at this hour."""
+  """
+  Snapshot of contract balance at this hour.
+  """
   contract_balance: numeric
-  """Timestamp when this snapshot was created."""
+  """
+  Timestamp when this snapshot was created.
+  """
   created_at: timestamptz!
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: Int!
-  """Snapshot of total accounts at this hour."""
+  """
+  Snapshot of total accounts at this hour.
+  """
   total_accounts: Int
-  """Snapshot of total atoms at this hour."""
+  """
+  Snapshot of total atoms at this hour.
+  """
   total_atoms: Int
-  """Snapshot of cumulative fees at this hour."""
+  """
+  Snapshot of cumulative fees at this hour.
+  """
   total_fees: numeric
-  """Snapshot of total positions at this hour."""
+  """
+  Snapshot of total positions at this hour.
+  """
   total_positions: Int
-  """Snapshot of total signals at this hour."""
+  """
+  Snapshot of total signals at this hour.
+  """
   total_signals: Int
-  """Snapshot of total triples at this hour."""
+  """
+  Snapshot of total triples at this hour.
+  """
   total_triples: Int
 }
 
@@ -13792,7 +19976,9 @@ input statHours_bool_exp {
   total_triples: Int_comparison_exp
 }
 
-"""Ordering options when selecting data from "stats_hour"."""
+"""
+Ordering options when selecting data from "stats_hour".
+"""
 input statHours_order_by {
   contract_balance: order_by
   created_at: order_by
@@ -13809,23 +19995,41 @@ input statHours_order_by {
 select columns of table "stats_hour"
 """
 enum statHours_select_column {
-  """column name"""
+  """
+  column name
+  """
   contract_balance
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   total_accounts
-  """column name"""
+  """
+  column name
+  """
   total_atoms
-  """column name"""
+  """
+  column name
+  """
   total_fees
-  """column name"""
+  """
+  column name
+  """
   total_positions
-  """column name"""
+  """
+  column name
+  """
   total_signals
-  """column name"""
+  """
+  column name
+  """
   total_triples
 }
 
@@ -13833,31 +20037,55 @@ enum statHours_select_column {
 Streaming cursor of the table "statHours"
 """
 input statHours_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: statHours_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input statHours_stream_cursor_value_input {
-  """Snapshot of contract balance at this hour."""
+  """
+  Snapshot of contract balance at this hour.
+  """
   contract_balance: numeric
-  """Timestamp when this snapshot was created."""
+  """
+  Timestamp when this snapshot was created.
+  """
   created_at: timestamptz
-  """Auto-incrementing primary key."""
+  """
+  Auto-incrementing primary key.
+  """
   id: Int
-  """Snapshot of total accounts at this hour."""
+  """
+  Snapshot of total accounts at this hour.
+  """
   total_accounts: Int
-  """Snapshot of total atoms at this hour."""
+  """
+  Snapshot of total atoms at this hour.
+  """
   total_atoms: Int
-  """Snapshot of cumulative fees at this hour."""
+  """
+  Snapshot of cumulative fees at this hour.
+  """
   total_fees: numeric
-  """Snapshot of total positions at this hour."""
+  """
+  Snapshot of total positions at this hour.
+  """
   total_positions: Int
-  """Snapshot of total signals at this hour."""
+  """
+  Snapshot of total signals at this hour.
+  """
   total_signals: Int
-  """Snapshot of total triples at this hour."""
+  """
+  Snapshot of total triples at this hour.
+  """
   total_triples: Int
 }
 
@@ -13865,27 +20093,49 @@ input statHours_stream_cursor_value_input {
 Global protocol statistics aggregated from all events, updated via triggers. Single-row table (id=0).
 """
 type stats {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: numeric
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Int!
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: numeric
-  """Timestamp of the most recent processed block."""
+  """
+  Timestamp of the most recent processed block.
+  """
   last_processed_block_timestamp: timestamptz
-  """Timestamp of last update to this stats record."""
+  """
+  Timestamp of last update to this stats record.
+  """
   last_updated: timestamptz!
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Int
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Int
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: numeric
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Int
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Int
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Int
 }
 
@@ -13914,25 +20164,45 @@ type stats_aggregate_fields {
   variance: stats_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type stats_avg_fields {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: Float
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Float
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: Float
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Float
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Float
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: Float
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Float
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Float
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Float
 }
 
@@ -13956,59 +20226,109 @@ input stats_bool_exp {
   total_triples: Int_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type stats_max_fields {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: numeric
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Int
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: numeric
-  """Timestamp of the most recent processed block."""
+  """
+  Timestamp of the most recent processed block.
+  """
   last_processed_block_timestamp: timestamptz
-  """Timestamp of last update to this stats record."""
+  """
+  Timestamp of last update to this stats record.
+  """
   last_updated: timestamptz
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Int
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Int
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: numeric
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Int
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Int
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Int
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type stats_min_fields {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: numeric
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Int
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: numeric
-  """Timestamp of the most recent processed block."""
+  """
+  Timestamp of the most recent processed block.
+  """
   last_processed_block_timestamp: timestamptz
-  """Timestamp of last update to this stats record."""
+  """
+  Timestamp of last update to this stats record.
+  """
   last_updated: timestamptz
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Int
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Int
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: numeric
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Int
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Int
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Int
 }
 
-"""Ordering options when selecting data from "stats"."""
+"""
+Ordering options when selecting data from "stats".
+"""
 input stats_order_by {
   contract_balance: order_by
   id: order_by
@@ -14027,93 +20347,175 @@ input stats_order_by {
 select columns of table "stats"
 """
 enum stats_select_column {
-  """column name"""
+  """
+  column name
+  """
   contract_balance
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   last_processed_block_number
-  """column name"""
+  """
+  column name
+  """
   last_processed_block_timestamp
-  """column name"""
+  """
+  column name
+  """
   last_updated
-  """column name"""
+  """
+  column name
+  """
   total_accounts
-  """column name"""
+  """
+  column name
+  """
   total_atoms
-  """column name"""
+  """
+  column name
+  """
   total_fees
-  """column name"""
+  """
+  column name
+  """
   total_positions
-  """column name"""
+  """
+  column name
+  """
   total_signals
-  """column name"""
+  """
+  column name
+  """
   total_triples
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type stats_stddev_fields {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: Float
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Float
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: Float
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Float
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Float
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: Float
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Float
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Float
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type stats_stddev_pop_fields {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: Float
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Float
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: Float
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Float
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Float
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: Float
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Float
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Float
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type stats_stddev_samp_fields {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: Float
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Float
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: Float
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Float
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Float
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: Float
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Float
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Float
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Float
 }
 
@@ -14121,123 +20523,231 @@ type stats_stddev_samp_fields {
 Streaming cursor of the table "stats"
 """
 input stats_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: stats_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input stats_stream_cursor_value_input {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: numeric
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Int
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: numeric
-  """Timestamp of the most recent processed block."""
+  """
+  Timestamp of the most recent processed block.
+  """
   last_processed_block_timestamp: timestamptz
-  """Timestamp of last update to this stats record."""
+  """
+  Timestamp of last update to this stats record.
+  """
   last_updated: timestamptz
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Int
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Int
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: numeric
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Int
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Int
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Int
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type stats_sum_fields {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: numeric
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Int
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: numeric
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Int
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Int
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: numeric
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Int
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Int
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Int
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type stats_var_pop_fields {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: Float
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Float
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: Float
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Float
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Float
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: Float
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Float
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Float
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type stats_var_samp_fields {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: Float
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Float
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: Float
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Float
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Float
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: Float
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Float
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Float
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type stats_variance_fields {
-  """Current total assets held in protocol vaults in wei."""
+  """
+  Current total assets held in protocol vaults in wei.
+  """
   contract_balance: Float
-  """Primary key, always 0 for singleton pattern."""
+  """
+  Primary key, always 0 for singleton pattern.
+  """
   id: Float
-  """Most recent block number indexed by the protocol."""
+  """
+  Most recent block number indexed by the protocol.
+  """
   last_processed_block_number: Float
-  """Total number of accounts created in the protocol."""
+  """
+  Total number of accounts created in the protocol.
+  """
   total_accounts: Float
-  """Total number of atoms created."""
+  """
+  Total number of atoms created.
+  """
   total_atoms: Float
-  """Cumulative protocol fees collected in wei."""
+  """
+  Cumulative protocol fees collected in wei.
+  """
   total_fees: Float
-  """Total number of active positions across all vaults."""
+  """
+  Total number of active positions across all vaults.
+  """
   total_positions: Float
-  """Total number of signal events (deposits and redemptions)."""
+  """
+  Total number of signal events (deposits and redemptions).
+  """
   total_signals: Float
-  """Total number of triples created."""
+  """
+  Total number of triples created.
+  """
   total_triples: Float
 }
 
@@ -14246,45 +20756,83 @@ Denormalized aggregate of triples grouped by (subject, predicate) for efficient 
 """
 type subject_predicates {
   opposer_count: bigint!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   predicate: atoms
-  """Predicate atom ID."""
+  """
+  Predicate atom ID.
+  """
   predicate_id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   subject: atoms
-  """Subject atom ID."""
+  """
+  Subject atom ID.
+  """
   subject_id: String!
   supporter_count: bigint!
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: numeric!
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Int!
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Int!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   triples(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): [triples!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   triples_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): triples_aggregate!
 }
@@ -14314,15 +20862,23 @@ type subject_predicates_aggregate_fields {
   variance: subject_predicates_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type subject_predicates_avg_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Float
 }
 
@@ -14346,39 +20902,65 @@ input subject_predicates_bool_exp {
   triples_aggregate: triples_aggregate_bool_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type subject_predicates_max_fields {
   opposer_count: bigint
-  """Predicate atom ID."""
+  """
+  Predicate atom ID.
+  """
   predicate_id: String
-  """Subject atom ID."""
+  """
+  Subject atom ID.
+  """
   subject_id: String
   supporter_count: bigint
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: numeric
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Int
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Int
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type subject_predicates_min_fields {
   opposer_count: bigint
-  """Predicate atom ID."""
+  """
+  Predicate atom ID.
+  """
   predicate_id: String
-  """Subject atom ID."""
+  """
+  Subject atom ID.
+  """
   subject_id: String
   supporter_count: bigint
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: numeric
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Int
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Int
 }
 
-"""Ordering options when selecting data from "subject_predicate"."""
+"""
+Ordering options when selecting data from "subject_predicate".
+"""
 input subject_predicates_order_by {
   opposer_count: order_by
   predicate: atoms_order_by
@@ -14396,55 +20978,93 @@ input subject_predicates_order_by {
 select columns of table "subject_predicate"
 """
 enum subject_predicates_select_column {
-  """column name"""
+  """
+  column name
+  """
   opposer_count
-  """column name"""
+  """
+  column name
+  """
   predicate_id
-  """column name"""
+  """
+  column name
+  """
   subject_id
-  """column name"""
+  """
+  column name
+  """
   supporter_count
-  """column name"""
+  """
+  column name
+  """
   total_market_cap
-  """column name"""
+  """
+  column name
+  """
   total_position_count
-  """column name"""
+  """
+  column name
+  """
   triple_count
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type subject_predicates_stddev_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type subject_predicates_stddev_pop_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type subject_predicates_stddev_samp_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Float
 }
 
@@ -14452,353 +21072,595 @@ type subject_predicates_stddev_samp_fields {
 Streaming cursor of the table "subject_predicates"
 """
 input subject_predicates_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: subject_predicates_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input subject_predicates_stream_cursor_value_input {
   opposer_count: bigint
-  """Predicate atom ID."""
+  """
+  Predicate atom ID.
+  """
   predicate_id: String
-  """Subject atom ID."""
+  """
+  Subject atom ID.
+  """
   subject_id: String
   supporter_count: bigint
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: numeric
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Int
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Int
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type subject_predicates_sum_fields {
   opposer_count: bigint
   supporter_count: bigint
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: numeric
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Int
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Int
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type subject_predicates_var_pop_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type subject_predicates_var_samp_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type subject_predicates_variance_fields {
   opposer_count: Float
   supporter_count: Float
-  """Total market cap across all triples with this combination, in wei."""
+  """
+  Total market cap across all triples with this combination, in wei.
+  """
   total_market_cap: Float
-  """Total positions across all triples with this combination."""
+  """
+  Total positions across all triples with this combination.
+  """
   total_position_count: Float
-  """Number of triples with this (subject, predicate) combination."""
+  """
+  Number of triples with this (subject, predicate) combination.
+  """
   triple_count: Float
 }
 
 type subscription_root {
-  """fetch data from the table: "account" using primary key columns"""
+  """
+  fetch data from the table: "account" using primary key columns
+  """
   account(
-    """Account address (Ethereum address or atom wallet address)."""
+    """
+    Account address (Ethereum address or atom wallet address).
+    """
     id: String!
   ): accounts
   """
   fetch data from the table: "account_pnl_rank"
   """
   account_pnl_rank(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [account_pnl_rank_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [account_pnl_rank_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: account_pnl_rank_bool_exp
   ): [account_pnl_rank!]!
   """
   fetch aggregated fields from the table: "account_pnl_rank"
   """
   account_pnl_rank_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [account_pnl_rank_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [account_pnl_rank_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: account_pnl_rank_bool_exp
   ): account_pnl_rank_aggregate!
   """
   fetch data from the table in a streaming manner: "account_pnl_rank"
   """
   account_pnl_rank_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [account_pnl_rank_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: account_pnl_rank_bool_exp
   ): [account_pnl_rank!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   accounts(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [accounts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [accounts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: accounts_bool_exp
   ): [accounts!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   accounts_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [accounts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [accounts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: accounts_bool_exp
   ): accounts_aggregate!
   """
   fetch data from the table in a streaming manner: "account"
   """
   accounts_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [accounts_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: accounts_bool_exp
   ): [accounts!]!
-  """fetch data from the table: "atom" using primary key columns"""
+  """
+  fetch data from the table: "atom" using primary key columns
+  """
   atom(
-    """Unique identifier linking to the term registry."""
+    """
+    Unique identifier linking to the term registry.
+    """
     term_id: String!
   ): atoms
-  """fetch data from the table: "atom_value" using primary key columns"""
+  """
+  fetch data from the table: "atom_value" using primary key columns
+  """
   atom_value(
-    """Unique identifier matching the atom value_id."""
+    """
+    Unique identifier matching the atom value_id.
+    """
     id: String!
   ): atom_values
   """
   fetch data from the table: "atom_value"
   """
   atom_values(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [atom_values_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [atom_values_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atom_values_bool_exp
   ): [atom_values!]!
   """
   fetch aggregated fields from the table: "atom_value"
   """
   atom_values_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [atom_values_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [atom_values_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atom_values_bool_exp
   ): atom_values_aggregate!
   """
   fetch data from the table in a streaming manner: "atom_value"
   """
   atom_values_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [atom_values_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atom_values_bool_exp
   ): [atom_values!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   atoms(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [atoms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [atoms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atoms_bool_exp
   ): [atoms!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   atoms_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [atoms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [atoms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atoms_bool_exp
   ): atoms_aggregate!
   """
   fetch data from the table in a streaming manner: "atom"
   """
   atoms_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [atoms_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: atoms_bool_exp
   ): [atoms!]!
-  """fetch data from the table: "book" using primary key columns"""
+  """
+  fetch data from the table: "book" using primary key columns
+  """
   book(
-    """Unique identifier for this book entity."""
+    """
+    Unique identifier for this book entity.
+    """
     id: String!
   ): books
   """
   fetch data from the table: "book"
   """
   books(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [books_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [books_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: books_bool_exp
   ): [books!]!
   """
   fetch aggregated fields from the table: "book"
   """
   books_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [books_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [books_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: books_bool_exp
   ): books_aggregate!
   """
   fetch data from the table in a streaming manner: "book"
   """
   books_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [books_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: books_bool_exp
   ): [books!]!
   """
   fetch data from the table: "byte_object"
   """
   byte_object(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [byte_object_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [byte_object_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: byte_object_bool_exp
   ): [byte_object!]!
   """
   fetch aggregated fields from the table: "byte_object"
   """
   byte_object_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [byte_object_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [byte_object_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: byte_object_bool_exp
   ): byte_object_aggregate!
-  """fetch data from the table: "byte_object" using primary key columns"""
+  """
+  fetch data from the table: "byte_object" using primary key columns
+  """
   byte_object_by_pk(
-    """Unique identifier for this byte object."""
+    """
+    Unique identifier for this byte object.
+    """
     id: String!
   ): byte_object
   """
   fetch data from the table in a streaming manner: "byte_object"
   """
   byte_object_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [byte_object_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: byte_object_bool_exp
   ): [byte_object!]!
   """
   fetch data from the table: "cached_images.cached_image"
   """
   cached_images_cached_image(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [cached_images_cached_image_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [cached_images_cached_image_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: cached_images_cached_image_bool_exp
   ): [cached_images_cached_image!]!
   """
@@ -14809,218 +21671,372 @@ type subscription_root {
   fetch data from the table in a streaming manner: "cached_images.cached_image"
   """
   cached_images_cached_image_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [cached_images_cached_image_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: cached_images_cached_image_bool_exp
   ): [cached_images_cached_image!]!
-  """fetch data from the table: "caip10" using primary key columns"""
+  """
+  fetch data from the table: "caip10" using primary key columns
+  """
   caip10(
-    """Unique identifier for this CAIP-10 account reference."""
+    """
+    Unique identifier for this CAIP-10 account reference.
+    """
     id: String!
   ): caip10
   """
   fetch aggregated fields from the table: "caip10"
   """
   caip10_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [caip10_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [caip10_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: caip10_bool_exp
   ): caip10_aggregate!
   """
   fetch data from the table in a streaming manner: "caip10"
   """
   caip10_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [caip10_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: caip10_bool_exp
   ): [caip10!]!
   """
   fetch data from the table: "caip10"
   """
   caip10s(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [caip10_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [caip10_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: caip10_bool_exp
   ): [caip10!]!
-  """fetch data from the table: "chainlink_price" using primary key columns"""
+  """
+  fetch data from the table: "chainlink_price" using primary key columns
+  """
   chainlink_price(
-    """Block number or timestamp identifier for the price data point."""
+    """
+    Block number or timestamp identifier for the price data point.
+    """
     id: numeric!
   ): chainlink_prices
   """
   fetch data from the table: "chainlink_price"
   """
   chainlink_prices(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [chainlink_prices_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [chainlink_prices_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: chainlink_prices_bool_exp
   ): [chainlink_prices!]!
   """
   fetch data from the table in a streaming manner: "chainlink_price"
   """
   chainlink_prices_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [chainlink_prices_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: chainlink_prices_bool_exp
   ): [chainlink_prices!]!
-  """fetch data from the table: "deposit" using primary key columns"""
+  """
+  fetch data from the table: "deposit" using primary key columns
+  """
   deposit(
-    """Unique identifier for this deposit event."""
+    """
+    Unique identifier for this deposit event.
+    """
     id: String!
   ): deposits
-  """An array relationship"""
+  """
+  An array relationship
+  """
   deposits(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): [deposits!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   deposits_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): deposits_aggregate!
   """
   fetch data from the table in a streaming manner: "deposit"
   """
   deposits_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [deposits_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): [deposits!]!
-  """fetch data from the table: "event" using primary key columns"""
+  """
+  fetch data from the table: "event" using primary key columns
+  """
   event(
-    """Unique identifier for this event."""
+    """
+    Unique identifier for this event.
+    """
     id: String!
   ): events
   """
   fetch data from the table: "event"
   """
   events(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [events_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [events_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: events_bool_exp
   ): [events!]!
   """
   fetch aggregated fields from the table: "event"
   """
   events_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [events_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [events_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: events_bool_exp
   ): events_aggregate!
   """
   fetch data from the table in a streaming manner: "event"
   """
   events_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [events_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: events_bool_exp
   ): [events!]!
-  """fetch data from the table: "fee_transfer" using primary key columns"""
+  """
+  fetch data from the table: "fee_transfer" using primary key columns
+  """
   fee_transfer(
-    """Unique identifier for this fee transfer event."""
+    """
+    Unique identifier for this fee transfer event.
+    """
     id: String!
   ): fee_transfers
-  """An array relationship"""
+  """
+  An array relationship
+  """
   fee_transfers(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [fee_transfers_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [fee_transfers_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: fee_transfers_bool_exp
   ): [fee_transfers!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   fee_transfers_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [fee_transfers_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [fee_transfers_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: fee_transfers_bool_exp
   ): fee_transfers_aggregate!
   """
   fetch data from the table in a streaming manner: "fee_transfer"
   """
   fee_transfers_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [fee_transfers_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: fee_transfers_bool_exp
   ): [fee_transfers!]!
   """
@@ -15031,15 +22047,25 @@ type subscription_root {
     input parameters for function "following"
     """
     args: following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [accounts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [accounts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: accounts_bool_exp
   ): [accounts!]!
   """
@@ -15050,15 +22076,25 @@ type subscription_root {
     input parameters for function "following_aggregate"
     """
     args: following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [accounts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [accounts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: accounts_bool_exp
   ): accounts_aggregate!
   """
@@ -15069,15 +22105,25 @@ type subscription_root {
     input parameters for function "get_account_pnl_rank"
     """
     args: get_account_pnl_rank_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [account_pnl_rank_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [account_pnl_rank_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: account_pnl_rank_bool_exp
   ): [account_pnl_rank!]!
   """
@@ -15088,15 +22134,25 @@ type subscription_root {
     input parameters for function "get_account_pnl_rank_aggregate"
     """
     args: get_account_pnl_rank_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [account_pnl_rank_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [account_pnl_rank_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: account_pnl_rank_bool_exp
   ): account_pnl_rank_aggregate!
   """
@@ -15107,15 +22163,25 @@ type subscription_root {
     input parameters for function "get_pnl_leaderboard"
     """
     args: get_pnl_leaderboard_args
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): [pnl_leaderboard_entry!]!
   """
@@ -15126,15 +22192,25 @@ type subscription_root {
     input parameters for function "get_pnl_leaderboard_aggregate"
     """
     args: get_pnl_leaderboard_args
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): pnl_leaderboard_entry_aggregate!
   """
@@ -15145,15 +22221,25 @@ type subscription_root {
     input parameters for function "get_pnl_leaderboard_stats"
     """
     args: get_pnl_leaderboard_stats_args
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_stats_bool_exp
   ): [pnl_leaderboard_stats!]!
   """
@@ -15164,15 +22250,25 @@ type subscription_root {
     input parameters for function "get_pnl_leaderboard_stats_aggregate"
     """
     args: get_pnl_leaderboard_stats_args
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_stats_bool_exp
   ): pnl_leaderboard_stats_aggregate!
   """
@@ -15183,15 +22279,25 @@ type subscription_root {
     input parameters for function "get_vault_leaderboard"
     """
     args: get_vault_leaderboard_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): [pnl_leaderboard_entry!]!
   """
@@ -15202,359 +22308,597 @@ type subscription_root {
     input parameters for function "get_vault_leaderboard_aggregate"
     """
     args: get_vault_leaderboard_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): pnl_leaderboard_entry_aggregate!
-  """fetch data from the table: "json_object" using primary key columns"""
+  """
+  fetch data from the table: "json_object" using primary key columns
+  """
   json_object(
-    """Unique identifier for this JSON object."""
+    """
+    Unique identifier for this JSON object.
+    """
     id: String!
   ): json_objects
   """
   fetch data from the table: "json_object"
   """
   json_objects(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [json_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [json_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: json_objects_bool_exp
   ): [json_objects!]!
   """
   fetch aggregated fields from the table: "json_object"
   """
   json_objects_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [json_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [json_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: json_objects_bool_exp
   ): json_objects_aggregate!
   """
   fetch data from the table in a streaming manner: "json_object"
   """
   json_objects_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [json_objects_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: json_objects_bool_exp
   ): [json_objects!]!
-  """fetch data from the table: "organization" using primary key columns"""
+  """
+  fetch data from the table: "organization" using primary key columns
+  """
   organization(
-    """Unique identifier for this organization entity."""
+    """
+    Unique identifier for this organization entity.
+    """
     id: String!
   ): organizations
   """
   fetch data from the table: "organization"
   """
   organizations(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [organizations_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [organizations_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: organizations_bool_exp
   ): [organizations!]!
   """
   fetch aggregated fields from the table: "organization"
   """
   organizations_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [organizations_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [organizations_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: organizations_bool_exp
   ): organizations_aggregate!
   """
   fetch data from the table in a streaming manner: "organization"
   """
   organizations_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [organizations_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: organizations_bool_exp
   ): [organizations!]!
-  """fetch data from the table: "person" using primary key columns"""
+  """
+  fetch data from the table: "person" using primary key columns
+  """
   person(
-    """Unique identifier for this person entity."""
+    """
+    Unique identifier for this person entity.
+    """
     id: String!
   ): persons
   """
   fetch data from the table: "person"
   """
   persons(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [persons_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [persons_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: persons_bool_exp
   ): [persons!]!
   """
   fetch aggregated fields from the table: "person"
   """
   persons_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [persons_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [persons_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: persons_bool_exp
   ): persons_aggregate!
   """
   fetch data from the table in a streaming manner: "person"
   """
   persons_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [persons_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: persons_bool_exp
   ): [persons!]!
   """
   fetch data from the table: "pnl_leaderboard_entry"
   """
   pnl_leaderboard_entry(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): [pnl_leaderboard_entry!]!
   """
   fetch aggregated fields from the table: "pnl_leaderboard_entry"
   """
   pnl_leaderboard_entry_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_entry_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_entry_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): pnl_leaderboard_entry_aggregate!
   """
   fetch data from the table in a streaming manner: "pnl_leaderboard_entry"
   """
   pnl_leaderboard_entry_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [pnl_leaderboard_entry_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_entry_bool_exp
   ): [pnl_leaderboard_entry!]!
   """
   fetch data from the table: "pnl_leaderboard_stats"
   """
   pnl_leaderboard_stats(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_stats_bool_exp
   ): [pnl_leaderboard_stats!]!
   """
   fetch aggregated fields from the table: "pnl_leaderboard_stats"
   """
   pnl_leaderboard_stats_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [pnl_leaderboard_stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [pnl_leaderboard_stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_stats_bool_exp
   ): pnl_leaderboard_stats_aggregate!
   """
   fetch data from the table in a streaming manner: "pnl_leaderboard_stats"
   """
   pnl_leaderboard_stats_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [pnl_leaderboard_stats_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: pnl_leaderboard_stats_bool_exp
   ): [pnl_leaderboard_stats!]!
-  """fetch data from the table: "position" using primary key columns"""
+  """
+  fetch data from the table: "position" using primary key columns
+  """
   position(
-    """Unique identifier for this position."""
+    """
+    Unique identifier for this position.
+    """
     id: String!
   ): positions
   """
   fetch data from the table: "position_change_daily"
   """
   position_change_daily(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [position_change_daily_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [position_change_daily_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: position_change_daily_bool_exp
   ): [position_change_daily!]!
   """
   fetch data from the table in a streaming manner: "position_change_daily"
   """
   position_change_daily_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [position_change_daily_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: position_change_daily_bool_exp
   ): [position_change_daily!]!
   """
   fetch data from the table: "position_change_hourly"
   """
   position_change_hourly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [position_change_hourly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [position_change_hourly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: position_change_hourly_bool_exp
   ): [position_change_hourly!]!
   """
   fetch data from the table in a streaming manner: "position_change_hourly"
   """
   position_change_hourly_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [position_change_hourly_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: position_change_hourly_bool_exp
   ): [position_change_hourly!]!
   """
   fetch data from the table: "position_change"
   """
   position_changes(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [position_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [position_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: position_changes_bool_exp
   ): [position_changes!]!
   """
   fetch aggregated fields from the table: "position_change"
   """
   position_changes_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [position_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [position_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: position_changes_bool_exp
   ): position_changes_aggregate!
   """
   fetch data from the table in a streaming manner: "position_change"
   """
   position_changes_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [position_changes_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: position_changes_bool_exp
   ): [position_changes!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   positions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   positions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
   """
@@ -15565,15 +22909,25 @@ type subscription_root {
     input parameters for function "positions_from_following"
     """
     args: positions_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
   """
@@ -15584,204 +22938,336 @@ type subscription_root {
     input parameters for function "positions_from_following_aggregate"
     """
     args: positions_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
   """
   fetch data from the table in a streaming manner: "position"
   """
   positions_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [positions_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
   """
   fetch data from the table: "position_with_value"
   """
   positions_with_value(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_with_value_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_with_value_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_with_value_bool_exp
   ): [positions_with_value!]!
   """
   fetch aggregated fields from the table: "position_with_value"
   """
   positions_with_value_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_with_value_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_with_value_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_with_value_bool_exp
   ): positions_with_value_aggregate!
   """
   fetch data from the table in a streaming manner: "position_with_value"
   """
   positions_with_value_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [positions_with_value_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_with_value_bool_exp
   ): [positions_with_value!]!
   """
   fetch data from the table: "predicate_object"
   """
   predicate_objects(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [predicate_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [predicate_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: predicate_objects_bool_exp
   ): [predicate_objects!]!
   """
   fetch aggregated fields from the table: "predicate_object"
   """
   predicate_objects_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [predicate_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [predicate_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: predicate_objects_bool_exp
   ): predicate_objects_aggregate!
   """
   fetch data from the table: "predicate_object" using primary key columns
   """
   predicate_objects_by_pk(
-    """Object atom ID."""
+    """
+    Object atom ID.
+    """
     object_id: String!
-    """Predicate atom ID."""
+    """
+    Predicate atom ID.
+    """
     predicate_id: String!
   ): predicate_objects
   """
   fetch data from the table in a streaming manner: "predicate_object"
   """
   predicate_objects_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [predicate_objects_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: predicate_objects_bool_exp
   ): [predicate_objects!]!
   """
   fetch data from the table: "protocol_fee_accrued"
   """
   protocol_fee_accruals(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [protocol_fee_accruals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [protocol_fee_accruals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: protocol_fee_accruals_bool_exp
   ): [protocol_fee_accruals!]!
   """
   fetch aggregated fields from the table: "protocol_fee_accrued"
   """
   protocol_fee_accruals_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [protocol_fee_accruals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [protocol_fee_accruals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: protocol_fee_accruals_bool_exp
   ): protocol_fee_accruals_aggregate!
   """
   fetch data from the table in a streaming manner: "protocol_fee_accrued"
   """
   protocol_fee_accruals_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [protocol_fee_accruals_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: protocol_fee_accruals_bool_exp
   ): [protocol_fee_accruals!]!
   """
   fetch data from the table: "protocol_fee_accrued" using primary key columns
   """
   protocol_fee_accrued(id: String!): protocol_fee_accruals
-  """fetch data from the table: "redemption" using primary key columns"""
+  """
+  fetch data from the table: "redemption" using primary key columns
+  """
   redemption(
-    """Unique identifier for this redemption event."""
+    """
+    Unique identifier for this redemption event.
+    """
     id: String!
   ): redemptions
-  """An array relationship"""
+  """
+  An array relationship
+  """
   redemptions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): [redemptions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   redemptions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): redemptions_aggregate!
   """
   fetch data from the table in a streaming manner: "redemption"
   """
   redemptions_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [redemptions_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): [redemptions!]!
   """
@@ -15792,15 +23278,25 @@ type subscription_root {
     input parameters for function "search_positions_on_subject"
     """
     args: search_positions_on_subject_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
   """
@@ -15811,15 +23307,25 @@ type subscription_root {
     input parameters for function "search_positions_on_subject_aggregate"
     """
     args: search_positions_on_subject_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
   """
@@ -15830,15 +23336,25 @@ type subscription_root {
     input parameters for function "search_term"
     """
     args: search_term_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): [terms!]!
   """
@@ -15849,15 +23365,25 @@ type subscription_root {
     input parameters for function "search_term_aggregate"
     """
     args: search_term_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): terms_aggregate!
   """
@@ -15868,15 +23394,25 @@ type subscription_root {
     input parameters for function "search_term_from_following"
     """
     args: search_term_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): [terms!]!
   """
@@ -15887,15 +23423,25 @@ type subscription_root {
     input parameters for function "search_term_from_following_aggregate"
     """
     args: search_term_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): terms_aggregate!
   """
@@ -15906,15 +23452,25 @@ type subscription_root {
     input parameters for function "search_term_tsvector"
     """
     args: search_term_tsvector_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): [terms!]!
   """
@@ -15925,18 +23481,30 @@ type subscription_root {
     input parameters for function "search_term_tsvector_aggregate"
     """
     args: search_term_tsvector_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): terms_aggregate!
-  """fetch data from the table: "season2_epoch" using primary key columns"""
+  """
+  fetch data from the table: "season2_epoch" using primary key columns
+  """
   season2_epoch(epoch: Int!): season2_epochs
   """
   fetch data from the table: "season2_epoch_price" using primary key columns
@@ -15946,123 +23514,205 @@ type subscription_root {
   fetch data from the table: "season2_epoch_price"
   """
   season2_epoch_prices(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_epoch_prices_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_epoch_prices_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epoch_prices_bool_exp
   ): [season2_epoch_prices!]!
   """
   fetch aggregated fields from the table: "season2_epoch_price"
   """
   season2_epoch_prices_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_epoch_prices_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_epoch_prices_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epoch_prices_bool_exp
   ): season2_epoch_prices_aggregate!
   """
   fetch data from the table in a streaming manner: "season2_epoch_price"
   """
   season2_epoch_prices_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [season2_epoch_prices_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epoch_prices_bool_exp
   ): [season2_epoch_prices!]!
   """
   fetch data from the table: "season2_epoch"
   """
   season2_epochs(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_epochs_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_epochs_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epochs_bool_exp
   ): [season2_epochs!]!
   """
   fetch aggregated fields from the table: "season2_epoch"
   """
   season2_epochs_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_epochs_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_epochs_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epochs_bool_exp
   ): season2_epochs_aggregate!
   """
   fetch data from the table in a streaming manner: "season2_epoch"
   """
   season2_epochs_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [season2_epochs_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_epochs_bool_exp
   ): [season2_epochs!]!
   """
   fetch data from the table: "season2_iq_ledger" using primary key columns
   """
   season2_iq_ledger(id: bigint!): season2_iq_ledger_entries
-  """An array relationship"""
+  """
+  An array relationship
+  """
   season2_iq_ledger_entries(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_iq_ledger_entries_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_iq_ledger_entries_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_iq_ledger_entries_bool_exp
   ): [season2_iq_ledger_entries!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   season2_iq_ledger_entries_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_iq_ledger_entries_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_iq_ledger_entries_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_iq_ledger_entries_bool_exp
   ): season2_iq_ledger_entries_aggregate!
   """
   fetch data from the table in a streaming manner: "season2_iq_ledger"
   """
   season2_iq_ledger_entries_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [season2_iq_ledger_entries_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_iq_ledger_entries_bool_exp
   ): [season2_iq_ledger_entries!]!
   """
@@ -16073,349 +23723,593 @@ type subscription_root {
   fetch data from the table: "season2_leaderboard_payout"
   """
   season2_leaderboard_payouts(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_leaderboard_payouts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_leaderboard_payouts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_leaderboard_payouts_bool_exp
   ): [season2_leaderboard_payouts!]!
   """
   fetch aggregated fields from the table: "season2_leaderboard_payout"
   """
   season2_leaderboard_payouts_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_leaderboard_payouts_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_leaderboard_payouts_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_leaderboard_payouts_bool_exp
   ): season2_leaderboard_payouts_aggregate!
   """
   fetch data from the table in a streaming manner: "season2_leaderboard_payout"
   """
   season2_leaderboard_payouts_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [season2_leaderboard_payouts_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_leaderboard_payouts_bool_exp
   ): [season2_leaderboard_payouts!]!
   """
   fetch data from the table: "season2_trust_price_snapshot" using primary key columns
   """
-  season2_trust_price_snapshot(snapshot_at: timestamptz!): season2_trust_price_snapshots
+  season2_trust_price_snapshot(
+    snapshot_at: timestamptz!
+  ): season2_trust_price_snapshots
   """
   fetch data from the table: "season2_trust_price_snapshot"
   """
   season2_trust_price_snapshots(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_trust_price_snapshots_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_trust_price_snapshots_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_trust_price_snapshots_bool_exp
   ): [season2_trust_price_snapshots!]!
   """
   fetch aggregated fields from the table: "season2_trust_price_snapshot"
   """
   season2_trust_price_snapshots_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [season2_trust_price_snapshots_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [season2_trust_price_snapshots_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_trust_price_snapshots_bool_exp
   ): season2_trust_price_snapshots_aggregate!
   """
   fetch data from the table in a streaming manner: "season2_trust_price_snapshot"
   """
   season2_trust_price_snapshots_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [season2_trust_price_snapshots_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: season2_trust_price_snapshots_bool_exp
   ): [season2_trust_price_snapshots!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_daily(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_daily_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_daily_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_daily_bool_exp
   ): [share_price_change_stats_daily!]!
   """
   fetch data from the table in a streaming manner: "share_price_change_stats_daily"
   """
   share_price_change_stats_daily_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [share_price_change_stats_daily_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_daily_bool_exp
   ): [share_price_change_stats_daily!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_hourly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_hourly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_hourly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_hourly_bool_exp
   ): [share_price_change_stats_hourly!]!
   """
   fetch data from the table in a streaming manner: "share_price_change_stats_hourly"
   """
   share_price_change_stats_hourly_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [share_price_change_stats_hourly_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_hourly_bool_exp
   ): [share_price_change_stats_hourly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_monthly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_monthly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_monthly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_monthly_bool_exp
   ): [share_price_change_stats_monthly!]!
   """
   fetch data from the table in a streaming manner: "share_price_change_stats_monthly"
   """
   share_price_change_stats_monthly_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [share_price_change_stats_monthly_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_monthly_bool_exp
   ): [share_price_change_stats_monthly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_weekly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_weekly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_weekly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_weekly_bool_exp
   ): [share_price_change_stats_weekly!]!
   """
   fetch data from the table in a streaming manner: "share_price_change_stats_weekly"
   """
   share_price_change_stats_weekly_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [share_price_change_stats_weekly_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_weekly_bool_exp
   ): [share_price_change_stats_weekly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_changes(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_changes_bool_exp
   ): [share_price_changes!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   share_price_changes_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_changes_bool_exp
   ): share_price_changes_aggregate!
   """
   fetch data from the table in a streaming manner: "share_price_change"
   """
   share_price_changes_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [share_price_changes_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_changes_bool_exp
   ): [share_price_changes!]!
   """
   fetch data from the table: "signal_stats_daily"
   """
   signal_stats_daily(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signal_stats_daily_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signal_stats_daily_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_daily_bool_exp
   ): [signal_stats_daily!]!
   """
   fetch data from the table in a streaming manner: "signal_stats_daily"
   """
   signal_stats_daily_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [signal_stats_daily_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_daily_bool_exp
   ): [signal_stats_daily!]!
   """
   fetch data from the table: "signal_stats_hourly"
   """
   signal_stats_hourly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signal_stats_hourly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signal_stats_hourly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_hourly_bool_exp
   ): [signal_stats_hourly!]!
   """
   fetch data from the table in a streaming manner: "signal_stats_hourly"
   """
   signal_stats_hourly_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [signal_stats_hourly_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_hourly_bool_exp
   ): [signal_stats_hourly!]!
   """
   fetch data from the table: "signal_stats_monthly"
   """
   signal_stats_monthly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signal_stats_monthly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signal_stats_monthly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_monthly_bool_exp
   ): [signal_stats_monthly!]!
   """
   fetch data from the table in a streaming manner: "signal_stats_monthly"
   """
   signal_stats_monthly_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [signal_stats_monthly_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_monthly_bool_exp
   ): [signal_stats_monthly!]!
   """
   fetch data from the table: "signal_stats_weekly"
   """
   signal_stats_weekly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signal_stats_weekly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signal_stats_weekly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_weekly_bool_exp
   ): [signal_stats_weekly!]!
   """
   fetch data from the table in a streaming manner: "signal_stats_weekly"
   """
   signal_stats_weekly_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [signal_stats_weekly_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signal_stats_weekly_bool_exp
   ): [signal_stats_weekly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   signals(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): [signals!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   signals_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): signals_aggregate!
   """
@@ -16426,15 +24320,25 @@ type subscription_root {
     input parameters for function "signals_from_following"
     """
     args: signals_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): [signals!]!
   """
@@ -16445,569 +24349,949 @@ type subscription_root {
     input parameters for function "signals_from_following_aggregate"
     """
     args: signals_from_following_args!
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): signals_aggregate!
   """
   fetch data from the table in a streaming manner: "signal"
   """
   signals_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [signals_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): [signals!]!
-  """fetch data from the table: "stats" using primary key columns"""
+  """
+  fetch data from the table: "stats" using primary key columns
+  """
   stat(
-    """Primary key, always 0 for singleton pattern."""
+    """
+    Primary key, always 0 for singleton pattern.
+    """
     id: Int!
   ): stats
-  """fetch data from the table: "stats_hour" using primary key columns"""
+  """
+  fetch data from the table: "stats_hour" using primary key columns
+  """
   statHour(
-    """Auto-incrementing primary key."""
+    """
+    Auto-incrementing primary key.
+    """
     id: Int!
   ): statHours
   """
   fetch data from the table: "stats_hour"
   """
   statHours(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [statHours_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [statHours_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: statHours_bool_exp
   ): [statHours!]!
   """
   fetch data from the table in a streaming manner: "stats_hour"
   """
   statHours_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [statHours_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: statHours_bool_exp
   ): [statHours!]!
   """
   fetch data from the table: "stats"
   """
   stats(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: stats_bool_exp
   ): [stats!]!
   """
   fetch aggregated fields from the table: "stats"
   """
   stats_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [stats_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [stats_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: stats_bool_exp
   ): stats_aggregate!
   """
   fetch data from the table in a streaming manner: "stats"
   """
   stats_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [stats_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: stats_bool_exp
   ): [stats!]!
   """
   fetch data from the table: "subject_predicate"
   """
   subject_predicates(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [subject_predicates_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [subject_predicates_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: subject_predicates_bool_exp
   ): [subject_predicates!]!
   """
   fetch aggregated fields from the table: "subject_predicate"
   """
   subject_predicates_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [subject_predicates_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [subject_predicates_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: subject_predicates_bool_exp
   ): subject_predicates_aggregate!
   """
   fetch data from the table: "subject_predicate" using primary key columns
   """
   subject_predicates_by_pk(
-    """Predicate atom ID."""
+    """
+    Predicate atom ID.
+    """
     predicate_id: String!
-    """Subject atom ID."""
+    """
+    Subject atom ID.
+    """
     subject_id: String!
   ): subject_predicates
   """
   fetch data from the table in a streaming manner: "subject_predicate"
   """
   subject_predicates_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [subject_predicates_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: subject_predicates_bool_exp
   ): [subject_predicates!]!
-  """fetch data from the table: "term" using primary key columns"""
+  """
+  fetch data from the table: "term" using primary key columns
+  """
   term(
-    """Unique term identifier (vault ID for atoms/triples)."""
+    """
+    Unique term identifier (vault ID for atoms/triples).
+    """
     id: String!
   ): terms
   """
   fetch data from the table: "term_total_state_change_stats_daily"
   """
   term_total_state_change_stats_daily(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_daily_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_daily_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_daily_bool_exp
   ): [term_total_state_change_stats_daily!]!
   """
   fetch data from the table in a streaming manner: "term_total_state_change_stats_daily"
   """
   term_total_state_change_stats_daily_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [term_total_state_change_stats_daily_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_daily_bool_exp
   ): [term_total_state_change_stats_daily!]!
   """
   fetch data from the table: "term_total_state_change_stats_hourly"
   """
   term_total_state_change_stats_hourly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_hourly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_hourly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_hourly_bool_exp
   ): [term_total_state_change_stats_hourly!]!
   """
   fetch data from the table in a streaming manner: "term_total_state_change_stats_hourly"
   """
   term_total_state_change_stats_hourly_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [term_total_state_change_stats_hourly_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_hourly_bool_exp
   ): [term_total_state_change_stats_hourly!]!
   """
   fetch data from the table: "term_total_state_change_stats_monthly"
   """
   term_total_state_change_stats_monthly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_monthly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_monthly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_monthly_bool_exp
   ): [term_total_state_change_stats_monthly!]!
   """
   fetch data from the table in a streaming manner: "term_total_state_change_stats_monthly"
   """
   term_total_state_change_stats_monthly_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [term_total_state_change_stats_monthly_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_monthly_bool_exp
   ): [term_total_state_change_stats_monthly!]!
   """
   fetch data from the table: "term_total_state_change_stats_weekly"
   """
   term_total_state_change_stats_weekly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_weekly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_weekly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_weekly_bool_exp
   ): [term_total_state_change_stats_weekly!]!
   """
   fetch data from the table in a streaming manner: "term_total_state_change_stats_weekly"
   """
   term_total_state_change_stats_weekly_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [term_total_state_change_stats_weekly_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_weekly_bool_exp
   ): [term_total_state_change_stats_weekly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   term_total_state_changes(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_changes_bool_exp
   ): [term_total_state_changes!]!
   """
   fetch data from the table in a streaming manner: "term_total_state_change"
   """
   term_total_state_changes_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [term_total_state_changes_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_changes_bool_exp
   ): [term_total_state_changes!]!
   """
   fetch data from the table: "term"
   """
   terms(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): [terms!]!
   """
   fetch aggregated fields from the table: "term"
   """
   terms_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [terms_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [terms_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): terms_aggregate!
   """
   fetch data from the table in a streaming manner: "term"
   """
   terms_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [terms_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: terms_bool_exp
   ): [terms!]!
-  """fetch data from the table: "text_object" using primary key columns"""
+  """
+  fetch data from the table: "text_object" using primary key columns
+  """
   text_object(
-    """Unique identifier for this text object."""
+    """
+    Unique identifier for this text object.
+    """
     id: String!
   ): text_objects
   """
   fetch data from the table: "text_object"
   """
   text_objects(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [text_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [text_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: text_objects_bool_exp
   ): [text_objects!]!
   """
   fetch aggregated fields from the table: "text_object"
   """
   text_objects_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [text_objects_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [text_objects_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: text_objects_bool_exp
   ): text_objects_aggregate!
   """
   fetch data from the table in a streaming manner: "text_object"
   """
   text_objects_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [text_objects_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: text_objects_bool_exp
   ): [text_objects!]!
-  """fetch data from the table: "thing" using primary key columns"""
+  """
+  fetch data from the table: "thing" using primary key columns
+  """
   thing(
-    """Unique identifier for this thing entity."""
+    """
+    Unique identifier for this thing entity.
+    """
     id: String!
   ): things
   """
   fetch data from the table: "thing"
   """
   things(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [things_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [things_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: things_bool_exp
   ): [things!]!
   """
   fetch aggregated fields from the table: "thing"
   """
   things_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [things_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [things_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: things_bool_exp
   ): things_aggregate!
   """
   fetch data from the table in a streaming manner: "thing"
   """
   things_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [things_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: things_bool_exp
   ): [things!]!
-  """fetch data from the table: "triple" using primary key columns"""
+  """
+  fetch data from the table: "triple" using primary key columns
+  """
   triple(
-    """Unique identifier linking to the term registry."""
+    """
+    Unique identifier linking to the term registry.
+    """
     term_id: String!
   ): triples
-  """fetch data from the table: "triple_term" using primary key columns"""
+  """
+  fetch data from the table: "triple_term" using primary key columns
+  """
   triple_term(
-    """Triple term ID this aggregated data represents."""
+    """
+    Triple term ID this aggregated data represents.
+    """
     term_id: String!
   ): triple_term
   """
   fetch data from the table in a streaming manner: "triple_term"
   """
   triple_term_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [triple_term_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triple_term_bool_exp
   ): [triple_term!]!
   """
   fetch data from the table: "triple_term"
   """
   triple_terms(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triple_term_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triple_term_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triple_term_bool_exp
   ): [triple_term!]!
-  """fetch data from the table: "triple_vault" using primary key columns"""
+  """
+  fetch data from the table: "triple_vault" using primary key columns
+  """
   triple_vault(
-    """Bonding curve ID for this vault."""
+    """
+    Bonding curve ID for this vault.
+    """
     curve_id: numeric!
-    """Triple term ID this aggregated vault data represents."""
+    """
+    Triple term ID this aggregated vault data represents.
+    """
     term_id: String!
   ): triple_vault
   """
   fetch data from the table in a streaming manner: "triple_vault"
   """
   triple_vault_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [triple_vault_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triple_vault_bool_exp
   ): [triple_vault!]!
   """
   fetch data from the table: "triple_vault"
   """
   triple_vaults(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triple_vault_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triple_vault_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triple_vault_bool_exp
   ): [triple_vault!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   triples(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): [triples!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   triples_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [triples_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [triples_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): triples_aggregate!
   """
   fetch data from the table in a streaming manner: "triple"
   """
   triples_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [triples_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: triples_bool_exp
   ): [triples!]!
-  """fetch data from the table: "vault" using primary key columns"""
+  """
+  fetch data from the table: "vault" using primary key columns
+  """
   vault(
-    """Bonding curve configuration ID determining pricing curve."""
+    """
+    Bonding curve configuration ID determining pricing curve.
+    """
     curve_id: numeric!
-    """Term ID this vault backs (atom or triple)."""
+    """
+    Term ID this vault backs (atom or triple).
+    """
     term_id: String!
   ): vaults
-  """An array relationship"""
+  """
+  An array relationship
+  """
   vaults(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [vaults_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [vaults_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: vaults_bool_exp
   ): [vaults!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   vaults_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [vaults_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [vaults_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: vaults_bool_exp
   ): vaults_aggregate!
   """
   fetch data from the table in a streaming manner: "vault"
   """
   vaults_stream(
-    """maximum number of rows returned in a single batch"""
+    """
+    maximum number of rows returned in a single batch
+    """
     batch_size: Int!
-    """cursor to stream the results returned by the query"""
+    """
+    cursor to stream the results returned by the query
+    """
     cursor: [vaults_stream_cursor_input]!
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: vaults_bool_exp
   ): [vaults!]!
 }
@@ -17100,15 +25384,25 @@ input term_total_state_change_stats_daily_order_by {
 select columns of table "term_total_state_change_stats_daily"
 """
 enum term_total_state_change_stats_daily_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   difference
-  """column name"""
+  """
+  column name
+  """
   first_total_market_cap
-  """column name"""
+  """
+  column name
+  """
   last_total_market_cap
-  """column name"""
+  """
+  column name
+  """
   term_id
 }
 
@@ -17143,13 +25437,19 @@ input term_total_state_change_stats_daily_stddev_samp_order_by {
 Streaming cursor of the table "term_total_state_change_stats_daily"
 """
 input term_total_state_change_stats_daily_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: term_total_state_change_stats_daily_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input term_total_state_change_stats_daily_stream_cursor_value_input {
   bucket: timestamptz
   difference: numeric
@@ -17282,15 +25582,25 @@ input term_total_state_change_stats_hourly_order_by {
 select columns of table "term_total_state_change_stats_hourly"
 """
 enum term_total_state_change_stats_hourly_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   difference
-  """column name"""
+  """
+  column name
+  """
   first_total_market_cap
-  """column name"""
+  """
+  column name
+  """
   last_total_market_cap
-  """column name"""
+  """
+  column name
+  """
   term_id
 }
 
@@ -17325,13 +25635,19 @@ input term_total_state_change_stats_hourly_stddev_samp_order_by {
 Streaming cursor of the table "term_total_state_change_stats_hourly"
 """
 input term_total_state_change_stats_hourly_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: term_total_state_change_stats_hourly_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input term_total_state_change_stats_hourly_stream_cursor_value_input {
   bucket: timestamptz
   difference: numeric
@@ -17464,15 +25780,25 @@ input term_total_state_change_stats_monthly_order_by {
 select columns of table "term_total_state_change_stats_monthly"
 """
 enum term_total_state_change_stats_monthly_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   difference
-  """column name"""
+  """
+  column name
+  """
   first_total_market_cap
-  """column name"""
+  """
+  column name
+  """
   last_total_market_cap
-  """column name"""
+  """
+  column name
+  """
   term_id
 }
 
@@ -17507,13 +25833,19 @@ input term_total_state_change_stats_monthly_stddev_samp_order_by {
 Streaming cursor of the table "term_total_state_change_stats_monthly"
 """
 input term_total_state_change_stats_monthly_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: term_total_state_change_stats_monthly_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input term_total_state_change_stats_monthly_stream_cursor_value_input {
   bucket: timestamptz
   difference: numeric
@@ -17646,15 +25978,25 @@ input term_total_state_change_stats_weekly_order_by {
 select columns of table "term_total_state_change_stats_weekly"
 """
 enum term_total_state_change_stats_weekly_select_column {
-  """column name"""
+  """
+  column name
+  """
   bucket
-  """column name"""
+  """
+  column name
+  """
   difference
-  """column name"""
+  """
+  column name
+  """
   first_total_market_cap
-  """column name"""
+  """
+  column name
+  """
   last_total_market_cap
-  """column name"""
+  """
+  column name
+  """
   term_id
 }
 
@@ -17689,13 +26031,19 @@ input term_total_state_change_stats_weekly_stddev_samp_order_by {
 Streaming cursor of the table "term_total_state_change_stats_weekly"
 """
 input term_total_state_change_stats_weekly_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: term_total_state_change_stats_weekly_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input term_total_state_change_stats_weekly_stream_cursor_value_input {
   bucket: timestamptz
   difference: numeric
@@ -17748,11 +26096,17 @@ type term_total_state_changes {
   Timestamp when this state change occurred (TimescaleDB partition column).
   """
   created_at: timestamptz!
-  """Term ID whose state changed."""
+  """
+  Term ID whose state changed.
+  """
   term_id: String!
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: numeric!
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: numeric!
 }
 
@@ -17777,9 +26131,13 @@ input term_total_state_changes_aggregate_order_by {
 order by avg() on columns of table "term_total_state_change"
 """
 input term_total_state_changes_avg_order_by {
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: order_by
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: order_by
 }
 
@@ -17804,11 +26162,17 @@ input term_total_state_changes_max_order_by {
   Timestamp when this state change occurred (TimescaleDB partition column).
   """
   created_at: order_by
-  """Term ID whose state changed."""
+  """
+  Term ID whose state changed.
+  """
   term_id: order_by
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: order_by
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: order_by
 }
 
@@ -17820,15 +26184,23 @@ input term_total_state_changes_min_order_by {
   Timestamp when this state change occurred (TimescaleDB partition column).
   """
   created_at: order_by
-  """Term ID whose state changed."""
+  """
+  Term ID whose state changed.
+  """
   term_id: order_by
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: order_by
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: order_by
 }
 
-"""Ordering options when selecting data from "term_total_state_change"."""
+"""
+Ordering options when selecting data from "term_total_state_change".
+"""
 input term_total_state_changes_order_by {
   created_at: order_by
   term_id: order_by
@@ -17840,13 +26212,21 @@ input term_total_state_changes_order_by {
 select columns of table "term_total_state_change"
 """
 enum term_total_state_changes_select_column {
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   total_assets
-  """column name"""
+  """
+  column name
+  """
   total_market_cap
 }
 
@@ -17854,9 +26234,13 @@ enum term_total_state_changes_select_column {
 order by stddev() on columns of table "term_total_state_change"
 """
 input term_total_state_changes_stddev_order_by {
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: order_by
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: order_by
 }
 
@@ -17864,9 +26248,13 @@ input term_total_state_changes_stddev_order_by {
 order by stddev_pop() on columns of table "term_total_state_change"
 """
 input term_total_state_changes_stddev_pop_order_by {
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: order_by
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: order_by
 }
 
@@ -17874,9 +26262,13 @@ input term_total_state_changes_stddev_pop_order_by {
 order by stddev_samp() on columns of table "term_total_state_change"
 """
 input term_total_state_changes_stddev_samp_order_by {
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: order_by
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: order_by
 }
 
@@ -17884,23 +26276,35 @@ input term_total_state_changes_stddev_samp_order_by {
 Streaming cursor of the table "term_total_state_changes"
 """
 input term_total_state_changes_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: term_total_state_changes_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input term_total_state_changes_stream_cursor_value_input {
   """
   Timestamp when this state change occurred (TimescaleDB partition column).
   """
   created_at: timestamptz
-  """Term ID whose state changed."""
+  """
+  Term ID whose state changed.
+  """
   term_id: String
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: numeric
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: numeric
 }
 
@@ -17908,9 +26312,13 @@ input term_total_state_changes_stream_cursor_value_input {
 order by sum() on columns of table "term_total_state_change"
 """
 input term_total_state_changes_sum_order_by {
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: order_by
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: order_by
 }
 
@@ -17918,9 +26326,13 @@ input term_total_state_changes_sum_order_by {
 order by var_pop() on columns of table "term_total_state_change"
 """
 input term_total_state_changes_var_pop_order_by {
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: order_by
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: order_by
 }
 
@@ -17928,9 +26340,13 @@ input term_total_state_changes_var_pop_order_by {
 order by var_samp() on columns of table "term_total_state_change"
 """
 input term_total_state_changes_var_samp_order_by {
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: order_by
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: order_by
 }
 
@@ -17938,9 +26354,13 @@ input term_total_state_changes_var_samp_order_by {
 order by variance() on columns of table "term_total_state_change"
 """
 input term_total_state_changes_variance_order_by {
-  """Snapshot of total_assets at this point in time, in wei."""
+  """
+  Snapshot of total_assets at this point in time, in wei.
+  """
   total_assets: order_by
-  """Snapshot of total_market_cap at this point in time, in wei."""
+  """
+  Snapshot of total_market_cap at this point in time, in wei.
+  """
   total_market_cap: order_by
 }
 
@@ -17965,301 +26385,577 @@ input term_type_comparison_exp {
 Unified registry of all terms (atoms, triples, counter-triples) with aggregated market data.
 """
 type terms {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atomById: atoms
-  """Reference to atom if this term is an Atom type."""
+  """
+  Reference to atom if this term is an Atom type.
+  """
   atom_id: String
-  """Timestamp when this term was created."""
+  """
+  Timestamp when this term was created.
+  """
   created_at: timestamptz!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   deposits(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): [deposits!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   deposits_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): deposits_aggregate!
-  """Unique term identifier (vault ID for atoms/triples)."""
+  """
+  Unique term identifier (vault ID for atoms/triples).
+  """
   id: String!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   positions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   positions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   redemptions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): [redemptions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   redemptions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): redemptions_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_daily(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_daily_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_daily_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_daily_bool_exp
   ): [share_price_change_stats_daily!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_hourly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_hourly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_hourly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_hourly_bool_exp
   ): [share_price_change_stats_hourly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_monthly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_monthly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_monthly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_monthly_bool_exp
   ): [share_price_change_stats_monthly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_weekly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_weekly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_weekly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_weekly_bool_exp
   ): [share_price_change_stats_weekly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_changes(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_changes_bool_exp
   ): [share_price_changes!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   share_price_changes_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_changes_bool_exp
   ): share_price_changes_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   signals(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): [signals!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   signals_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): signals_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   term_total_state_change_daily(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_daily_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_daily_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_daily_bool_exp
   ): [term_total_state_change_stats_daily!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   term_total_state_change_hourly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_hourly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_hourly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_hourly_bool_exp
   ): [term_total_state_change_stats_hourly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   term_total_state_change_monthly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_monthly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_monthly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_monthly_bool_exp
   ): [term_total_state_change_stats_monthly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   term_total_state_change_weekly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_change_stats_weekly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_change_stats_weekly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_change_stats_weekly_bool_exp
   ): [term_total_state_change_stats_weekly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   term_total_state_changes(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [term_total_state_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [term_total_state_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: term_total_state_changes_bool_exp
   ): [term_total_state_changes!]!
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: numeric
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: numeric
-  """An object relationship"""
+  """
+  An object relationship
+  """
   triple: triples
-  """An object relationship"""
+  """
+  An object relationship
+  """
   tripleById: triples
-  """Reference to triple if this term is a Triple or CounterTriple type."""
+  """
+  Reference to triple if this term is a Triple or CounterTriple type.
+  """
   triple_id: String
-  """Type of term: Atom, Triple, or CounterTriple."""
+  """
+  Type of term: Atom, Triple, or CounterTriple.
+  """
   type: term_type!
-  """Timestamp of last update to this term."""
+  """
+  Timestamp of last update to this term.
+  """
   updated_at: timestamptz!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   vaults(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [vaults_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [vaults_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: vaults_bool_exp
   ): [vaults!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   vaults_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [vaults_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [vaults_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: vaults_bool_exp
   ): vaults_aggregate!
 }
@@ -18286,11 +26982,17 @@ type terms_aggregate_fields {
   variance: terms_variance_fields
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type terms_avg_fields {
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: Float
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: Float
 }
 
@@ -18336,47 +27038,85 @@ input terms_bool_exp {
   vaults_aggregate: vaults_aggregate_bool_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type terms_max_fields {
-  """Reference to atom if this term is an Atom type."""
+  """
+  Reference to atom if this term is an Atom type.
+  """
   atom_id: String
-  """Timestamp when this term was created."""
+  """
+  Timestamp when this term was created.
+  """
   created_at: timestamptz
-  """Unique term identifier (vault ID for atoms/triples)."""
+  """
+  Unique term identifier (vault ID for atoms/triples).
+  """
   id: String
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: numeric
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: numeric
-  """Reference to triple if this term is a Triple or CounterTriple type."""
+  """
+  Reference to triple if this term is a Triple or CounterTriple type.
+  """
   triple_id: String
-  """Type of term: Atom, Triple, or CounterTriple."""
+  """
+  Type of term: Atom, Triple, or CounterTriple.
+  """
   type: term_type
-  """Timestamp of last update to this term."""
+  """
+  Timestamp of last update to this term.
+  """
   updated_at: timestamptz
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type terms_min_fields {
-  """Reference to atom if this term is an Atom type."""
+  """
+  Reference to atom if this term is an Atom type.
+  """
   atom_id: String
-  """Timestamp when this term was created."""
+  """
+  Timestamp when this term was created.
+  """
   created_at: timestamptz
-  """Unique term identifier (vault ID for atoms/triples)."""
+  """
+  Unique term identifier (vault ID for atoms/triples).
+  """
   id: String
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: numeric
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: numeric
-  """Reference to triple if this term is a Triple or CounterTriple type."""
+  """
+  Reference to triple if this term is a Triple or CounterTriple type.
+  """
   triple_id: String
-  """Type of term: Atom, Triple, or CounterTriple."""
+  """
+  Type of term: Atom, Triple, or CounterTriple.
+  """
   type: term_type
-  """Timestamp of last update to this term."""
+  """
+  Timestamp of last update to this term.
+  """
   updated_at: timestamptz
 }
 
-"""Ordering options when selecting data from "term"."""
+"""
+Ordering options when selecting data from "term".
+"""
 input terms_order_by {
   atom: atoms_order_by
   atomById: atoms_order_by
@@ -18411,45 +27151,79 @@ input terms_order_by {
 select columns of table "term"
 """
 enum terms_select_column {
-  """column name"""
+  """
+  column name
+  """
   atom_id
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   total_assets
-  """column name"""
+  """
+  column name
+  """
   total_market_cap
-  """column name"""
+  """
+  column name
+  """
   triple_id
-  """column name"""
+  """
+  column name
+  """
   type
-  """column name"""
+  """
+  column name
+  """
   updated_at
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type terms_stddev_fields {
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: Float
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: Float
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type terms_stddev_pop_fields {
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: Float
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: Float
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type terms_stddev_samp_fields {
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: Float
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: Float
 }
 
@@ -18457,71 +27231,125 @@ type terms_stddev_samp_fields {
 Streaming cursor of the table "terms"
 """
 input terms_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: terms_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input terms_stream_cursor_value_input {
-  """Reference to atom if this term is an Atom type."""
+  """
+  Reference to atom if this term is an Atom type.
+  """
   atom_id: String
-  """Timestamp when this term was created."""
+  """
+  Timestamp when this term was created.
+  """
   created_at: timestamptz
-  """Unique term identifier (vault ID for atoms/triples)."""
+  """
+  Unique term identifier (vault ID for atoms/triples).
+  """
   id: String
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: numeric
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: numeric
-  """Reference to triple if this term is a Triple or CounterTriple type."""
+  """
+  Reference to triple if this term is a Triple or CounterTriple type.
+  """
   triple_id: String
-  """Type of term: Atom, Triple, or CounterTriple."""
+  """
+  Type of term: Atom, Triple, or CounterTriple.
+  """
   type: term_type
-  """Timestamp of last update to this term."""
+  """
+  Timestamp of last update to this term.
+  """
   updated_at: timestamptz
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type terms_sum_fields {
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: numeric
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: numeric
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type terms_var_pop_fields {
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: Float
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: Float
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type terms_var_samp_fields {
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: Float
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: Float
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type terms_variance_fields {
-  """Total assets across all curves for this term, in wei."""
+  """
+  Total assets across all curves for this term, in wei.
+  """
   total_assets: Float
-  """Total market capitalization across all curves for this term, in wei."""
+  """
+  Total market capitalization across all curves for this term, in wei.
+  """
   total_market_cap: Float
 }
 
-"""Plain text storage for atom values containing simple text content."""
+"""
+Plain text storage for atom values containing simple text content.
+"""
 type text_objects {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
-  """Plain text content."""
+  """
+  Plain text content.
+  """
   data: String!
-  """Unique identifier for this text object."""
+  """
+  Unique identifier for this text object.
+  """
   id: String!
 }
 
@@ -18554,23 +27382,37 @@ input text_objects_bool_exp {
   id: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type text_objects_max_fields {
-  """Plain text content."""
+  """
+  Plain text content.
+  """
   data: String
-  """Unique identifier for this text object."""
+  """
+  Unique identifier for this text object.
+  """
   id: String
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type text_objects_min_fields {
-  """Plain text content."""
+  """
+  Plain text content.
+  """
   data: String
-  """Unique identifier for this text object."""
+  """
+  Unique identifier for this text object.
+  """
   id: String
 }
 
-"""Ordering options when selecting data from "text_object"."""
+"""
+Ordering options when selecting data from "text_object".
+"""
 input text_objects_order_by {
   atom: atoms_order_by
   data: order_by
@@ -18581,9 +27423,13 @@ input text_objects_order_by {
 select columns of table "text_object"
 """
 enum text_objects_select_column {
-  """column name"""
+  """
+  column name
+  """
   data
-  """column name"""
+  """
+  column name
+  """
   id
 }
 
@@ -18591,17 +27437,27 @@ enum text_objects_select_column {
 Streaming cursor of the table "text_objects"
 """
 input text_objects_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: text_objects_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input text_objects_stream_cursor_value_input {
-  """Plain text content."""
+  """
+  Plain text content.
+  """
   data: String
-  """Unique identifier for this text object."""
+  """
+  Unique identifier for this text object.
+  """
   id: String
 }
 
@@ -18609,18 +27465,30 @@ input text_objects_stream_cursor_value_input {
 Generic thing entities following schema.org Thing specification for atom values.
 """
 type things {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   atom: atoms
   cached_image: cached_images_cached_image
-  """Description of the thing."""
+  """
+  Description of the thing.
+  """
   description: String
-  """Unique identifier for this thing entity."""
+  """
+  Unique identifier for this thing entity.
+  """
   id: String!
-  """Image URL for the thing."""
+  """
+  Image URL for the thing.
+  """
   image: String
-  """Name or title of the thing."""
+  """
+  Name or title of the thing.
+  """
   name: String
-  """External URL or homepage for the thing."""
+  """
+  External URL or homepage for the thing.
+  """
   url: String
 }
 
@@ -18656,35 +27524,61 @@ input things_bool_exp {
   url: String_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type things_max_fields {
-  """Description of the thing."""
+  """
+  Description of the thing.
+  """
   description: String
-  """Unique identifier for this thing entity."""
+  """
+  Unique identifier for this thing entity.
+  """
   id: String
-  """Image URL for the thing."""
+  """
+  Image URL for the thing.
+  """
   image: String
-  """Name or title of the thing."""
+  """
+  Name or title of the thing.
+  """
   name: String
-  """External URL or homepage for the thing."""
+  """
+  External URL or homepage for the thing.
+  """
   url: String
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type things_min_fields {
-  """Description of the thing."""
+  """
+  Description of the thing.
+  """
   description: String
-  """Unique identifier for this thing entity."""
+  """
+  Unique identifier for this thing entity.
+  """
   id: String
-  """Image URL for the thing."""
+  """
+  Image URL for the thing.
+  """
   image: String
-  """Name or title of the thing."""
+  """
+  Name or title of the thing.
+  """
   name: String
-  """External URL or homepage for the thing."""
+  """
+  External URL or homepage for the thing.
+  """
   url: String
 }
 
-"""Ordering options when selecting data from "thing"."""
+"""
+Ordering options when selecting data from "thing".
+"""
 input things_order_by {
   atom: atoms_order_by
   description: order_by
@@ -18698,15 +27592,25 @@ input things_order_by {
 select columns of table "thing"
 """
 enum things_select_column {
-  """column name"""
+  """
+  column name
+  """
   description
-  """column name"""
+  """
+  column name
+  """
   id
-  """column name"""
+  """
+  column name
+  """
   image
-  """column name"""
+  """
+  column name
+  """
   name
-  """column name"""
+  """
+  column name
+  """
   url
 }
 
@@ -18714,23 +27618,39 @@ enum things_select_column {
 Streaming cursor of the table "things"
 """
 input things_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: things_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input things_stream_cursor_value_input {
-  """Description of the thing."""
+  """
+  Description of the thing.
+  """
   description: String
-  """Unique identifier for this thing entity."""
+  """
+  Unique identifier for this thing entity.
+  """
   id: String
-  """Image URL for the thing."""
+  """
+  Image URL for the thing.
+  """
   image: String
-  """Name or title of the thing."""
+  """
+  Name or title of the thing.
+  """
   name: String
-  """External URL or homepage for the thing."""
+  """
+  External URL or homepage for the thing.
+  """
   url: String
 }
 
@@ -18755,23 +27675,39 @@ input timestamptz_comparison_exp {
 Aggregated term-level data for triples, tracking total assets and positions across all curves.
 """
 type triple_term {
-  """An object relationship"""
+  """
+  An object relationship
+  """
   counter_term: terms
-  """Counter-triple term ID for this triple."""
+  """
+  Counter-triple term ID for this triple.
+  """
   counter_term_id: String!
   opposer_count: bigint!
   supporter_count: bigint!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
-  """Triple term ID this aggregated data represents."""
+  """
+  Triple term ID this aggregated data represents.
+  """
   term_id: String!
-  """Total assets across all curves for this triple, in wei."""
+  """
+  Total assets across all curves for this triple, in wei.
+  """
   total_assets: numeric!
-  """Total market cap across all curves for this triple, in wei."""
+  """
+  Total market cap across all curves for this triple, in wei.
+  """
   total_market_cap: numeric!
-  """Total positions across all curves for this triple."""
+  """
+  Total positions across all curves for this triple.
+  """
   total_position_count: bigint!
-  """Timestamp of last update."""
+  """
+  Timestamp of last update.
+  """
   updated_at: timestamptz!
 }
 
@@ -18794,7 +27730,9 @@ input triple_term_bool_exp {
   updated_at: timestamptz_comparison_exp
 }
 
-"""Ordering options when selecting data from "triple_term"."""
+"""
+Ordering options when selecting data from "triple_term".
+"""
 input triple_term_order_by {
   counter_term: terms_order_by
   counter_term_id: order_by
@@ -18812,21 +27750,37 @@ input triple_term_order_by {
 select columns of table "triple_term"
 """
 enum triple_term_select_column {
-  """column name"""
+  """
+  column name
+  """
   counter_term_id
-  """column name"""
+  """
+  column name
+  """
   opposer_count
-  """column name"""
+  """
+  column name
+  """
   supporter_count
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   total_assets
-  """column name"""
+  """
+  column name
+  """
   total_market_cap
-  """column name"""
+  """
+  column name
+  """
   total_position_count
-  """column name"""
+  """
+  column name
+  """
   updated_at
 }
 
@@ -18834,27 +27788,45 @@ enum triple_term_select_column {
 Streaming cursor of the table "triple_term"
 """
 input triple_term_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: triple_term_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input triple_term_stream_cursor_value_input {
-  """Counter-triple term ID for this triple."""
+  """
+  Counter-triple term ID for this triple.
+  """
   counter_term_id: String
   opposer_count: bigint
   supporter_count: bigint
-  """Triple term ID this aggregated data represents."""
+  """
+  Triple term ID this aggregated data represents.
+  """
   term_id: String
-  """Total assets across all curves for this triple, in wei."""
+  """
+  Total assets across all curves for this triple, in wei.
+  """
   total_assets: numeric
-  """Total market cap across all curves for this triple, in wei."""
+  """
+  Total market cap across all curves for this triple, in wei.
+  """
   total_market_cap: numeric
-  """Total positions across all curves for this triple."""
+  """
+  Total positions across all curves for this triple.
+  """
   total_position_count: bigint
-  """Timestamp of last update."""
+  """
+  Timestamp of last update.
+  """
   updated_at: timestamptz
 }
 
@@ -18862,29 +27834,53 @@ input triple_term_stream_cursor_value_input {
 Aggregated vault data for triples, denormalized from vault table for query performance.
 """
 type triple_vault {
-  """Block number of most recent update."""
+  """
+  Block number of most recent update.
+  """
   block_number: numeric!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   counter_term: terms
-  """Counter-triple term ID for this triple."""
+  """
+  Counter-triple term ID for this triple.
+  """
   counter_term_id: String!
-  """Bonding curve ID for this vault."""
+  """
+  Bonding curve ID for this vault.
+  """
   curve_id: numeric!
-  """Log index of most recent update."""
+  """
+  Log index of most recent update.
+  """
   log_index: bigint!
-  """Total market cap across triple and counter-triple vaults, in wei."""
+  """
+  Total market cap across triple and counter-triple vaults, in wei.
+  """
   market_cap: numeric!
-  """Total positions across triple and counter-triple vaults."""
+  """
+  Total positions across triple and counter-triple vaults.
+  """
   position_count: bigint!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
-  """Triple term ID this aggregated vault data represents."""
+  """
+  Triple term ID this aggregated vault data represents.
+  """
   term_id: String!
-  """Total assets across triple and counter-triple vaults, in wei."""
+  """
+  Total assets across triple and counter-triple vaults, in wei.
+  """
   total_assets: numeric!
-  """Total shares across triple and counter-triple vaults."""
+  """
+  Total shares across triple and counter-triple vaults.
+  """
   total_shares: numeric!
-  """Timestamp of last update."""
+  """
+  Timestamp of last update.
+  """
   updated_at: timestamptz!
 }
 
@@ -18909,7 +27905,9 @@ input triple_vault_bool_exp {
   updated_at: timestamptz_comparison_exp
 }
 
-"""Ordering options when selecting data from "triple_vault"."""
+"""
+Ordering options when selecting data from "triple_vault".
+"""
 input triple_vault_order_by {
   block_number: order_by
   counter_term: terms_order_by
@@ -18929,25 +27927,45 @@ input triple_vault_order_by {
 select columns of table "triple_vault"
 """
 enum triple_vault_select_column {
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   counter_term_id
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   log_index
-  """column name"""
+  """
+  column name
+  """
   market_cap
-  """column name"""
+  """
+  column name
+  """
   position_count
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   total_assets
-  """column name"""
+  """
+  column name
+  """
   total_shares
-  """column name"""
+  """
+  column name
+  """
   updated_at
 }
 
@@ -18955,33 +27973,59 @@ enum triple_vault_select_column {
 Streaming cursor of the table "triple_vault"
 """
 input triple_vault_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: triple_vault_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input triple_vault_stream_cursor_value_input {
-  """Block number of most recent update."""
+  """
+  Block number of most recent update.
+  """
   block_number: numeric
-  """Counter-triple term ID for this triple."""
+  """
+  Counter-triple term ID for this triple.
+  """
   counter_term_id: String
-  """Bonding curve ID for this vault."""
+  """
+  Bonding curve ID for this vault.
+  """
   curve_id: numeric
-  """Log index of most recent update."""
+  """
+  Log index of most recent update.
+  """
   log_index: bigint
-  """Total market cap across triple and counter-triple vaults, in wei."""
+  """
+  Total market cap across triple and counter-triple vaults, in wei.
+  """
   market_cap: numeric
-  """Total positions across triple and counter-triple vaults."""
+  """
+  Total positions across triple and counter-triple vaults.
+  """
   position_count: bigint
-  """Triple term ID this aggregated vault data represents."""
+  """
+  Triple term ID this aggregated vault data represents.
+  """
   term_id: String
-  """Total assets across triple and counter-triple vaults, in wei."""
+  """
+  Total assets across triple and counter-triple vaults, in wei.
+  """
   total_assets: numeric
-  """Total shares across triple and counter-triple vaults."""
+  """
+  Total shares across triple and counter-triple vaults.
+  """
   total_shares: numeric
-  """Timestamp of last update."""
+  """
+  Timestamp of last update.
+  """
   updated_at: timestamptz
 }
 
@@ -18989,97 +28033,185 @@ input triple_vault_stream_cursor_value_input {
 Knowledge claims expressed as subject-predicate-object triples, forming the core knowledge graph.
 """
 type triples {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: numeric!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   counter_positions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   counter_positions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   counter_term: terms
-  """Term ID of the opposing CounterTriple for this triple."""
+  """
+  Term ID of the opposing CounterTriple for this triple.
+  """
   counter_term_id: String!
-  """Timestamp when this triple was created."""
+  """
+  Timestamp when this triple was created.
+  """
   created_at: timestamptz!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   creator: accounts
-  """Account that created this triple via smart contract transaction."""
+  """
+  Account that created this triple via smart contract transaction.
+  """
   creator_id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   object: atoms
-  """Object atom ID forming the third element of the triple."""
+  """
+  Object atom ID forming the third element of the triple.
+  """
   object_id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   object_term: terms
-  """An array relationship"""
+  """
+  An array relationship
+  """
   positions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   positions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   predicate: atoms
-  """Predicate atom ID forming the relationship of the triple."""
+  """
+  Predicate atom ID forming the relationship of the triple.
+  """
   predicate_id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   predicate_term: terms
-  """An object relationship"""
+  """
+  An object relationship
+  """
   subject: atoms
-  """Subject atom ID forming the first element of the triple."""
+  """
+  Subject atom ID forming the first element of the triple.
+  """
   subject_id: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   subject_term: terms
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: String!
-  """Transaction hash of the triple creation event."""
+  """
+  Transaction hash of the triple creation event.
+  """
   transaction_hash: String!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   triple_term: triple_term
-  """An object relationship"""
+  """
+  An object relationship
+  """
   triple_vault: triple_vault
 }
 
@@ -19136,9 +28268,13 @@ input triples_aggregate_order_by {
   variance: triples_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type triples_avg_fields {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: Float
 }
 
@@ -19146,7 +28282,9 @@ type triples_avg_fields {
 order by avg() on columns of table "triple"
 """
 input triples_avg_order_by {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: order_by
 }
 
@@ -19183,25 +28321,45 @@ input triples_bool_exp {
   triple_vault: triple_vault_bool_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type triples_max_fields {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: numeric
-  """Term ID of the opposing CounterTriple for this triple."""
+  """
+  Term ID of the opposing CounterTriple for this triple.
+  """
   counter_term_id: String
-  """Timestamp when this triple was created."""
+  """
+  Timestamp when this triple was created.
+  """
   created_at: timestamptz
-  """Account that created this triple via smart contract transaction."""
+  """
+  Account that created this triple via smart contract transaction.
+  """
   creator_id: String
-  """Object atom ID forming the third element of the triple."""
+  """
+  Object atom ID forming the third element of the triple.
+  """
   object_id: String
-  """Predicate atom ID forming the relationship of the triple."""
+  """
+  Predicate atom ID forming the relationship of the triple.
+  """
   predicate_id: String
-  """Subject atom ID forming the first element of the triple."""
+  """
+  Subject atom ID forming the first element of the triple.
+  """
   subject_id: String
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: String
-  """Transaction hash of the triple creation event."""
+  """
+  Transaction hash of the triple creation event.
+  """
   transaction_hash: String
 }
 
@@ -19209,45 +28367,83 @@ type triples_max_fields {
 order by max() on columns of table "triple"
 """
 input triples_max_order_by {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: order_by
-  """Term ID of the opposing CounterTriple for this triple."""
+  """
+  Term ID of the opposing CounterTriple for this triple.
+  """
   counter_term_id: order_by
-  """Timestamp when this triple was created."""
+  """
+  Timestamp when this triple was created.
+  """
   created_at: order_by
-  """Account that created this triple via smart contract transaction."""
+  """
+  Account that created this triple via smart contract transaction.
+  """
   creator_id: order_by
-  """Object atom ID forming the third element of the triple."""
+  """
+  Object atom ID forming the third element of the triple.
+  """
   object_id: order_by
-  """Predicate atom ID forming the relationship of the triple."""
+  """
+  Predicate atom ID forming the relationship of the triple.
+  """
   predicate_id: order_by
-  """Subject atom ID forming the first element of the triple."""
+  """
+  Subject atom ID forming the first element of the triple.
+  """
   subject_id: order_by
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: order_by
-  """Transaction hash of the triple creation event."""
+  """
+  Transaction hash of the triple creation event.
+  """
   transaction_hash: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type triples_min_fields {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: numeric
-  """Term ID of the opposing CounterTriple for this triple."""
+  """
+  Term ID of the opposing CounterTriple for this triple.
+  """
   counter_term_id: String
-  """Timestamp when this triple was created."""
+  """
+  Timestamp when this triple was created.
+  """
   created_at: timestamptz
-  """Account that created this triple via smart contract transaction."""
+  """
+  Account that created this triple via smart contract transaction.
+  """
   creator_id: String
-  """Object atom ID forming the third element of the triple."""
+  """
+  Object atom ID forming the third element of the triple.
+  """
   object_id: String
-  """Predicate atom ID forming the relationship of the triple."""
+  """
+  Predicate atom ID forming the relationship of the triple.
+  """
   predicate_id: String
-  """Subject atom ID forming the first element of the triple."""
+  """
+  Subject atom ID forming the first element of the triple.
+  """
   subject_id: String
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: String
-  """Transaction hash of the triple creation event."""
+  """
+  Transaction hash of the triple creation event.
+  """
   transaction_hash: String
 }
 
@@ -19255,27 +28451,47 @@ type triples_min_fields {
 order by min() on columns of table "triple"
 """
 input triples_min_order_by {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: order_by
-  """Term ID of the opposing CounterTriple for this triple."""
+  """
+  Term ID of the opposing CounterTriple for this triple.
+  """
   counter_term_id: order_by
-  """Timestamp when this triple was created."""
+  """
+  Timestamp when this triple was created.
+  """
   created_at: order_by
-  """Account that created this triple via smart contract transaction."""
+  """
+  Account that created this triple via smart contract transaction.
+  """
   creator_id: order_by
-  """Object atom ID forming the third element of the triple."""
+  """
+  Object atom ID forming the third element of the triple.
+  """
   object_id: order_by
-  """Predicate atom ID forming the relationship of the triple."""
+  """
+  Predicate atom ID forming the relationship of the triple.
+  """
   predicate_id: order_by
-  """Subject atom ID forming the first element of the triple."""
+  """
+  Subject atom ID forming the first element of the triple.
+  """
   subject_id: order_by
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: order_by
-  """Transaction hash of the triple creation event."""
+  """
+  Transaction hash of the triple creation event.
+  """
   transaction_hash: order_by
 }
 
-"""Ordering options when selecting data from "triple"."""
+"""
+Ordering options when selecting data from "triple".
+"""
 input triples_order_by {
   block_number: order_by
   counter_positions_aggregate: positions_aggregate_order_by
@@ -19305,29 +28521,51 @@ input triples_order_by {
 select columns of table "triple"
 """
 enum triples_select_column {
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   counter_term_id
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   creator_id
-  """column name"""
+  """
+  column name
+  """
   object_id
-  """column name"""
+  """
+  column name
+  """
   predicate_id
-  """column name"""
+  """
+  column name
+  """
   subject_id
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type triples_stddev_fields {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: Float
 }
 
@@ -19335,13 +28573,19 @@ type triples_stddev_fields {
 order by stddev() on columns of table "triple"
 """
 input triples_stddev_order_by {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type triples_stddev_pop_fields {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: Float
 }
 
@@ -19349,13 +28593,19 @@ type triples_stddev_pop_fields {
 order by stddev_pop() on columns of table "triple"
 """
 input triples_stddev_pop_order_by {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type triples_stddev_samp_fields {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: Float
 }
 
@@ -19363,7 +28613,9 @@ type triples_stddev_samp_fields {
 order by stddev_samp() on columns of table "triple"
 """
 input triples_stddev_samp_order_by {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: order_by
 }
 
@@ -19371,37 +28623,65 @@ input triples_stddev_samp_order_by {
 Streaming cursor of the table "triples"
 """
 input triples_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: triples_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input triples_stream_cursor_value_input {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: numeric
-  """Term ID of the opposing CounterTriple for this triple."""
+  """
+  Term ID of the opposing CounterTriple for this triple.
+  """
   counter_term_id: String
-  """Timestamp when this triple was created."""
+  """
+  Timestamp when this triple was created.
+  """
   created_at: timestamptz
-  """Account that created this triple via smart contract transaction."""
+  """
+  Account that created this triple via smart contract transaction.
+  """
   creator_id: String
-  """Object atom ID forming the third element of the triple."""
+  """
+  Object atom ID forming the third element of the triple.
+  """
   object_id: String
-  """Predicate atom ID forming the relationship of the triple."""
+  """
+  Predicate atom ID forming the relationship of the triple.
+  """
   predicate_id: String
-  """Subject atom ID forming the first element of the triple."""
+  """
+  Subject atom ID forming the first element of the triple.
+  """
   subject_id: String
-  """Unique identifier linking to the term registry."""
+  """
+  Unique identifier linking to the term registry.
+  """
   term_id: String
-  """Transaction hash of the triple creation event."""
+  """
+  Transaction hash of the triple creation event.
+  """
   transaction_hash: String
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type triples_sum_fields {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: numeric
 }
 
@@ -19409,13 +28689,19 @@ type triples_sum_fields {
 order by sum() on columns of table "triple"
 """
 input triples_sum_order_by {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type triples_var_pop_fields {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: Float
 }
 
@@ -19423,13 +28709,19 @@ type triples_var_pop_fields {
 order by var_pop() on columns of table "triple"
 """
 input triples_var_pop_order_by {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type triples_var_samp_fields {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: Float
 }
 
@@ -19437,13 +28729,19 @@ type triples_var_samp_fields {
 order by var_samp() on columns of table "triple"
 """
 input triples_var_samp_order_by {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type triples_variance_fields {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: Float
 }
 
@@ -19451,7 +28749,9 @@ type triples_variance_fields {
 order by variance() on columns of table "triple"
 """
 input triples_variance_order_by {
-  """Block number when this triple was created."""
+  """
+  Block number when this triple was created.
+  """
   block_number: order_by
 }
 
@@ -19476,213 +28776,407 @@ input vault_type_comparison_exp {
 Bonding curve vaults that hold assets backing atoms or triples, tracking shares and market capitalization.
 """
 type vaults {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: bigint!
-  """Timestamp when this vault was created."""
+  """
+  Timestamp when this vault was created.
+  """
   created_at: timestamptz!
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: numeric!
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: numeric!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   deposits(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): [deposits!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   deposits_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [deposits_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [deposits_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: deposits_bool_exp
   ): deposits_aggregate!
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: bigint!
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: numeric!
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Int!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   positions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): [positions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   positions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [positions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [positions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: positions_bool_exp
   ): positions_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   redemptions(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): [redemptions!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   redemptions_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [redemptions_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [redemptions_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: redemptions_bool_exp
   ): redemptions_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_daily(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_daily_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_daily_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_daily_bool_exp
   ): [share_price_change_stats_daily!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_hourly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_hourly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_hourly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_hourly_bool_exp
   ): [share_price_change_stats_hourly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_monthly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_monthly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_monthly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_monthly_bool_exp
   ): [share_price_change_stats_monthly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_change_stats_weekly(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_change_stats_weekly_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_change_stats_weekly_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_change_stats_weekly_bool_exp
   ): [share_price_change_stats_weekly!]!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   share_price_changes(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_changes_bool_exp
   ): [share_price_changes!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   share_price_changes_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [share_price_changes_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [share_price_changes_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: share_price_changes_bool_exp
   ): share_price_changes_aggregate!
-  """An array relationship"""
+  """
+  An array relationship
+  """
   signals(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): [signals!]!
-  """An aggregate relationship"""
+  """
+  An aggregate relationship
+  """
   signals_aggregate(
-    """distinct select on columns"""
+    """
+    distinct select on columns
+    """
     distinct_on: [signals_select_column!]
-    """limit the number of rows returned"""
+    """
+    limit the number of rows returned
+    """
     limit: Int
-    """skip the first n rows. Use only with order_by"""
+    """
+    skip the first n rows. Use only with order_by
+    """
     offset: Int
-    """sort the rows by one or more columns"""
+    """
+    sort the rows by one or more columns
+    """
     order_by: [signals_order_by!]
-    """filter the rows returned"""
+    """
+    filter the rows returned
+    """
     where: signals_bool_exp
   ): signals_aggregate!
-  """An object relationship"""
+  """
+  An object relationship
+  """
   term: terms
-  """Term ID this vault backs (atom or triple)."""
+  """
+  Term ID this vault backs (atom or triple).
+  """
   term_id: String!
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: numeric!
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: numeric!
-  """Transaction hash of the most recent vault state update."""
+  """
+  Transaction hash of the most recent vault state update.
+  """
   transaction_hash: String!
-  """Timestamp of last update to this vault."""
+  """
+  Timestamp of last update to this vault.
+  """
   updated_at: timestamptz!
 }
 
@@ -19739,23 +29233,41 @@ input vaults_aggregate_order_by {
   variance: vaults_variance_order_by
 }
 
-"""aggregate avg on columns"""
+"""
+aggregate avg on columns
+"""
 type vaults_avg_fields {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: Float
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: Float
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: Float
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: Float
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: Float
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Float
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: Float
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: Float
 }
 
@@ -19763,21 +29275,37 @@ type vaults_avg_fields {
 order by avg() on columns of table "vault"
 """
 input vaults_avg_order_by {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: order_by
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: order_by
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: order_by
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: order_by
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: order_by
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: order_by
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: order_by
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: order_by
 }
 
@@ -19817,31 +29345,57 @@ input vaults_bool_exp {
   updated_at: timestamptz_comparison_exp
 }
 
-"""aggregate max on columns"""
+"""
+aggregate max on columns
+"""
 type vaults_max_fields {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: bigint
-  """Timestamp when this vault was created."""
+  """
+  Timestamp when this vault was created.
+  """
   created_at: timestamptz
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: numeric
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: numeric
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: bigint
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: numeric
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Int
-  """Term ID this vault backs (atom or triple)."""
+  """
+  Term ID this vault backs (atom or triple).
+  """
   term_id: String
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: numeric
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: numeric
-  """Transaction hash of the most recent vault state update."""
+  """
+  Transaction hash of the most recent vault state update.
+  """
   transaction_hash: String
-  """Timestamp of last update to this vault."""
+  """
+  Timestamp of last update to this vault.
+  """
   updated_at: timestamptz
 }
 
@@ -19849,57 +29403,107 @@ type vaults_max_fields {
 order by max() on columns of table "vault"
 """
 input vaults_max_order_by {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: order_by
-  """Timestamp when this vault was created."""
+  """
+  Timestamp when this vault was created.
+  """
   created_at: order_by
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: order_by
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: order_by
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: order_by
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: order_by
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: order_by
-  """Term ID this vault backs (atom or triple)."""
+  """
+  Term ID this vault backs (atom or triple).
+  """
   term_id: order_by
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: order_by
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: order_by
-  """Transaction hash of the most recent vault state update."""
+  """
+  Transaction hash of the most recent vault state update.
+  """
   transaction_hash: order_by
-  """Timestamp of last update to this vault."""
+  """
+  Timestamp of last update to this vault.
+  """
   updated_at: order_by
 }
 
-"""aggregate min on columns"""
+"""
+aggregate min on columns
+"""
 type vaults_min_fields {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: bigint
-  """Timestamp when this vault was created."""
+  """
+  Timestamp when this vault was created.
+  """
   created_at: timestamptz
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: numeric
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: numeric
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: bigint
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: numeric
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Int
-  """Term ID this vault backs (atom or triple)."""
+  """
+  Term ID this vault backs (atom or triple).
+  """
   term_id: String
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: numeric
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: numeric
-  """Transaction hash of the most recent vault state update."""
+  """
+  Transaction hash of the most recent vault state update.
+  """
   transaction_hash: String
-  """Timestamp of last update to this vault."""
+  """
+  Timestamp of last update to this vault.
+  """
   updated_at: timestamptz
 }
 
@@ -19907,33 +29511,59 @@ type vaults_min_fields {
 order by min() on columns of table "vault"
 """
 input vaults_min_order_by {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: order_by
-  """Timestamp when this vault was created."""
+  """
+  Timestamp when this vault was created.
+  """
   created_at: order_by
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: order_by
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: order_by
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: order_by
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: order_by
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: order_by
-  """Term ID this vault backs (atom or triple)."""
+  """
+  Term ID this vault backs (atom or triple).
+  """
   term_id: order_by
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: order_by
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: order_by
-  """Transaction hash of the most recent vault state update."""
+  """
+  Transaction hash of the most recent vault state update.
+  """
   transaction_hash: order_by
-  """Timestamp of last update to this vault."""
+  """
+  Timestamp of last update to this vault.
+  """
   updated_at: order_by
 }
 
-"""Ordering options when selecting data from "vault"."""
+"""
+Ordering options when selecting data from "vault".
+"""
 input vaults_order_by {
   block_number: order_by
   created_at: order_by
@@ -19963,49 +29593,91 @@ input vaults_order_by {
 select columns of table "vault"
 """
 enum vaults_select_column {
-  """column name"""
+  """
+  column name
+  """
   block_number
-  """column name"""
+  """
+  column name
+  """
   created_at
-  """column name"""
+  """
+  column name
+  """
   current_share_price
-  """column name"""
+  """
+  column name
+  """
   curve_id
-  """column name"""
+  """
+  column name
+  """
   log_index
-  """column name"""
+  """
+  column name
+  """
   market_cap
-  """column name"""
+  """
+  column name
+  """
   position_count
-  """column name"""
+  """
+  column name
+  """
   term_id
-  """column name"""
+  """
+  column name
+  """
   total_assets
-  """column name"""
+  """
+  column name
+  """
   total_shares
-  """column name"""
+  """
+  column name
+  """
   transaction_hash
-  """column name"""
+  """
+  column name
+  """
   updated_at
 }
 
-"""aggregate stddev on columns"""
+"""
+aggregate stddev on columns
+"""
 type vaults_stddev_fields {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: Float
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: Float
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: Float
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: Float
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: Float
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Float
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: Float
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: Float
 }
 
@@ -20013,41 +29685,75 @@ type vaults_stddev_fields {
 order by stddev() on columns of table "vault"
 """
 input vaults_stddev_order_by {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: order_by
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: order_by
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: order_by
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: order_by
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: order_by
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: order_by
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: order_by
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: order_by
 }
 
-"""aggregate stddev_pop on columns"""
+"""
+aggregate stddev_pop on columns
+"""
 type vaults_stddev_pop_fields {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: Float
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: Float
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: Float
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: Float
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: Float
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Float
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: Float
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: Float
 }
 
@@ -20055,41 +29761,75 @@ type vaults_stddev_pop_fields {
 order by stddev_pop() on columns of table "vault"
 """
 input vaults_stddev_pop_order_by {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: order_by
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: order_by
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: order_by
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: order_by
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: order_by
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: order_by
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: order_by
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: order_by
 }
 
-"""aggregate stddev_samp on columns"""
+"""
+aggregate stddev_samp on columns
+"""
 type vaults_stddev_samp_fields {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: Float
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: Float
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: Float
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: Float
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: Float
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Float
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: Float
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: Float
 }
 
@@ -20097,21 +29837,37 @@ type vaults_stddev_samp_fields {
 order by stddev_samp() on columns of table "vault"
 """
 input vaults_stddev_samp_order_by {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: order_by
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: order_by
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: order_by
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: order_by
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: order_by
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: order_by
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: order_by
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: order_by
 }
 
@@ -20119,57 +29875,105 @@ input vaults_stddev_samp_order_by {
 Streaming cursor of the table "vaults"
 """
 input vaults_stream_cursor_input {
-  """Stream column input with initial value"""
+  """
+  Stream column input with initial value
+  """
   initial_value: vaults_stream_cursor_value_input!
-  """cursor ordering"""
+  """
+  cursor ordering
+  """
   ordering: cursor_ordering
 }
 
-"""Initial value of the column from where the streaming should start"""
+"""
+Initial value of the column from where the streaming should start
+"""
 input vaults_stream_cursor_value_input {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: bigint
-  """Timestamp when this vault was created."""
+  """
+  Timestamp when this vault was created.
+  """
   created_at: timestamptz
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: numeric
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: numeric
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: bigint
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: numeric
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Int
-  """Term ID this vault backs (atom or triple)."""
+  """
+  Term ID this vault backs (atom or triple).
+  """
   term_id: String
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: numeric
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: numeric
-  """Transaction hash of the most recent vault state update."""
+  """
+  Transaction hash of the most recent vault state update.
+  """
   transaction_hash: String
-  """Timestamp of last update to this vault."""
+  """
+  Timestamp of last update to this vault.
+  """
   updated_at: timestamptz
 }
 
-"""aggregate sum on columns"""
+"""
+aggregate sum on columns
+"""
 type vaults_sum_fields {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: bigint
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: numeric
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: numeric
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: bigint
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: numeric
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Int
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: numeric
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: numeric
 }
 
@@ -20177,41 +29981,75 @@ type vaults_sum_fields {
 order by sum() on columns of table "vault"
 """
 input vaults_sum_order_by {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: order_by
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: order_by
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: order_by
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: order_by
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: order_by
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: order_by
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: order_by
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: order_by
 }
 
-"""aggregate var_pop on columns"""
+"""
+aggregate var_pop on columns
+"""
 type vaults_var_pop_fields {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: Float
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: Float
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: Float
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: Float
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: Float
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Float
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: Float
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: Float
 }
 
@@ -20219,41 +30057,75 @@ type vaults_var_pop_fields {
 order by var_pop() on columns of table "vault"
 """
 input vaults_var_pop_order_by {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: order_by
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: order_by
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: order_by
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: order_by
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: order_by
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: order_by
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: order_by
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: order_by
 }
 
-"""aggregate var_samp on columns"""
+"""
+aggregate var_samp on columns
+"""
 type vaults_var_samp_fields {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: Float
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: Float
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: Float
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: Float
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: Float
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Float
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: Float
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: Float
 }
 
@@ -20261,41 +30133,75 @@ type vaults_var_samp_fields {
 order by var_samp() on columns of table "vault"
 """
 input vaults_var_samp_order_by {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: order_by
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: order_by
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: order_by
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: order_by
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: order_by
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: order_by
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: order_by
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: order_by
 }
 
-"""aggregate variance on columns"""
+"""
+aggregate variance on columns
+"""
 type vaults_variance_fields {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: Float
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: Float
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: Float
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: Float
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: Float
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: Float
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: Float
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: Float
 }
 
@@ -20303,20 +30209,36 @@ type vaults_variance_fields {
 order by variance() on columns of table "vault"
 """
 input vaults_variance_order_by {
-  """Block number of the most recent vault state update."""
+  """
+  Block number of the most recent vault state update.
+  """
   block_number: order_by
-  """Current price per share in wei."""
+  """
+  Current price per share in wei.
+  """
   current_share_price: order_by
-  """Bonding curve configuration ID determining pricing curve."""
+  """
+  Bonding curve configuration ID determining pricing curve.
+  """
   curve_id: order_by
-  """Log index of the most recent vault state update."""
+  """
+  Log index of the most recent vault state update.
+  """
   log_index: order_by
-  """Market capitalization (total_shares * current_share_price) in wei."""
+  """
+  Market capitalization (total_shares * current_share_price) in wei.
+  """
   market_cap: order_by
-  """Number of active positions in this vault."""
+  """
+  Number of active positions in this vault.
+  """
   position_count: order_by
-  """Total assets held in this vault in wei."""
+  """
+  Total assets held in this vault in wei.
+  """
   total_assets: order_by
-  """Total shares issued by this vault."""
+  """
+  Total shares issued by this vault.
+  """
   total_shares: order_by
 }


### PR DESCRIPTION
  Summary

  Reworks the post-mark experience: the cart opens the Amplify ticket directly (no intermediate drawer), Amplify and "Mark captured" are full-screen, all colors come from design-system tokens only, and the Mark page loads selectively so it no longer fully refreshes   when stats update.

  Cart → Amplify (no more drawer)

  - The slide-up cart list (.cart-drawer*) is removed. Opening the cart (FAB or sofia:open-cart) goes straight to the Amplify ticket — its basket (.b3-basket) already lists every item with per-row remove + weight selector, so the drawer was redundant.
  - Submit / close / reward-handoff / view-echoes logic preserved. CartFab / CartToast exports unchanged; the 11 other WeightModal consumers are untouched (single-cert, follow, trust, stake, quest claim, group detail…).

  Full-screen modals + scrolling

  - Amplify (.amp.b3) and "Mark captured" (.rc) take the full screen via :has() on the modal overlay/content (no frame/size caps).
  - Long baskets scroll inside Amplify (.b3-body) so Cancel/Confirm stay reachable; actions pinned to the bottom when content is short.
  - "Mark captured" list fills the full height and scrolls internally (.rc-marks flex:1 instead of max-height:240px) — many tx visible, ledger (Balance) sits right above "View my Echoes".
                                                                                                                                                                                                                                                                           Design-system colors only

  - Removed the invented --peach-1..4 scale and all color-mix() — peach → var(--ds-accent), white → var(--ds-ink), black → var(--ds-on-accent).
  - Surfaces use raw DS tokens only: outer var(--ds-bg-subtle), ticket var(--ds-card), borders var(--ds-border).
  - Topic pills now match the DS VerbTag size/font; topic color on text + border, transparent background (GroupDetailView, Amplify, Mark captured).
                                                                                                                                                                                                                                                                           Mark captured / Amplify polish

  - Trust/distrust marks resolve a verb from the predicate label so the VerbTag (Trusted/Distrusted) shows in Amplify + Mark captured.
  - Dropped ITEMS/DATE stub, perforation, predicate kicker, cart toast and the "Awarded for marking" line; single-line uniform "Mark captured." title.
  - b3-row-name → Geist (was unreadable Fraunces); checkmark black; tier pills bottom-aligned with verb/topic tags.
  - Badges: earned only, no "locked".

  Mark page (PageBlockchainCard)

  - Selective loading: header + "Actions on this page" render immediately (tab-derived); only the Stats panel shows a skeleton (PageStatsSkeleton) until ready.
  - Background refresh dims only the Stats panel — the whole card no longer greys out / freezes.

  Echoes

  - "Open on Explorer" → https://explorer.sofia.intuition.box/profil.
  - Manage + Open-on-Explorer wrapped in .echoes-actions so they stay side by side (row container size unchanged).

  Verification

  - bun run --filter extension build → 🟢 DONE + 2 localhost origins stripped (clean prod build) on every commit.

  Test plan

  - Cart FAB / Validate → Amplify opens directly, no drawer; remove items via row toggle; Cancel closes; Confirm → loader → "Mark captured"
  - Amplify with many items: list scrolls, Cancel/Confirm reachable
  - "Mark captured" full-screen: many tx visible + scrollable, Balance above "View my Echoes"
  - Trust mark shows "Trusted" verb in Amplify + Mark captured
  - Mark page: header/Actions instant, only Stats skeleton; stats refresh doesn't grey the whole card
  - Both themes look intentional (DS tokens only)
                                                                                                                                                                                                                                                                           Known residual (out of scope)

  On a transaction error, WeightModal still falls back to its legacy .modal-body surface — shared by the 11 other consumers, so left untouched here to avoid breaking those flows. Routing the cart error into the Amplify surface is a follow-up.

  ---
  Branche ext/weightmodal → dev, 2 commits (7fac7f5f, ce4ffef9), 11 fichiers (+767/−832). Le travail antérieur est déjà intégré à dev (merge-base = 97040130).