### PR TITLE
feat(landing): mobile-responsive deck + zero inline styles

### DIFF
--- a/apps/landing/src/App.module.css
+++ b/apps/landing/src/App.module.css
@@ -37,12 +37,12 @@
 .frame {
   flex: 1;
   position: relative;
-  margin: 24px;
+  margin: var(--frame-margin);
   border: 1px solid rgba(128, 128, 128, 0.55);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 24px 32px;
+  padding: var(--frame-padding-y) var(--frame-padding-x);
   min-width: 0;
   min-height: 0;
 }
@@ -117,7 +117,7 @@
   position: absolute;
   inset: 0;
   display: grid;
-  gap: 16px;
+  gap: var(--zone-gap);
   min-height: 0;
   min-width: 0;
   transition: opacity 220ms cubic-bezier(0.65, 0, 0.35, 1);
@@ -373,6 +373,77 @@
   --enter-delay: calc(440ms + var(--zone-i) * 80ms + var(--zone-extra-delay));
 }
 
+/* ── Per-zone CSS-variable bindings driven by data-attributes ──
+ *
+ * The PlaceholderSlide component picks a zone's grid position, cascade
+ * index, and entrance delay role via data-attributes. CSS resolves
+ * those to the numeric values the entrance choreography needs, so the
+ * JSX stays free of inline styles — everything declarative.
+ *
+ * `data-grid-area` maps a layout slot letter (a-f, h) to the CSS
+ * `grid-area` it should occupy. Layout shapes are defined by the
+ * `.layout_*` classes above.
+ */
+
+.zone[data-grid-area='a'] { grid-area: a; }
+.zone[data-grid-area='b'] { grid-area: b; }
+.zone[data-grid-area='c'] { grid-area: c; }
+.zone[data-grid-area='d'] { grid-area: d; }
+.zone[data-grid-area='e'] { grid-area: e; }
+.zone[data-grid-area='f'] { grid-area: f; }
+/* The `h` cell (header banner inside the grid) is rendered as
+   .gridBanner, not .zone — but kept here for completeness if the
+   shape ever changes. */
+.gridBanner[data-grid-area='h'] { grid-area: h; }
+
+/* `data-zone-i` resolves the cascade index used by --enter-delay.
+   LAYOUT_AREAS in PlaceholderSlide.tsx caps at 6 zones (left-quintet-
+   right + reveal), so we cover 0–5 explicitly. */
+.zone[data-zone-i='0'] { --zone-i: 0; }
+.zone[data-zone-i='1'] { --zone-i: 1; }
+.zone[data-zone-i='2'] { --zone-i: 2; }
+.zone[data-zone-i='3'] { --zone-i: 3; }
+.zone[data-zone-i='4'] { --zone-i: 4; }
+.zone[data-zone-i='5'] { --zone-i: 5; }
+
+/* `data-zone-role` flags the lead zone (no extra delay) vs cascade
+   zones (extra delay = the slide's --reveal-delay token). The slide
+   sets --reveal-delay on its root when revealDelay > 0; falls back
+   to 0ms when unset so non-cascading slides stay snappy. */
+.zone[data-zone-role='lead'] { --zone-extra-delay: 0ms; }
+.zone[data-zone-role='cascade'] {
+  --zone-extra-delay: var(--reveal-delay, 0ms);
+}
+
+/* `data-wipe-tint` picks the slab colour for the diagonal entrance
+   wipe. Each slide configures a single tint via its `wipeColor` prop;
+   the slide root inherits the matching --intent token down to the wipe
+   zone. When no tint is configured, the .peach/.dark fallbacks below
+   set sensible defaults (#02000e on peach, --color-accent on dark). */
+
+.placeholder[data-wipe-tint='fun'] .zone[data-anim='wipe'] {
+  --zone-wipe-color: var(--intent-fun);
+}
+.placeholder[data-wipe-tint='trusted'] .zone[data-anim='wipe'] {
+  --zone-wipe-color: var(--intent-trusted);
+}
+.placeholder[data-wipe-tint='learning'] .zone[data-anim='wipe'] {
+  --zone-wipe-color: var(--intent-learning);
+}
+.placeholder[data-wipe-tint='inspiration'] .zone[data-anim='wipe'] {
+  --zone-wipe-color: var(--intent-inspiration);
+}
+.placeholder[data-wipe-tint='work'] .zone[data-anim='wipe'] {
+  --zone-wipe-color: var(--intent-work);
+}
+
+/* `data-reveal-delay` on .placeholder propagates the cascade beat
+   (extra delay added to non-lead zones). Bounded set so we enumerate
+   the values used in slides.config.tsx. */
+.placeholder[data-reveal-delay='700'] {
+  --reveal-delay: 700ms;
+}
+
 /* slide-up (default for non-first zones) — hidden state. The fast
    default transition is what plays on EXIT (slide leaving): a quick
    200ms fade-out so the dots/cards don't linger across the bg wipe.
@@ -547,4 +618,159 @@
 
 .dark .revealCard {
   background: rgba(255, 255, 255, 0.04);
+}
+
+/* ── Mobile flow (<= 899px) ────────────────────────────────
+ *
+ * The deck stops behaving like a fixed-height stage and lets each
+ * slide grow to its content. All grid layouts collapse to a single
+ * column so zones stack vertically, the absolute-positioned reveal
+ * layer becomes a sibling block below the base zones (both visible),
+ * and zones get a sensible min-height so they don't visually collapse.
+ *
+ * Intra-slide entrance animations still play (wipe / slide-up /
+ * scale), gated by `data-active` flipped by IntersectionObserver in
+ * SceneStack.tsx as each .placeholder scrolls into view.
+ */
+
+@media (max-width: 899px) {
+  .placeholder {
+    height: auto;
+    min-height: 100vh;
+  }
+  /* Drop the frame chrome on mobile — the deck's signature outline +
+     margin reads as "card on a slab" on desktop, but on a portrait
+     viewport it competes with the content for breathing room AND
+     prevents per-layer backgrounds from going edge-to-edge. The
+     metaStrip sits inside the placeholder, painted by .placeholder's
+     own bg. Each .zones layer carries its own padding so it reads as
+     a full-bleed section. */
+  .frame {
+    margin: 0;
+    padding: 0;
+    border: none;
+    min-height: auto;
+    overflow: hidden;
+  }
+  .metaStrip {
+    padding: 14px var(--gutter);
+  }
+  /* The placeholder paints the BASE variant's bg via data-base-variant
+     (set by PlaceholderSlide.tsx). This colours the meta strip and any
+     gap before/after the .zones layers. Each .zones / .revealZones
+     layer then paints its OWN variant bg on top, allowing the same
+     slide to host two stacked colours (e.g. S.01 HERO peach → WHY
+     SOFIA dark) the way the desktop crossfade did. */
+  .placeholder[data-base-variant='peach'] {
+    background: var(--color-accent);
+    color: #02000e;
+  }
+  .placeholder[data-base-variant='dark'] {
+    background: var(--color-bg);
+    color: var(--color-text);
+  }
+  /* The content area no longer needs to be a positioned box — the
+     zones grid below flows naturally and pushes the frame height. */
+  .contentArea {
+    position: static;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+  /* Every layout collapses to a single column. We override grid-template
+     wholesale (areas removed, auto-flow row) so the .zone selectors
+     keep working but ignore the original 2/3-column shape. */
+  .zones {
+    position: static;
+    inset: auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--zone-gap);
+    padding: 36px var(--gutter);
+  }
+  /* Per-layer backgrounds — each .zones / .revealZones layer paints
+     its own colour edge-to-edge so two layers stacked vertically can
+     carry the same desktop palette split (e.g. HERO peach above WHY
+     SOFIA dark, with a clean horizontal seam between them). */
+  .zones.peach,
+  .revealZones.peach {
+    background: var(--color-accent);
+    color: #02000e;
+  }
+  .zones.dark,
+  .revealZones.dark {
+    background: var(--color-bg);
+    color: var(--color-text);
+  }
+  /* Each zone gets enough breathing room to host real content without
+     collapsing flat. min-height keeps the wipe slab visible on entry
+     and gives the cards room for typography clamps. */
+  .zone {
+    min-height: 50vh;
+  }
+  /* The custom-content zones (typography-heavy) sit on auto height so
+     they only consume what they need — a 50vh hero next to a 50vh
+     partner strip would be too long otherwise. */
+  .zone[data-custom='true'] {
+    min-height: auto;
+  }
+  /* .zoneContent uses absolute positioning on desktop so SVGs stretch
+     to fill the zone. On mobile we want it to flow with the rest, so
+     it switches to static and the zone grows to its content. */
+  .zoneContent {
+    position: static;
+    padding: 24px 0;
+  }
+  /* Wireframe zones (no custom content) keep a centred presentation. */
+  .zoneInner {
+    padding: 32px 0;
+  }
+  /* Base + reveal layers coexist vertically. The base no longer fades
+     when the reveal arrives — they're both fully visible, ordered
+     normally in the flow. */
+  .zones[data-hidden='true'] {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .revealZones {
+    opacity: 1;
+    transform: none;
+    pointer-events: auto;
+  }
+  .revealZones[data-revealed='false'] .zone .zoneInner,
+  .revealZones[data-revealed='false'] .zone .zoneContent {
+    opacity: 1;
+    transform: none;
+  }
+  .revealZones[data-revealed='false'] .zone[data-anim='wipe']::after {
+    transform: skewX(-30deg) translateX(160%);
+  }
+  /* In-grid banner cell — drops the grid-area anchor on mobile so the
+     banner just sits as a normal block at the top of the flow. */
+  .gridBanner {
+    grid-area: auto !important;
+    padding: 0;
+  }
+  /* Reveal zones that intentionally mirror a base zone (via
+     revealNumOverride pointing to a number < revealStart) would render
+     the same content twice in mobile flow mode, because base + reveal
+     coexist stacked instead of crossfading. Hide them — the base copy
+     remains visible. See PlaceholderSlide.tsx `mirrorsBase`. */
+  .zone[data-mirror-of-base='true'] {
+    display: none;
+  }
+}
+
+/* ── Smallest viewports (<= 640px) — final tightening. */
+@media (max-width: 640px) {
+  .zone {
+    min-height: 40vh;
+  }
+  .placeholder {
+    min-height: auto;
+  }
+  .frame {
+    min-height: auto;
+  }
 }

--- a/apps/landing/src/components/CirclesSequence.module.css
+++ b/apps/landing/src/components/CirclesSequence.module.css
@@ -1,0 +1,12 @@
+/**
+ * CirclesSequence — animated SVG. The component owns the geometry +
+ * animation loop; this module exposes the few reusable visual hooks
+ * that would otherwise need inline styles.
+ */
+
+/* Nucleus halo — additive blending so overlapping halos brighten
+ *  rather than just stacking opacity. Applied to the underlying disc
+ *  behind each hexagonal nucleus. */
+.haloLighten {
+  mix-blend-mode: lighten;
+}

--- a/apps/landing/src/components/CirclesSequence.tsx
+++ b/apps/landing/src/components/CirclesSequence.tsx
@@ -12,6 +12,7 @@
  * correctly on both slab variants.
  */
 import { useEffect, useState } from 'react'
+import styles from './CirclesSequence.module.css'
 
 interface CirclesSequenceProps {
   /** Palette to render in. Matches the deck slide variants. */
@@ -558,7 +559,7 @@ export function CirclesSequence({ variant = 'dark' }: CirclesSequenceProps) {
               r={nR + 6 * p.nScale}
               fill={nucleusColor}
               fillOpacity={(involved ? 0.55 : 0.4) * vis[i]}
-              style={{ mixBlendMode: 'lighten' }}
+              className={styles.haloLighten}
             />
             <path
               d={hex(p.x, p.y, nR, 0)}

--- a/apps/landing/src/components/HexSplit.module.css
+++ b/apps/landing/src/components/HexSplit.module.css
@@ -1,14 +1,23 @@
 /**
- * HexSplit — scroll-driven decoration. Two hexagons centered over the
- * section, that spread outward and rotate as the section is scrolled
- * past the viewport. Drives the visual energy of How / Comparison / CTA.
- *
- * Variables set inline by the React component:
- *   --hex-size  : edge length of each hex (default 420px)
- *   --hex-color : fill color (default rgba(0,0,0,.05))
- *   --hex-spread: lateral offset px (animated)
- *   --hex-rot   : extra rotation deg (animated)
+ * HexSplit — two hexagons that spread outward and rotate when the
+ * closest `[data-deck-slide]` ancestor becomes active. Pure CSS:
+ * @property declarations make --hex-spread / --hex-rot animatable, and
+ * a transition fires on the descendant selector below as soon as
+ * data-active flips. No JS animation loop — the deck owns the trigger
+ * via data-attributes.
  */
+
+@property --hex-spread {
+  syntax: '<length>';
+  initial-value: 0px;
+  inherits: false;
+}
+
+@property --hex-rot {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
 
 .host {
   position: absolute;
@@ -16,32 +25,61 @@
   pointer-events: none;
   overflow: hidden;
   z-index: 0;
+  --hex-size: 520px;
+  --hex-color: rgba(0, 0, 0, 0.05);
+  --hex-spread: 0px;
+  --hex-rot: 0deg;
 }
 
 .hex {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: var(--hex-size, 420px);
+  width: var(--hex-size);
   aspect-ratio: 1;
-  background: var(--hex-color, rgba(0, 0, 0, 0.05));
+  background: var(--hex-color);
   clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
   will-change: transform;
+  transition:
+    --hex-spread 1400ms cubic-bezier(0.215, 0.61, 0.355, 1) 700ms,
+    --hex-rot 1400ms cubic-bezier(0.215, 0.61, 0.355, 1) 700ms,
+    transform 1400ms cubic-bezier(0.215, 0.61, 0.355, 1) 700ms;
 }
 
 .l {
-  transform: translate(calc(-50% - var(--hex-spread, 0px)), -50%)
-    rotate(calc(-12deg - var(--hex-rot, 0deg)));
+  transform: translate(calc(-50% - var(--hex-spread)), -50%)
+    rotate(calc(-12deg - var(--hex-rot)));
 }
 
 .r {
-  transform: translate(calc(-50% + var(--hex-spread, 0px)), -50%)
-    rotate(calc(18deg + var(--hex-rot, 0deg)));
+  transform: translate(calc(-50% + var(--hex-spread)), -50%)
+    rotate(calc(18deg + var(--hex-rot)));
+}
+
+/* Animate when the owning deck slide is active. Targets the closest
+   `[data-deck-slide][data-active='true']` ancestor — fires whether the
+   trigger comes from the desktop snap or the mobile IntersectionObserver,
+   so the choreography stays consistent across modes. */
+[data-deck-slide][data-active='true'] .host {
+  --hex-spread: max(40vw, 480px);
+  --hex-rot: 60deg;
+}
+
+@media (max-width: 640px) {
+  .host {
+    --hex-size: 320px;
+  }
+  [data-deck-slide][data-active='true'] .host {
+    --hex-spread: 40vw;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .l,
-  .r {
-    transform: translate(-50%, -50%) rotate(0deg);
+  .hex {
+    transition: none;
+  }
+  [data-deck-slide][data-active='true'] .host {
+    --hex-spread: 0px;
+    --hex-rot: 0deg;
   }
 }

--- a/apps/landing/src/components/HexSplit.tsx
+++ b/apps/landing/src/components/HexSplit.tsx
@@ -1,74 +1,20 @@
-import { useEffect, useRef, type CSSProperties } from 'react'
 import styles from './HexSplit.module.css'
-
-interface HexSplitProps {
-  size?: string
-  color?: string
-}
 
 /**
  * HexSplit — two hexagons that spread outward and rotate when the
- * closest `[data-deck-slide]` ancestor becomes active. Waits the wipe
- * duration (~700ms), then animates --hex-spread from 0 → max and
- * --hex-rot from 0 → 60deg over ~1.4s with an easeOutCubic curve.
- * Resets when the slide leaves.
+ * closest `[data-deck-slide]` ancestor becomes active. Pure CSS — the
+ * `@property` declarations in HexSplit.module.css make --hex-spread
+ * and --hex-rot animatable, and a single descendant selector
+ * (`[data-deck-slide][data-active='true'] .host`) drives the
+ * transition. No JS observer, no runtime style mutations.
+ *
+ * Sizing and colour are CSS-module-owned. The S.09 CTA is the only
+ * caller — adjust the `.host` defaults in HexSplit.module.css if you
+ * need a different look.
  */
-export function HexSplit({ size, color }: HexSplitProps) {
-  const ref = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    const host = ref.current
-    const slide = host?.closest('[data-deck-slide]') as HTMLElement | null
-    if (!host || !slide) return
-    const DELAY = 700
-    const DURATION = 1400
-    let raf = 0
-    let timer: ReturnType<typeof setTimeout> | null = null
-    const max = Math.max(window.innerWidth * 0.4, 480)
-    const setVars = (p: number) => {
-      host.style.setProperty('--hex-spread', `${p * max}px`)
-      host.style.setProperty('--hex-rot', `${p * 60}deg`)
-    }
-    const animate = () => {
-      const start = performance.now()
-      const tick = () => {
-        const elapsed = performance.now() - start
-        const t = Math.min(1, elapsed / DURATION)
-        const p = 1 - Math.pow(1 - t, 3)
-        setVars(p)
-        if (t < 1) raf = requestAnimationFrame(tick)
-      }
-      raf = requestAnimationFrame(tick)
-    }
-    const begin = () => {
-      setVars(0)
-      timer = setTimeout(animate, DELAY)
-    }
-    const reset = () => {
-      cancelAnimationFrame(raf)
-      if (timer) clearTimeout(timer)
-      setVars(0)
-    }
-    let active = slide.dataset.active === 'true'
-    if (active) begin()
-    const mo = new MutationObserver(() => {
-      const next = slide.dataset.active === 'true'
-      if (next && !active) begin()
-      if (!next && active) reset()
-      active = next
-    })
-    mo.observe(slide, { attributes: true, attributeFilter: ['data-active'] })
-    return () => {
-      cancelAnimationFrame(raf)
-      if (timer) clearTimeout(timer)
-      mo.disconnect()
-    }
-  }, [])
-  const style: CSSProperties = {
-    ...(size ? ({ ['--hex-size' as never]: size } as CSSProperties) : {}),
-    ...(color ? ({ ['--hex-color' as never]: color } as CSSProperties) : {}),
-  }
+export function HexSplit() {
   return (
-    <div ref={ref} className={styles.host} style={style} aria-hidden="true">
+    <div className={styles.host} aria-hidden="true">
       <div className={`${styles.hex} ${styles.l}`} />
       <div className={`${styles.hex} ${styles.r}`} />
     </div>

--- a/apps/landing/src/components/IsoStack.module.css
+++ b/apps/landing/src/components/IsoStack.module.css
@@ -10,3 +10,10 @@
   max-width: 100%;
   max-height: 100%;
 }
+
+/* Per-plate group — opacity is driven by the React rAF reveal loop via
+   the `opacity` SVG attribute. The transition lives here so the
+   component stays free of inline styles. */
+.plate {
+  transition: opacity 0.2s linear;
+}

--- a/apps/landing/src/components/IsoStack.tsx
+++ b/apps/landing/src/components/IsoStack.tsx
@@ -251,7 +251,7 @@ export function IsoStack({
     const labelX = right[0] + 22
     const labelY = right[1] + 2
     return (
-      <g opacity={opacity} style={{ transition: 'opacity 0.2s linear' }}>
+      <g opacity={opacity} className={styles.plate}>
         <path
           d={path}
           fill={plateFill ?? color}

--- a/apps/landing/src/components/Navbar.module.css
+++ b/apps/landing/src/components/Navbar.module.css
@@ -239,9 +239,15 @@
   transform: translateY(-5px) rotate(-45deg);
 }
 
+/* Backdrop — sits behind the drawer and dims the rest of the page.
+   Clicking it closes the menu (handler in Navbar.tsx). Anchored to the
+   navbar height so the bar itself stays interactive above it. */
 .overlay {
   position: fixed;
-  inset: 56px 0 0;
+  top: var(--nav-h, 64px);
+  left: 0;
+  right: 0;
+  bottom: 0;
   background: rgba(0, 0, 0, 0.5);
   z-index: 90;
 }
@@ -255,16 +261,29 @@
   .nav {
     grid-template-columns: 1fr auto;
   }
+  /* Mobile drawer — anchored to the right edge of the screen, slides
+     in below the navbar. Width caps at 320px so it doesn't dominate
+     the viewport on large phones / small tablets, but takes 80% on
+     narrow phones (<= 400px) so tap targets stay comfortable. */
   .menu.menuOpen {
     display: flex;
     position: fixed;
-    inset: 56px 0 0;
+    top: var(--nav-h, 64px);
+    right: 0;
+    bottom: 0;
+    width: min(80vw, 320px);
     flex-direction: column;
     background: var(--color-bg);
+    border-left: 1px solid var(--color-border-soft);
     padding: 32px var(--gutter);
     z-index: 95;
     gap: 24px;
     align-items: flex-start;
+    box-shadow: -12px 0 32px rgba(0, 0, 0, 0.35);
+  }
+  .menu.menuOpen a {
+    font-size: 1rem;
+    color: var(--color-text);
   }
   .burger {
     display: inline-flex;

--- a/apps/landing/src/components/TopicsRadar.module.css
+++ b/apps/landing/src/components/TopicsRadar.module.css
@@ -1,0 +1,26 @@
+/**
+ * TopicsRadar — animated polar/radar field. The component owns the
+ * SVG + rAF animation loop; this module owns the layout chassis (host
+ * frame + ink palette) so the JSX stays free of inline styles.
+ */
+
+.host {
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  aspect-ratio: 1 / 1;
+  font-family: var(--font-mono);
+}
+
+.host[data-ink='light'] {
+  color: #f5e9d8;
+}
+
+.host[data-ink='dark'] {
+  color: #0a0a0a;
+}
+
+.svg {
+  width: 100%;
+  height: auto;
+}

--- a/apps/landing/src/components/TopicsRadar.tsx
+++ b/apps/landing/src/components/TopicsRadar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import styles from './TopicsRadar.module.css'
 
 /* TopicsRadar — animated polar/radar field. 11 axes (3 topics + 8
  * intentions). Concentric polygons breathe along each axis via
@@ -83,16 +84,7 @@ export function TopicsRadar({ ink = 'dark' }: TopicsRadarProps) {
   const fillBase = ink === 'light' ? '245,233,216' : '10,10,10'
 
   return (
-    <div
-      style={{
-        position: 'relative',
-        width: '100%',
-        maxWidth: 600,
-        aspectRatio: '1 / 1',
-        fontFamily: 'var(--font-mono)',
-        color: inkHex,
-      }}
-    >
+    <div className={styles.host} data-ink={ink}>
       {/* Single SVG canvas — no external border, no corner ticks, no
           header/footer bars. Chrome (FIG tag + sub label + progress bar)
           lives inline inside the SVG, matching the Fig V.06 chassis. */}
@@ -103,7 +95,7 @@ export function TopicsRadar({ ink = 'dark' }: TopicsRadarProps) {
            header (top) and progress bar (bottom). */
         viewBox="-25 -30 500 500"
         xmlns="http://www.w3.org/2000/svg"
-        style={{ width: '100%', height: 'auto' }}
+        className={styles.svg}
       >
         {/* Outer ring */}
         <circle

--- a/apps/landing/src/components/buttons/PrimaryBtn.module.css
+++ b/apps/landing/src/components/buttons/PrimaryBtn.module.css
@@ -1,0 +1,34 @@
+/**
+ * PrimaryBtn — solid filled CTA matching the Hero "Open Explorer" look.
+ * Deep-ink slab + peach text at rest; hard swap to white slab + deep-ink
+ * text on hover with a 1px lift.
+ */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 9999px;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  background: #02000e;
+  border: 1px solid #02000e;
+  color: var(--color-accent);
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    color 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease;
+}
+
+.btn:hover {
+  background: #ffffff;
+  border-color: #ffffff;
+  color: #02000e;
+  transform: translateY(-1px);
+}

--- a/apps/landing/src/components/buttons/PrimaryBtn.tsx
+++ b/apps/landing/src/components/buttons/PrimaryBtn.tsx
@@ -1,4 +1,5 @@
-import { useState, type CSSProperties, type ReactNode } from 'react'
+import type { ReactNode } from 'react'
+import styles from './PrimaryBtn.module.css'
 
 interface PrimaryBtnProps {
   href: string
@@ -8,43 +9,16 @@ interface PrimaryBtnProps {
 /**
  * PrimaryBtn — solid filled CTA matching the Hero "Open Explorer" look
  * (deep-ink slab + peach text) with a hard hover swap to white bg +
- * deep-ink text. Inline-styled with React hover state so the colours
- * are deterministic across slide variants and CSS cascade.
+ * deep-ink text. All styling lives in PrimaryBtn.module.css; hover is a
+ * pure :hover pseudo so no JS state.
  */
 export function PrimaryBtn({ href, children }: PrimaryBtnProps) {
-  const [hover, setHover] = useState(false)
-  const base: CSSProperties = {
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: 8,
-    padding: '10px 18px',
-    borderRadius: 999,
-    fontFamily: 'var(--font-mono)',
-    fontSize: '0.85rem',
-    fontWeight: 500,
-    letterSpacing: '0.04em',
-    textDecoration: 'none',
-    background: '#02000e',
-    border: '1px solid #02000e',
-    color: 'var(--color-accent)',
-    transition:
-      'background 160ms ease, color 160ms ease, border-color 160ms ease, transform 160ms ease',
-    cursor: 'pointer',
-  }
-  const hovered: CSSProperties = {
-    background: '#ffffff',
-    borderColor: '#ffffff',
-    color: '#02000e',
-    transform: 'translateY(-1px)',
-  }
   return (
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      style={{ ...base, ...(hover ? hovered : null) }}>
+      className={styles.btn}>
       {children}
     </a>
   )

--- a/apps/landing/src/components/buttons/SceneBtn.module.css
+++ b/apps/landing/src/components/buttons/SceneBtn.module.css
@@ -1,0 +1,96 @@
+/**
+ * SceneBtn — variant-aware outline pill, drop-in replacement for the
+ * global `.btn.btn-secondary` anchors used inside the deck.
+ *
+ * Variants composed via data-attributes so the markup stays declarative
+ * and no JS state is needed for hover.
+ */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 9999px;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    background 160ms ease,
+    color 160ms ease,
+    border-color 160ms ease,
+    transform 160ms ease;
+}
+
+/* ── Resting state — ink colour drives the border + text. ────── */
+
+.btn[data-ink='light'] {
+  color: #f5e9d8;
+  border-color: #f5e9d8;
+}
+.btn[data-ink='dark'] {
+  color: #02000e;
+  border-color: #02000e;
+}
+
+/* ── Resting fill — outline-only by default, optional white slab. */
+
+.btn[data-rest-fill='transparent'] {
+  background: transparent;
+}
+.btn[data-rest-fill='white'] {
+  background: #ffffff;
+}
+
+/* ── Hover state — fills the pill, lifts 1px. ──────────────── */
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+/* Explicit hover override — white pill, deep-ink text. */
+.btn[data-hover-fill='white']:hover {
+  background: #ffffff;
+  border-color: #ffffff;
+  color: #02000e;
+}
+
+/* Explicit hover override — peach pill, deep-ink text. */
+.btn[data-hover-fill='peach']:hover {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #02000e;
+}
+
+/* Default hover — derived from the slide variant when no explicit
+   hoverFill is set. peach slab → peach pill; dark slab → ink pill. */
+.btn[data-variant='peach']:not([data-hover-fill]):hover {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #02000e;
+}
+.btn[data-variant='dark']:not([data-hover-fill]):hover {
+  background: #02000e;
+  border-color: #02000e;
+  color: #f5e9d8;
+}
+
+/* ── Size modifier — used by zones that want a compact pill (zones
+ *  20 / 21 grant CTA row). Modifier picked via data-size to keep the
+ *  surface area of variants flat. */
+
+.btn[data-size='sm'] {
+  padding: 8px 14px;
+  font-size: 0.78rem;
+}
+
+/* Zone 20 — "About the team" CTA sits below the team list with a
+ *  small top gap to space it from the quote. */
+.btn[data-anchor='team-cta'] {
+  margin-top: 16px;
+  align-self: flex-start;
+}

--- a/apps/landing/src/components/buttons/SceneBtn.tsx
+++ b/apps/landing/src/components/buttons/SceneBtn.tsx
@@ -1,4 +1,5 @@
-import { useState, type CSSProperties, type ReactNode } from 'react'
+import type { ReactNode } from 'react'
+import styles from './SceneBtn.module.css'
 
 interface SceneBtnProps {
   href: string
@@ -22,14 +23,21 @@ interface SceneBtnProps {
    *  rest — useful on near-white slabs where the button still needs to
    *  read as a distinct surface against the slab. */
   restFill?: 'transparent' | 'white'
-  style?: CSSProperties
+  /** Size token. Default ``undefined`` → standard 10×16 padding. */
+  size?: 'sm'
+  /** Per-zone positioning hook. Looked up by CSS via `data-anchor` so
+   *  zones that need extra margin/alignment around the button (e.g.
+   *  the team CTA below the quote list) declare it as a CSS rule
+   *  rather than pushing inline styles through the component. */
+  anchor?: 'team-cta'
 }
 
 /**
  * SceneBtn — drop-in replacement for the global `.btn.btn-secondary`
  * anchors. Variant-aware hover (black on dark slabs, peach on peach
- * slabs). Inline styles driven by React state so the hover is
- * deterministic — no specificity fights, no class collisions.
+ * slabs). All styling lives in `SceneBtn.module.css` — variants and
+ * size modifiers are picked via data-attributes so the markup stays
+ * declarative and the component carries no inline styles.
  */
 export function SceneBtn({
   href,
@@ -38,65 +46,22 @@ export function SceneBtn({
   ink,
   hoverFill,
   restFill,
-  style,
+  size,
+  anchor,
 }: SceneBtnProps) {
-  const [hover, setHover] = useState(false)
   const resolvedInk = ink ?? (variant === 'peach' ? 'light' : 'dark')
-  const restingInk = resolvedInk === 'light' ? '#f5e9d8' : '#02000e'
-  const base: CSSProperties = {
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: 8,
-    padding: '10px 16px',
-    border: `1px solid ${restingInk}`,
-    borderRadius: 999,
-    fontFamily: 'var(--font-mono)',
-    fontSize: '0.85rem',
-    fontWeight: 500,
-    letterSpacing: '0.04em',
-    textDecoration: 'none',
-    color: restingInk,
-    background: restFill === 'white' ? '#ffffff' : 'transparent',
-    transition:
-      'background 160ms ease, color 160ms ease, border-color 160ms ease, transform 160ms ease',
-    cursor: 'pointer',
-  }
-  const hovered: CSSProperties =
-    hoverFill === 'white'
-      ? {
-          background: '#ffffff',
-          borderColor: '#ffffff',
-          color: '#02000e',
-          transform: 'translateY(-1px)',
-        }
-      : hoverFill === 'peach'
-        ? {
-            background: 'var(--color-accent)',
-            borderColor: 'var(--color-accent)',
-            color: '#02000e',
-            transform: 'translateY(-1px)',
-          }
-        : variant === 'peach'
-          ? {
-              background: 'var(--color-accent)',
-              borderColor: 'var(--color-accent)',
-              color: '#02000e',
-              transform: 'translateY(-1px)',
-            }
-          : {
-              background: '#02000e',
-              borderColor: '#02000e',
-              color: '#f5e9d8',
-              transform: 'translateY(-1px)',
-            }
   return (
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      style={{ ...base, ...(hover ? hovered : null), ...style }}>
+      className={styles.btn}
+      data-variant={variant}
+      data-ink={resolvedInk}
+      data-rest-fill={restFill ?? 'transparent'}
+      data-hover-fill={hoverFill}
+      data-size={size}
+      data-anchor={anchor}>
       {children}
     </a>
   )

--- a/apps/landing/src/components/cards/Card.module.css
+++ b/apps/landing/src/components/cards/Card.module.css
@@ -1,0 +1,153 @@
+/**
+ * Card.module.css — shared visual primitives for the deck's three card
+ * components (OpenCard, ProductCard, ValueCard). One set of tokens for
+ * the eyebrow / h3 clamp / lede so the four S.05 VISION cards and the
+ * two S.04 PRODUCT cards render at identical scale.
+ */
+
+/* ── Shared shell — full-cell flex column. ───────────────────── */
+
+.shell {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+.title {
+  margin: 10px 0 8px;
+  font-size: clamp(1.1rem, 0.9rem + 0.9vw, 1.9rem);
+  line-height: 1.1;
+}
+
+.desc {
+  margin: 0;
+  font-size: clamp(0.78rem, 0.7rem + 0.35vw, 1rem);
+}
+
+/* ── CTA row — sits under the lede. Variants for OpenCard
+ *  (margin-top 12) and ProductCard (margin-top 10). */
+
+.cta {
+  margin-top: 12px;
+}
+
+.ctaCompact {
+  margin-top: 10px;
+}
+
+/* ── ValueCard — extends .shell with eyebrow + TRUST figure +
+ *  bottom pill. Bigger TRUST figure on top, then h-section title, lede,
+ *  and either a staking button or "See on Intuition" pill. */
+
+.valueShell {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+  text-decoration: none;
+  color: inherit;
+}
+
+.valueShell[data-linkable='true'] {
+  cursor: pointer;
+}
+
+.valueTrustRow {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 2px;
+  line-height: 0.95;
+}
+
+.valueTrustFigure {
+  font-family: var(--font-mono);
+  font-size: clamp(1.8rem, 1.2rem + 2.2vw, 3rem);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.valueTrustUnit {
+  font-family: var(--font-mono);
+  font-size: clamp(0.7rem, 0.6rem + 0.25vw, 0.9rem);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  opacity: 0.7;
+}
+
+.valueTitle {
+  margin: 6px 0 4px;
+  font-size: clamp(1rem, 0.85rem + 0.7vw, 1.6rem);
+  line-height: 1.1;
+}
+
+.valueDesc {
+  margin: 0;
+  font-size: clamp(0.75rem, 0.68rem + 0.3vw, 0.95rem);
+  line-height: 1.4;
+}
+
+/* ── Pill — bottom CTA on ValueCard (vote or "See on Intuition").
+ *  Hover handled by CSS :hover. Two markups (button or span) share the
+ *  same .pill class. */
+
+.pill {
+  margin-top: 10px;
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid currentColor;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    color 160ms ease,
+    border-color 160ms ease;
+}
+
+.pill:hover {
+  background: #02000e;
+  border-color: #02000e;
+  color: #f5e9d8;
+}
+
+.pill:disabled {
+  cursor: progress;
+}
+
+/* `data-vote-state="signing"` flips the cursor while the staking tx is
+   in flight. Kept declarative so no inline style is needed. */
+.pill[data-vote-state='signing'] {
+  cursor: progress;
+}
+
+.valueErr {
+  margin: 0;
+  font-size: 11px;
+  color: #e87c7c;
+  font-family: var(--font-mono);
+}
+
+/* ── Mobile — slightly smaller pill / tighter margins. */
+
+@media (max-width: 640px) {
+  .title {
+    font-size: clamp(1rem, 5vw, 1.4rem);
+  }
+  .valueTrustFigure {
+    font-size: clamp(1.6rem, 7vw, 2.2rem);
+  }
+}

--- a/apps/landing/src/components/cards/OpenCard.tsx
+++ b/apps/landing/src/components/cards/OpenCard.tsx
@@ -1,6 +1,7 @@
 import { Arrow } from '../Arrow'
 import { PrimaryBtn } from '../buttons/PrimaryBtn'
 import { SceneBtn } from '../buttons/SceneBtn'
+import styles from './Card.module.css'
 
 interface OpenCardProps {
   tag: string
@@ -21,34 +22,12 @@ interface OpenCardProps {
  */
 export function OpenCard({ tag, title, desc, cta, ctaPrimary }: OpenCardProps) {
   return (
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        textAlign: 'left',
-      }}>
+    <div className={styles.shell}>
       <span className="eyebrow">{tag}</span>
-      <h3
-        className="h-section"
-        style={{
-          margin: '10px 0 8px',
-          fontSize: 'clamp(1.1rem, 0.9rem + 0.9vw, 1.9rem)',
-          lineHeight: 1.1,
-        }}>
-        {title}
-      </h3>
-      <p
-        className="lede"
-        style={{
-          margin: 0,
-          fontSize: 'clamp(0.78rem, 0.7rem + 0.35vw, 1rem)',
-        }}>
-        {desc}
-      </p>
+      <h3 className={`h-section ${styles.title}`}>{title}</h3>
+      <p className={`lede ${styles.desc}`}>{desc}</p>
       {cta && (
-        <div style={{ marginTop: 12 }}>
+        <div className={styles.cta}>
           {ctaPrimary ? (
             <PrimaryBtn href={cta.href}>
               {cta.label} <Arrow />
@@ -58,7 +37,7 @@ export function OpenCard({ tag, title, desc, cta, ctaPrimary }: OpenCardProps) {
               href={cta.href}
               variant="dark"
               hoverFill="white"
-              style={{ padding: '8px 14px', fontSize: '0.78rem' }}>
+              size="sm">
               {cta.label} <Arrow />
             </SceneBtn>
           )}

--- a/apps/landing/src/components/cards/ProductCard.tsx
+++ b/apps/landing/src/components/cards/ProductCard.tsx
@@ -1,5 +1,6 @@
 import { Arrow } from '../Arrow'
 import { SceneBtn } from '../buttons/SceneBtn'
+import styles from './Card.module.css'
 
 interface ProductCardProps {
   tag: string
@@ -16,38 +17,17 @@ interface ProductCardProps {
  */
 export function ProductCard({ tag, title, desc, cta }: ProductCardProps) {
   return (
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        textAlign: 'left',
-      }}>
+    <div className={styles.shell}>
       <span className="eyebrow">{tag}</span>
-      <h3
-        className="h-section"
-        style={{
-          margin: '10px 0 8px',
-          fontSize: 'clamp(1.1rem, 0.9rem + 0.9vw, 1.9rem)',
-        }}>
-        {title}
-      </h3>
-      <p
-        className="lede"
-        style={{
-          margin: 0,
-          fontSize: 'clamp(0.78rem, 0.7rem + 0.35vw, 1rem)',
-        }}>
-        {desc}
-      </p>
-      <div style={{ marginTop: 10 }}>
+      <h3 className={`h-section ${styles.title}`}>{title}</h3>
+      <p className={`lede ${styles.desc}`}>{desc}</p>
+      <div className={styles.ctaCompact}>
         <SceneBtn
           href={cta.href}
           variant="dark"
           ink="light"
           hoverFill="peach"
-          style={{ padding: '8px 14px', fontSize: '0.78rem' }}>
+          size="sm">
           {cta.label} <Arrow />
         </SceneBtn>
       </div>

--- a/apps/landing/src/components/cards/ValueCard.tsx
+++ b/apps/landing/src/components/cards/ValueCard.tsx
@@ -1,6 +1,7 @@
-import { useState, type CSSProperties } from 'react'
+import { useState } from 'react'
 import { useVoteStats } from '../../hooks/useVoteStats'
 import { useVoting } from '../../hooks/useVoting'
+import styles from './Card.module.css'
 
 interface ValueCardProps {
   tag: string
@@ -14,39 +15,12 @@ interface ValueCardProps {
   tripleId?: `0x${string}`
 }
 
-const PILL_BASE: CSSProperties = {
-  marginTop: 10,
-  alignSelf: 'flex-start',
-  display: 'inline-flex',
-  alignItems: 'center',
-  gap: 6,
-  padding: '6px 12px',
-  border: '1px solid currentColor',
-  borderRadius: 999,
-  fontSize: 11,
-  fontWeight: 500,
-  letterSpacing: '0.08em',
-  textTransform: 'uppercase',
-  fontFamily: 'var(--font-mono)',
-  background: 'transparent',
-  color: 'inherit',
-  transition:
-    'background 160ms ease, color 160ms ease, border-color 160ms ease',
-}
-
-const PILL_HOVER: CSSProperties = {
-  background: '#02000e',
-  borderColor: '#02000e',
-  color: '#f5e9d8',
-}
-
 /**
  * ValueCard — compact card used inside reveal-cell zones: eyebrow tag,
  * big mono TRUST figure (community conviction), then h-section title +
  * lede description. When `tripleId` is provided, switches to live mode
- * with on-chain vote stats and a real staking button. Pill hover is
- * driven by React state on the wrapper so we don't need a parent-class
- * cascade from App.module.css.
+ * with on-chain vote stats and a real staking button. All styling lives
+ * in Card.module.css; pill hover handled by CSS :hover so no JS state.
  */
 export function ValueCard({
   tag,
@@ -66,7 +40,6 @@ export function ValueCard({
   const { depositFor, isConnected } = useVoting()
   const [voting, setVoting] = useState(false)
   const [voteErr, setVoteErr] = useState<string | null>(null)
-  const [hovered, setHovered] = useState(false)
   const handleVote = async (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
@@ -82,77 +55,22 @@ export function ValueCard({
     }
   }
   const liveTrust = tripleId ? (isLoading ? '…' : forDisplay) : trust
-  const pillStyle: CSSProperties = {
-    ...PILL_BASE,
-    ...(hovered ? PILL_HOVER : null),
-  }
   return (
     <a
       href={href}
       target="_blank"
       rel="noreferrer noopener"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 6,
-        textAlign: 'left',
-        textDecoration: 'none',
-        color: 'inherit',
-        cursor: href ? 'pointer' : 'default',
-      }}>
+      className={styles.valueShell}
+      data-linkable={href ? 'true' : 'false'}>
       <span className="eyebrow">{tag}</span>
       {liveTrust && (
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'baseline',
-            gap: 8,
-            marginTop: 2,
-            lineHeight: 0.95,
-          }}>
-          <span
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 'clamp(1.8rem, 1.2rem + 2.2vw, 3rem)',
-              fontWeight: 600,
-              letterSpacing: '-0.02em',
-            }}>
-            {liveTrust}
-          </span>
-          <span
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 'clamp(0.7rem, 0.6rem + 0.25vw, 0.9rem)',
-              fontWeight: 500,
-              letterSpacing: '0.08em',
-              opacity: 0.7,
-            }}>
-            TRUST
-          </span>
+        <div className={styles.valueTrustRow}>
+          <span className={styles.valueTrustFigure}>{liveTrust}</span>
+          <span className={styles.valueTrustUnit}>TRUST</span>
         </div>
       )}
-      <h3
-        className="h-section"
-        style={{
-          margin: '6px 0 4px',
-          fontSize: 'clamp(1rem, 0.85rem + 0.7vw, 1.6rem)',
-          lineHeight: 1.1,
-        }}>
-        {title}
-      </h3>
-      <p
-        className="lede"
-        style={{
-          margin: 0,
-          fontSize: 'clamp(0.75rem, 0.68rem + 0.3vw, 0.95rem)',
-          lineHeight: 1.4,
-        }}>
-        {desc}
-      </p>
+      <h3 className={`h-section ${styles.valueTitle}`}>{title}</h3>
+      <p className={`lede ${styles.valueDesc}`}>{desc}</p>
       {/* Bottom CTA — staking button takes precedence when a tripleId
        *  is wired; otherwise fall back to the "See on Intuition" pill.
        *  The button stops event propagation so clicking it doesn't also
@@ -162,26 +80,17 @@ export function ValueCard({
           type="button"
           onClick={handleVote}
           disabled={voting}
-          style={{ ...pillStyle, cursor: voting ? 'progress' : 'pointer' }}>
+          className={styles.pill}
+          data-vote-state={voting ? 'signing' : 'idle'}>
           {voting ? 'Signing…' : isConnected ? 'Support' : 'Connect to vote'}
           <span aria-hidden="true">↑</span>
         </button>
       ) : href ? (
-        <span style={pillStyle}>
+        <span className={styles.pill}>
           See on Intuition <span aria-hidden="true">↗</span>
         </span>
       ) : null}
-      {voteErr && (
-        <p
-          style={{
-            margin: 0,
-            fontSize: 11,
-            color: '#e87c7c',
-            fontFamily: 'var(--font-mono)',
-          }}>
-          {voteErr}
-        </p>
-      )}
+      {voteErr && <p className={styles.valueErr}>{voteErr}</p>}
     </a>
   )
 }

--- a/apps/landing/src/scenes/PlaceholderSlide.tsx
+++ b/apps/landing/src/scenes/PlaceholderSlide.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type ReactNode } from 'react'
+import { type ReactNode } from 'react'
 import { useSceneSubState } from './SceneStack'
 import { ZONE_LABELS, ZONE_NODES } from './zones'
 import styles from '../App.module.css'
@@ -18,6 +18,12 @@ export type SlideLayout =
   | 'quad'
   | 'quad-tall-right'
   | 'quad-banner-tall-right'
+
+/** Semantic wipe-tint names. Each maps to an `--intent-*` token in
+ *  variables.css. Slides pick one to colour their diagonal entrance
+ *  slab — kept as a constrained set so the deck stays palette-coherent
+ *  and the CSS module can resolve it without runtime values. */
+export type WipeTint = 'fun' | 'trusted' | 'learning' | 'inspiration' | 'work'
 
 export interface PlaceholderSlideProps {
   code: string
@@ -51,8 +57,9 @@ export interface PlaceholderSlideProps {
    *  (no wipe on reveals — they all use scale-fade). */
   revealWipeIndex?: number
   /** Extra delay (ms) added to every non-wipe base zone. Lets the
-   *  wipe zone land first, then the rest cascade in after a beat. */
-  revealDelay?: number
+   *  wipe zone land first, then the rest cascade in after a beat.
+   *  Bounded to the values handled by CSS (currently 0 and 700). */
+  revealDelay?: 0 | 700
   /** Per-revealIdx number override. Use to make a reveal zone display
    *  the same number/label as a base zone (e.g. S.01 reveal idx 0
    *  mirrors base zone 3 so the swap reads as "3 slides left"). */
@@ -61,11 +68,9 @@ export interface PlaceholderSlideProps {
    *  grid. Lets a slide carry a paragraph of intro copy ABOVE its
    *  zone layout without consuming a zone number. */
   headerContent?: ReactNode
-  /** Hex colour applied to the section's diagonal wipe slab. When set,
-   *  it overrides the default peach/dark mapping via inline
-   *  `--zone-wipe-color` on the lead zone. Used to flag each slide
-   *  with a distinct intention colour. */
-  wipeColor?: string
+  /** Wipe slab tint. Semantic enum mapped to an `--intent-*` token in
+   *  variables.css so the deck colour palette stays a closed set. */
+  wipeColor?: WipeTint
 }
 
 export const LAYOUT_AREAS: Record<SlideLayout, string[]> = {
@@ -144,13 +149,19 @@ export function PlaceholderSlide({
      own per-layer variant class on `.zones` so they stay stable. */
   const activeVariant = revealed && revealVariant ? revealVariant : variant
   const revealStart = zoneStart + baseAreas.length
+  /* Lead zone (no extra delay) = the wipe zone if there is one;
+     otherwise idx 0. The other zones cascade in after `revealDelay`. */
+  const baseLeadIdx = wipeIndex >= 0 ? wipeIndex : 0
+  const revealLeadIdx = revealWipeIndex >= 0 ? revealWipeIndex : 0
   return (
     <section
       className={`${styles.placeholder} ${styles[activeVariant]}`}
       data-active={isActive ? 'true' : 'false'}
       data-deck-slide="true"
       data-variant={activeVariant}
-    >
+      data-base-variant={variant}
+      data-wipe-tint={wipeColor}
+      data-reveal-delay={revealDelay > 0 ? String(revealDelay) : undefined}>
       <div className={styles.frame}>
         <div className={styles.metaStrip}>
           <span>
@@ -164,8 +175,7 @@ export function PlaceholderSlide({
             in this slot, above the grid. */}
         {headerContent && layout !== 'quad-banner-tall-right' && (
           <div
-            className={`${styles.header} ${variant === 'peach' ? 'on-peach' : ''}`}
-          >
+            className={`${styles.header} ${variant === 'peach' ? 'on-peach' : ''}`}>
             {headerContent}
           </div>
         )}
@@ -173,13 +183,12 @@ export function PlaceholderSlide({
         <div className={styles.contentArea}>
           <div
             className={`${styles.zones} ${styles[layoutClass(layout)]} ${styles[variant]} ${variant === 'peach' ? 'on-peach' : ''}`}
-            data-hidden={revealed ? 'true' : 'false'}
-          >
+            data-hidden={revealed ? 'true' : 'false'}>
             {/* In-grid banner: layouts that declare an `h` grid area
                 host headerContent as a normal grid cell so the tall
                 right column ('e') keeps its full-slide span. */}
             {headerContent && layout === 'quad-banner-tall-right' && (
-              <div className={styles.gridBanner} style={{ gridArea: 'h' }}>
+              <div className={styles.gridBanner} data-grid-area="h">
                 {headerContent}
               </div>
             )}
@@ -190,35 +199,21 @@ export function PlaceholderSlide({
                  + fade. wipeIndex = -1 disables the wipe entirely on
                  this slide. */
               const anim = idx === wipeIndex ? 'wipe' : 'slide-up'
-              /* Lead zone (no extra delay) = the wipe zone if there is
-                 one; otherwise the first zone. The other zones cascade
-                 in after `revealDelay`. */
-              const leadIdx = wipeIndex >= 0 ? wipeIndex : 0
-              const extraDelay = idx === leadIdx ? 0 : revealDelay
+              const role = idx === baseLeadIdx ? 'lead' : 'cascade'
               /* Use the BASE variant (not activeVariant) — base zones
                  fade out as a layer, they shouldn't flip palette mid
                  fade-out otherwise the catch phrase + partner logos
                  turn the wrong colour for a beat. */
               const customNode = ZONE_NODES[n]?.(variant)
-              /* Apply the per-slide wipe colour only on the actual
-                 wipe zone — the inline CSS var beats the default
-                 peach/dark mapping in the cascade. */
-              const zoneStyle: CSSProperties = {
-                gridArea: area,
-                ['--zone-i' as never]: idx,
-                ['--zone-extra-delay' as never]: `${extraDelay}ms`,
-              }
-              if (anim === 'wipe' && wipeColor) {
-                zoneStyle['--zone-wipe-color' as never] = wipeColor as never
-              }
               return (
                 <div
                   key={n}
                   className={styles.zone}
                   data-anim={anim}
                   data-custom={customNode ? 'true' : 'false'}
-                  style={zoneStyle}
-                >
+                  data-grid-area={area}
+                  data-zone-i={idx}
+                  data-zone-role={role}>
                   {customNode ? (
                     <div className={styles.zoneContent}>{customNode}</div>
                   ) : (
@@ -237,11 +232,19 @@ export function PlaceholderSlide({
           {revealLayout && (
             <div
               className={`${styles.zones} ${styles[layoutClass(revealLayout)]} ${styles.revealZones} ${styles[revealVariant ?? variant]} ${(revealVariant ?? variant) === 'peach' ? 'on-peach' : ''}`}
-              data-revealed={revealed ? 'true' : 'false'}
-            >
+              data-revealed={revealed ? 'true' : 'false'}>
               {revealAreas.map((area, idx) => {
                 const n = revealStart + idx
                 const displayN = revealNumOverride?.[idx] ?? n
+                /* When a reveal slot mirrors a base zone (via
+                   revealNumOverride pointing to a number < revealStart),
+                   it intentionally re-renders the same content in a
+                   different grid position so the desktop crossfade
+                   reads as a graphic sliding from right to left. On
+                   mobile, base + reveal coexist stacked — so a mirror
+                   would appear twice. Tag it with data-mirror-of-base
+                   so CSS can hide the duplicate at <=899px. */
+                const mirrorsBase = displayN < revealStart
                 /* Reveal zones get their dedicated variant (e.g. dark
                    on the WHY SOFIA reveal of S.01) — stable across the
                    crossfade, no palette flip mid-transition. */
@@ -255,26 +258,18 @@ export function PlaceholderSlide({
                    otherwise the default 'scale' fade. */
                 const isRevealWipe =
                   revealWipeIndex >= 0 && idx === revealWipeIndex
-                const revealLeadIdx = revealWipeIndex >= 0 ? revealWipeIndex : 0
-                const extraDelay = idx === revealLeadIdx ? 0 : revealDelay
+                const role = idx === revealLeadIdx ? 'lead' : 'cascade'
                 const anim = isRevealWipe ? 'wipe' : 'scale'
-                const revealZoneStyle: CSSProperties = {
-                  gridArea: area,
-                  ['--zone-i' as never]: idx,
-                  ['--zone-extra-delay' as never]: `${extraDelay}ms`,
-                }
-                if (anim === 'wipe' && wipeColor) {
-                  revealZoneStyle['--zone-wipe-color' as never] =
-                    wipeColor as never
-                }
                 return (
                   <div
                     key={n}
                     className={styles.zone}
                     data-anim={anim}
                     data-custom={customNode ? 'true' : 'false'}
-                    style={revealZoneStyle}
-                  >
+                    data-grid-area={area}
+                    data-zone-i={idx}
+                    data-zone-role={role}
+                    data-mirror-of-base={mirrorsBase ? 'true' : 'false'}>
                     {customNode ? (
                       <div className={styles.zoneContent}>{customNode}</div>
                     ) : (

--- a/apps/landing/src/scenes/SceneStack.module.css
+++ b/apps/landing/src/scenes/SceneStack.module.css
@@ -2,9 +2,9 @@
  * SceneStack — N-stage scroll-trigger pin + two-step trigger choreography.
  *
  * Layout:
- *   .region       Block in document flow, reserves `var(--stages)`×
- *                 100vh of vertical space. Each stage gets a 100vh
- *                 anchor marker so deep-links resolve natively.
+ *   .region       Block in document flow, reserves `--stages` × 100vh of
+ *                 vertical space. Each stage gets a 100vh anchor marker
+ *                 so deep-links resolve natively.
  *   .snapMarker   Invisible 100vh anchor — one per stage. The active
  *                 stage is derived from scroll progress by
  *                 ScrollTrigger; layout is painted by the sticky
@@ -21,18 +21,40 @@
  *   t = 0–step1    bgBlocks slide horizontally, angled border sweeps
  *   t = step1      bg has settled; content starts moving
  *   t = step1–total  slide content slides in vertically
+ *
+ * Per-slide/per-stage indices reach the CSS via data-attributes that
+ * map to CSS custom properties (`data-slide-i='2'` → `--slide-i: 2`).
+ * All transforms run in pure CSS — no inline styles on the JSX side.
  */
 
 .region {
   position: relative;
   width: 100%;
-  /* --stages + --stage-gap are injected inline by SceneStack.tsx.
-     Total scroll = (N - 1) gaps + one stage worth of sticky time at
-     the end so the last stage stays pinned for a beat before it lets
-     the page release into the footer. */
-  height: calc((var(--stages, 1) - 1) * var(--stage-gap, 100vh) + 100vh);
   overscroll-behavior: contain;
 }
+
+/* `data-stages` resolves to the region's total scroll height. We
+   enumerate up to 16 stages to cover the current deck (~10 stages
+   after subStates) with headroom; bump the upper bound when adding
+   slides. The formula matches the legacy `--stages` calc:
+     height = (stages - 1) × --stage-gap + 100vh
+   which gives one stage worth of sticky time at the end so the last
+   stage stays pinned before the page releases into the footer. */
+.region[data-stages='2'] { height: calc(1 * var(--stage-gap) + 100vh); }
+.region[data-stages='3'] { height: calc(2 * var(--stage-gap) + 100vh); }
+.region[data-stages='4'] { height: calc(3 * var(--stage-gap) + 100vh); }
+.region[data-stages='5'] { height: calc(4 * var(--stage-gap) + 100vh); }
+.region[data-stages='6'] { height: calc(5 * var(--stage-gap) + 100vh); }
+.region[data-stages='7'] { height: calc(6 * var(--stage-gap) + 100vh); }
+.region[data-stages='8'] { height: calc(7 * var(--stage-gap) + 100vh); }
+.region[data-stages='9'] { height: calc(8 * var(--stage-gap) + 100vh); }
+.region[data-stages='10'] { height: calc(9 * var(--stage-gap) + 100vh); }
+.region[data-stages='11'] { height: calc(10 * var(--stage-gap) + 100vh); }
+.region[data-stages='12'] { height: calc(11 * var(--stage-gap) + 100vh); }
+.region[data-stages='13'] { height: calc(12 * var(--stage-gap) + 100vh); }
+.region[data-stages='14'] { height: calc(13 * var(--stage-gap) + 100vh); }
+.region[data-stages='15'] { height: calc(14 * var(--stage-gap) + 100vh); }
+.region[data-stages='16'] { height: calc(15 * var(--stage-gap) + 100vh); }
 
 /* Anchor markers — absolutely positioned so they don't push the sticky
    `.stage` out of the flow. They only exist as deep-link targets; the
@@ -45,6 +67,25 @@
   pointer-events: none;
   scroll-margin-top: var(--nav-h, 64px);
 }
+
+/* Per-stage top offset — pre-computed to avoid inline `top: calc(...)`.
+   Bump the upper bound when adding stages. */
+.snapMarker[data-stage-i='0'] { top: 0; }
+.snapMarker[data-stage-i='1'] { top: calc(1 * var(--stage-gap)); }
+.snapMarker[data-stage-i='2'] { top: calc(2 * var(--stage-gap)); }
+.snapMarker[data-stage-i='3'] { top: calc(3 * var(--stage-gap)); }
+.snapMarker[data-stage-i='4'] { top: calc(4 * var(--stage-gap)); }
+.snapMarker[data-stage-i='5'] { top: calc(5 * var(--stage-gap)); }
+.snapMarker[data-stage-i='6'] { top: calc(6 * var(--stage-gap)); }
+.snapMarker[data-stage-i='7'] { top: calc(7 * var(--stage-gap)); }
+.snapMarker[data-stage-i='8'] { top: calc(8 * var(--stage-gap)); }
+.snapMarker[data-stage-i='9'] { top: calc(9 * var(--stage-gap)); }
+.snapMarker[data-stage-i='10'] { top: calc(10 * var(--stage-gap)); }
+.snapMarker[data-stage-i='11'] { top: calc(11 * var(--stage-gap)); }
+.snapMarker[data-stage-i='12'] { top: calc(12 * var(--stage-gap)); }
+.snapMarker[data-stage-i='13'] { top: calc(13 * var(--stage-gap)); }
+.snapMarker[data-stage-i='14'] { top: calc(14 * var(--stage-gap)); }
+.snapMarker[data-stage-i='15'] { top: calc(15 * var(--stage-gap)); }
 
 .stage {
   position: sticky;
@@ -60,14 +101,23 @@
   isolation: isolate;
 }
 
-/* ── Background slabs (step 1) ───────────────────────────── */
+/* `data-active-slide` exposes the currently active slide index to all
+   descendants as a CSS variable. Children that need to position
+   themselves relative to the active slide consume `--active-slide`. */
+.stage[data-active-slide='0'] { --active-slide: 0; }
+.stage[data-active-slide='1'] { --active-slide: 1; }
+.stage[data-active-slide='2'] { --active-slide: 2; }
+.stage[data-active-slide='3'] { --active-slide: 3; }
+.stage[data-active-slide='4'] { --active-slide: 4; }
+.stage[data-active-slide='5'] { --active-slide: 5; }
+.stage[data-active-slide='6'] { --active-slide: 6; }
+.stage[data-active-slide='7'] { --active-slide: 7; }
+.stage[data-active-slide='8'] { --active-slide: 8; }
+.stage[data-active-slide='9'] { --active-slide: 9; }
+.stage[data-active-slide='10'] { --active-slide: 10; }
+.stage[data-active-slide='11'] { --active-slide: 11; }
 
-.bgLayer {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
-}
+/* ── Background slabs (step 1) ───────────────────────────── */
 
 .bgLayer {
   position: absolute;
@@ -98,6 +148,40 @@
   right: calc(-1 * var(--hex-shift));
   transform-origin: top left;
   will-change: transform;
+  /* Default transform — drives the horizontal slab slide as the active
+     slide changes. The reveal variant overrides this with a discrete
+     on/off translate (see .bgBlockReveal below). */
+  transform: translate3d(
+      calc((var(--bg-i, 0) - var(--active-slide, 0)) * 100%),
+      0,
+      0
+    )
+    skewX(-30deg);
+  transition: transform var(--scene-step1-ms) var(--ease-in-out, cubic-bezier(0.65, 0, 0.35, 1));
+}
+
+/* Per-block index — enumerate up to 12 slides. */
+.bgBlock[data-bg-i='0'] { --bg-i: 0; }
+.bgBlock[data-bg-i='1'] { --bg-i: 1; }
+.bgBlock[data-bg-i='2'] { --bg-i: 2; }
+.bgBlock[data-bg-i='3'] { --bg-i: 3; }
+.bgBlock[data-bg-i='4'] { --bg-i: 4; }
+.bgBlock[data-bg-i='5'] { --bg-i: 5; }
+.bgBlock[data-bg-i='6'] { --bg-i: 6; }
+.bgBlock[data-bg-i='7'] { --bg-i: 7; }
+.bgBlock[data-bg-i='8'] { --bg-i: 8; }
+.bgBlock[data-bg-i='9'] { --bg-i: 9; }
+.bgBlock[data-bg-i='10'] { --bg-i: 10; }
+.bgBlock[data-bg-i='11'] { --bg-i: 11; }
+
+/* Reveal slabs — parked off-screen right at rest, slide to 0 when the
+   owning slide is active and its sub-state ≥ 1. The `data-showing`
+   attribute toggles the discrete state. */
+.bgBlockReveal[data-showing='false'] {
+  transform: translate3d(100%, 0, 0) skewX(-30deg);
+}
+.bgBlockReveal[data-showing='true'] {
+  transform: translate3d(0, 0, 0) skewX(-30deg);
 }
 
 .bgBlock[data-bg='peach'] {
@@ -116,7 +200,30 @@
   overflow: hidden;
   z-index: 1;
   will-change: transform;
+  /* Drives the vertical stack — each slide translates by its index
+     offset relative to the currently active slide. The `step1Ms`
+     delay lets the bg slabs land before the content slides over. */
+  transform: translate3d(
+    0,
+    calc((var(--slide-i, 0) - var(--active-slide, 0)) * 100%),
+    0
+  );
+  transition: transform var(--scene-step2-ms)
+    var(--ease-in-out, cubic-bezier(0.65, 0, 0.35, 1)) var(--scene-step1-ms);
 }
+
+.slide[data-slide-i='0'] { --slide-i: 0; }
+.slide[data-slide-i='1'] { --slide-i: 1; }
+.slide[data-slide-i='2'] { --slide-i: 2; }
+.slide[data-slide-i='3'] { --slide-i: 3; }
+.slide[data-slide-i='4'] { --slide-i: 4; }
+.slide[data-slide-i='5'] { --slide-i: 5; }
+.slide[data-slide-i='6'] { --slide-i: 6; }
+.slide[data-slide-i='7'] { --slide-i: 7; }
+.slide[data-slide-i='8'] { --slide-i: 8; }
+.slide[data-slide-i='9'] { --slide-i: 9; }
+.slide[data-slide-i='10'] { --slide-i: 10; }
+.slide[data-slide-i='11'] { --slide-i: 11; }
 
 .slide > * {
   width: 100%;
@@ -196,5 +303,58 @@
 @media (max-width: 720px) {
   .sharedPlate {
     display: none;
+  }
+}
+
+/* ── Mobile flow mode (<= 899px) ──────────────────────────
+ *
+ * The pinned scroll-snap deck is replaced by a vertical flow: each
+ * slide flows naturally at its own height, no sticky stage, no
+ * absolute-positioned slabs sliding between slides. The intra-slide
+ * entrance animations still play (driven by IntersectionObserver in
+ * SceneStack.tsx → data-active on .placeholder), but the inter-slide
+ * diagonal wipe is gone — that one was tied to the snap's
+ * instant-stage-change semantics and doesn't translate to a gradual
+ * scroll.
+ *
+ * Each .slide paints its own background via data-slide-bg.
+ */
+
+@media (max-width: 899px) {
+  .region {
+    height: auto !important;
+    overscroll-behavior: auto;
+  }
+  .snapMarker {
+    display: none;
+  }
+  .stage {
+    position: static;
+    height: auto;
+    overflow: visible;
+    background: transparent;
+    isolation: auto;
+  }
+  /* bgLayer isn't rendered on mobile (see SceneStack.tsx), but keep
+     a defensive display:none in case a future change reintroduces it. */
+  .bgLayer {
+    display: none;
+  }
+  .slide {
+    position: relative;
+    inset: auto;
+    padding-top: 0;
+    overflow: visible;
+    /* Drop the snap-driven transform on mobile — slides flow naturally
+       in the document. transition: none avoids any leftover animation
+       interfering with normal scrolling. transparent so the inner
+       .placeholder + .zones layers can paint their own per-layer bgs
+       (see App.module.css mobile rules). */
+    transform: none;
+    transition: none;
+    background: transparent;
+  }
+  .slide > * {
+    height: auto;
   }
 }

--- a/apps/landing/src/scenes/SceneStack.tsx
+++ b/apps/landing/src/scenes/SceneStack.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
   type ReactNode,
 } from 'react'
 import { ScrollTrigger } from '../lib/animation/gsap'
@@ -20,12 +19,13 @@ interface SceneStackProps {
   /** Optional reveal-state background per slide. When set on slide
    *  `i`, a second slab paints the reveal colour on top of the base
    *  slab as soon as that slide's sub-state goes ≥ 1 — same 60°
-   *  diagonal wipe as a slide-to-slide transition. */
+   *  diagonal wipe as a slide-to-slide transition.
+   *
+   *  Note: reveal backgrounds only apply in desktop snap mode. In
+   *  mobile flow mode there's no sub-state — base and reveal zones
+   *  stack vertically — so each slide paints a single bg via its
+   *  base variant. */
   revealBgs?: (SlideBg | undefined)[]
-  /** Duration (ms) of step 1: background slab + angled border wipe. */
-  step1Ms?: number
-  /** Duration (ms) of step 2: content slides over the new background. */
-  step2Ms?: number
   /** Per-slide sub-state count. `subStates[i] = n` means slide `i`
    *  has `n` reveal stages on top of its base layout. Children read
    *  their current sub-state via `useSceneSubState()`. */
@@ -44,10 +44,12 @@ export function useSceneSubState() {
   return useContext(SceneStackCtx)
 }
 
-const EASE = 'cubic-bezier(0.65, 0, 0.35, 1)'
+const MOBILE_BREAKPOINT = '(max-width: 899px)'
 
 /**
  * SceneStack — scroll-trigger slide stack with two-step transition.
+ *
+ * ── Desktop (>= 900px) — pinned scroll-snap deck.
  *
  * The deck reserves N × 100vh of vertical space, where N is the total
  * number of stages (sum of slides + sub-states). Each stage gets an
@@ -64,13 +66,29 @@ const EASE = 'cubic-bezier(0.65, 0, 0.35, 1)'
  * Lenis stays untouched — it drives smooth scroll globally, and
  * ScrollTrigger consumes its scroll events via the wiring in
  * `SmoothScroll.tsx`.
+ *
+ * ── Mobile (<= 899px) — vertical flow with per-slide entrance.
+ *
+ * The pin/snap mechanic doesn't translate to touch (kinetic scroll
+ * mismatches break the snap timing). On mobile we drop scroll-jacking
+ * entirely: each slide flows vertically at its natural height, base
+ * and reveal layers stack instead of crossfading (see App.module.css
+ * mobile overrides), and an IntersectionObserver flips `isActive` on
+ * each slide as it scrolls into view — so the intra-slide entrance
+ * animations (wipe / slide-up / scale) still play in sequence.
+ *
+ * ── Styling convention.
+ *
+ * Layout, transforms, transitions, and per-stage offsets are all
+ * driven by data-attributes resolved in `SceneStack.module.css`. No
+ * inline styles anywhere — index values map to CSS custom-property
+ * bindings (`data-slide-i='2'` → `--slide-i: 2`) and the transform
+ * math runs in pure CSS.
  */
 export function SceneStack({
   children,
   bgs,
   revealBgs,
-  step1Ms = 220,
-  step2Ms = 220,
   subStates = [],
   slideCodes = [],
 }: SceneStackProps) {
@@ -106,10 +124,34 @@ export function SceneStack({
   const [slideSubStates, setSlideSubStates] = useState<Record<number, number>>(
     {},
   )
+  /* Mobile mode — per-slide active flag, driven by IntersectionObserver.
+     Slides stay active once they've entered the viewport so leaving and
+     re-entering doesn't replay the entrance. */
+  const [activeMobileSlides, setActiveMobileSlides] = useState<Set<number>>(
+    () => new Set(),
+  )
+
+  /* Layout mode tracked in JS so the context can return the right
+     `isActive` for each slide and we can opt out of the desktop-only
+     transforms. SSR-safe: assume desktop until hydration. */
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.matchMedia(MOBILE_BREAKPOINT).matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const mq = window.matchMedia(MOBILE_BREAKPOINT)
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
 
   const regionRef = useRef<HTMLDivElement>(null)
 
+  /* Desktop — pinned snap deck. Only active in desktop mode. */
   useEffect(() => {
+    if (isMobile) return
     if (!regionRef.current || totalStages < 2) return
 
     let lastStageIdx = -1
@@ -150,89 +192,131 @@ export function SceneStack({
     return () => {
       st.kill()
     }
-  }, [stages, totalStages])
+  }, [isMobile, stages, totalStages])
+
+  /* Mobile — pre-reveal every sub-state so base + reveal zones can
+     coexist stacked (no crossfade), then observe each slide for the
+     entrance animation cue. */
+  useEffect(() => {
+    if (!isMobile || !regionRef.current) return
+
+    const allRevealed: Record<number, number> = {}
+    for (let i = 0; i < N; i++) {
+      allRevealed[i] = subStates[i] ?? 0
+    }
+    setSlideSubStates(allRevealed)
+
+    const slideEls =
+      regionRef.current.querySelectorAll<HTMLElement>('[data-slide-idx]')
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue
+          const idx = Number(entry.target.getAttribute('data-slide-idx'))
+          setActiveMobileSlides((prev) => {
+            if (prev.has(idx)) return prev
+            const next = new Set(prev)
+            next.add(idx)
+            return next
+          })
+        }
+      },
+      /* 15 % visible is enough to fire the entrance — feels responsive
+         without firing too early on long slides with content far down. */
+      { threshold: 0.15, rootMargin: '0px 0px -10% 0px' },
+    )
+    slideEls.forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [isMobile, N, subStates])
 
   return (
     <div
       ref={regionRef}
       className={styles.region}
-      style={
-        {
-          ['--stages' as string]: totalStages,
-          /* Per-stage scroll travel. Tweak here to make the snap feel
-             tighter or longer without touching CSS. */
-          ['--stage-gap' as string]: '60vh',
-        } as CSSProperties
-      }>
-      {/* Anchor markers — one zero-height anchor per stage, positioned
-          absolutely at the snap point so deep-links resolve natively.
-          They're out of flow so the sticky `.stage` stays at the top
-          of the region. */}
-      {stages.map((stage, i) => (
-        <div
-          key={stage.anchorId}
-          id={stage.anchorId}
-          className={styles.snapMarker}
-          style={{ top: `calc(${i} * var(--stage-gap))` }}
-          data-stage-slide={stage.slideIdx}
-          data-stage-sub={stage.sub}
-        />
-      ))}
-
-      <div className={styles.stage}>
-        {/* Background slabs — step 1. */}
-        <div className={styles.bgLayer}>
-          {slides.map((_, i) => (
-            <div
-              key={`base-${i}`}
-              className={styles.bgBlock}
-              data-bg={bgs?.[i] ?? 'peach'}
-              style={{
-                transform: `translate3d(${(i - slideIdx) * 100}%, 0, 0) skewX(-30deg)`,
-                transition: `transform ${step1Ms}ms ${EASE}`,
-              }}
-            />
-          ))}
-          {/* Reveal slabs — parked off-screen right; slide to 0 when
-              the owning slide is active and its sub-state ≥ 1. */}
-          {slides.map((_, i) => {
-            const revealBg = revealBgs?.[i]
-            if (!revealBg) return null
-            const sub = slideSubStates[i] ?? 0
-            const showing = i === slideIdx && sub >= 1
-            return (
-              <div
-                key={`reveal-${i}`}
-                className={styles.bgBlock}
-                data-bg={revealBg}
-                style={{
-                  transform: `translate3d(${showing ? 0 : 100}%, 0, 0) skewX(-30deg)`,
-                  transition: `transform ${step1Ms}ms ${EASE}`,
-                }}
-              />
-            )
-          })}
-        </div>
-
-        {/* Content slides — step 2, delayed by step1Ms. */}
-        {slides.map((child, i) => (
+      data-mode={isMobile ? 'mobile' : 'desktop'}
+      data-stages={totalStages}>
+      {/* Anchor markers — desktop deep-link targets. Hidden on mobile
+          where each slide is its own scrollable block (use slide id
+          instead if you need a deep-link there). */}
+      {!isMobile &&
+        stages.map((stage, i) => (
           <div
-            key={i}
-            className={styles.slide}
-            style={{
-              transform: `translate3d(0, ${(i - slideIdx) * 100}%, 0)`,
-              transition: `transform ${step2Ms}ms ${EASE} ${step1Ms}ms`,
-            }}>
-            <SceneStackCtx.Provider
-              value={{
-                slideIdx: i,
-                subState: slideSubStates[i] ?? 0,
-                isActive: i === slideIdx,
-              }}>
-              {child}
-            </SceneStackCtx.Provider>
-          </div>
+            key={stage.anchorId}
+            id={stage.anchorId}
+            className={styles.snapMarker}
+            data-stage-i={i}
+            data-stage-slide={stage.slideIdx}
+            data-stage-sub={stage.sub}
+          />
         ))}
+
+      <div className={styles.stage} data-active-slide={slideIdx}>
+        {/* Background slabs — desktop only. The horizontal slide of the
+            slabs is the visual signature of the snap deck; on mobile
+            each slide paints its own bg via .placeholder color rules
+            (see App.module.css). */}
+        {!isMobile && (
+          <div className={styles.bgLayer}>
+            {slides.map((_, i) => (
+              <div
+                key={`base-${i}`}
+                className={styles.bgBlock}
+                data-bg={bgs?.[i] ?? 'peach'}
+                data-bg-i={i}
+              />
+            ))}
+            {/* Reveal slabs — parked off-screen right; slide to 0 when
+                the owning slide is active and its sub-state ≥ 1. */}
+            {slides.map((_, i) => {
+              const revealBg = revealBgs?.[i]
+              if (!revealBg) return null
+              const sub = slideSubStates[i] ?? 0
+              const showing = i === slideIdx && sub >= 1
+              return (
+                <div
+                  key={`reveal-${i}`}
+                  className={`${styles.bgBlock} ${styles.bgBlockReveal}`}
+                  data-bg={revealBg}
+                  data-showing={showing ? 'true' : 'false'}
+                />
+              )
+            })}
+          </div>
+        )}
+
+        {/* Content slides — translated vertically by the active-slide
+            offset on desktop, statically stacked on mobile. The
+            translate math runs in CSS via the --slide-i / --active-slide
+            variables resolved from data-attributes.
+
+            `data-slide-bg` only paints in mobile mode (see
+            SceneStack.module.css mobile rules) and gets used by slides
+            without a reveal layer. Slides WITH a reveal split their
+            background per layer — each .zones paints its own colour
+            (see App.module.css mobile rules) so HERO can stay peach
+            while WHY SOFIA goes dark inside the same slide. */}
+        {slides.map((child, i) => {
+          const isActive = isMobile
+            ? activeMobileSlides.has(i)
+            : i === slideIdx
+          return (
+            <div
+              key={i}
+              className={styles.slide}
+              data-slide-idx={i}
+              data-slide-i={i}
+              data-slide-bg={bgs?.[i] ?? 'peach'}>
+              <SceneStackCtx.Provider
+                value={{
+                  slideIdx: i,
+                  subState: slideSubStates[i] ?? 0,
+                  isActive,
+                }}>
+                {child}
+              </SceneStackCtx.Provider>
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/apps/landing/src/scenes/slides.config.tsx
+++ b/apps/landing/src/scenes/slides.config.tsx
@@ -1,4 +1,5 @@
 import { LAYOUT_AREAS, type PlaceholderSlideProps } from './PlaceholderSlide'
+import zoneStyles from './zones.module.css'
 
 export type SlideConfig = Omit<PlaceholderSlideProps, 'variant' | 'zoneStart'>
 
@@ -29,14 +30,14 @@ export const SLIDES: SlideConfig[] = [
        right-tall). The diagonal slab balaie le graphic à l'entrée de
        slide, le catch phrase + partners cascadent en slide-up. */
     wipeIndex: 2,
-    wipeColor: '#e4b95a' /* fun · jaune */,
+    wipeColor: 'fun' /* jaune */,
   },
   {
     code: 'S.03',
     label: 'INSTRUMENT',
     meta: 'CAROUSEL',
     layout: 'single',
-    wipeColor: '#6dd4a0' /* trusted · vert */,
+    wipeColor: 'trusted' /* vert */,
   },
   /* S.04 — 11 (left tall) lands first with its diagonal wipe, then
      12/13/14 cascade in after a 700ms beat. */
@@ -46,7 +47,7 @@ export const SLIDES: SlideConfig[] = [
     meta: 'PREVIEW',
     layout: 'left-banner-pair-right',
     revealDelay: 700,
-    wipeColor: '#5cc4d6' /* learning · turquoise */,
+    wipeColor: 'learning' /* turquoise */,
   },
   /* S.05 — VISION. Quad of feature cards on the left/middle (15-18),
      Plate D vector graphic (IsoStack) on the right tall slot (19),
@@ -61,28 +62,14 @@ export const SLIDES: SlideConfig[] = [
     meta: 'FEATURES',
     layout: 'quad-banner-tall-right',
     wipeIndex: 4,
-    wipeColor: '#a78bdb' /* inspiration · violet */,
+    wipeColor: 'inspiration' /* violet */,
     headerContent: (
-      <div style={{ width: '100%', textAlign: 'left' }}>
-        <h2
-          className="h-section"
-          style={{
-            margin: '0 0 8px',
-            fontSize: 'clamp(1.4rem, 1rem + 1.4vw, 2rem)',
-            lineHeight: 1.15,
-          }}
-        >
+      <div className={zoneStyles.s05BannerRoot}>
+        <h2 className={`h-section ${zoneStyles.s05BannerTitle}`}>
           You are the hero of your own story.{' '}
           <em>Sofia ensures you finally own the pen.</em>
         </h2>
-        <p
-          className="lede"
-          style={{
-            margin: 0,
-            fontSize: 'clamp(0.82rem, 0.7rem + 0.4vw, 1rem)',
-            maxWidth: 'none',
-          }}
-        >
+        <p className={`lede ${zoneStyles.s05BannerLede}`}>
           Sofia turns every meaningful action you take online — what you read,
           certify, back — into a verifiable proof only you own. Identity becomes
           lived, not declared.
@@ -104,7 +91,7 @@ export const SLIDES: SlideConfig[] = [
     revealLabel: 'COMMUNITY',
     wipeIndex: 1,
     revealDelay: 700,
-    wipeColor: '#e4b95a' /* fun · jaune (cycle) */,
+    wipeColor: 'fun' /* jaune (cycle) */,
   },
   /* S.07 — 25 (left tall) lands first with its wipe, then the 2×2
      quad 26/27/28/29 cascade in after a beat. */
@@ -114,21 +101,21 @@ export const SLIDES: SlideConfig[] = [
     meta: '04 PRINCIPLES',
     layout: 'left-quad-right',
     revealDelay: 700,
-    wipeColor: '#7bade0' /* work · bleu (cycle) */,
+    wipeColor: 'work' /* bleu (cycle) */,
   },
   {
     code: 'S.08',
     label: 'LOOKUPS',
     meta: 'Q&A',
     layout: 'two-col-narrow-left',
-    wipeColor: '#6dd4a0' /* trusted · vert (cycle) */,
+    wipeColor: 'trusted' /* vert (cycle) */,
   },
   {
     code: 'S.09',
     label: 'CTA',
     meta: 'JOIN',
     layout: 'single',
-    wipeColor: '#5cc4d6' /* learning · turquoise (cycle) */,
+    wipeColor: 'learning' /* turquoise (cycle) */,
   },
 ]
 

--- a/apps/landing/src/scenes/zones.module.css
+++ b/apps/landing/src/scenes/zones.module.css
@@ -1,0 +1,722 @@
+/**
+ * zones.module.css — Per-zone classes for the deck's custom content.
+ *
+ * Most zones in `zones.tsx` carry their layout via inline styles. We
+ * extract the patterns that need to respond to viewport changes into
+ * this module so a single mobile media query can flip them all to a
+ * stacked single-column shape without touching the markup.
+ *
+ * Naming follows the zone number for clarity: `.zoneN_role`.
+ *
+ * The deck's `data-active` / `data-revealed` choreography is owned by
+ * App.module.css — this file only adjusts intra-zone composition.
+ */
+
+/* ── Zone 1 — hero (catch phrase + CTA stack) ─────────────────── */
+
+.heroRoot {
+  width: 100%;
+  height: 100%;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  /* space-between separates the h1 (top of cell) from the CTA row
+     (bottom of cell). Buttons get flex-shrink:0 so they stay rendered;
+     h1 gets flex-shrink:1 so it yields space on short viewports rather
+     than pushing the buttons out. */
+  justify-content: space-between;
+  gap: 24px;
+  min-height: 0;
+}
+
+.heroTitle {
+  font-size: clamp(3rem, 4vh + 6vw, 8.8rem);
+  line-height: 1.05;
+  padding-top: 0.08em;
+  padding-bottom: 0.05em;
+  margin: 0;
+  flex-shrink: 1;
+  min-height: 0;
+}
+
+.heroActions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .heroTitle {
+    font-size: clamp(2.4rem, 8vw, 3.6rem);
+  }
+  .heroActions {
+    width: 100%;
+  }
+  /* Buttons stretch to full width on the narrowest viewports so the
+     CTA stack reads as a clear vertical column instead of two small
+     pills floating against the slab. */
+  .heroActions > * {
+    flex: 1 1 100%;
+    justify-content: center;
+  }
+}
+
+/* ── Zone 2 — partner logos ──────────────────────────────────── */
+
+.partnersRoot {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 16px;
+}
+
+.partnersList {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.partnerLink {
+  opacity: 0.78;
+  display: inline-flex;
+}
+
+.partnerLogo {
+  height: 28px;
+  max-height: 28px;
+  width: auto;
+  display: block;
+}
+
+.partnerLogo[data-phala='true'] {
+  height: auto;
+  max-width: 90px;
+}
+
+/* On dark slabs, monochrome logos stay native. On peach, brightness(0)
+   flattens them to deep ink so they read at uniform weight. Phala keeps
+   its native palette because flattening would erase the inner "P". */
+.partnerLogo[data-flatten='true'] {
+  filter: brightness(0);
+}
+
+@media (max-width: 899px) {
+  .partnersRoot {
+    justify-content: flex-start;
+  }
+  .partnersList {
+    gap: 20px;
+  }
+}
+
+@media (max-width: 640px) {
+  .partnersList {
+    gap: 16px 24px;
+  }
+  .partnerLogo {
+    height: 22px;
+    max-height: 22px;
+  }
+  .partnerLogo[data-phala='true'] {
+    max-width: 72px;
+  }
+}
+
+/* ── Section heads (zones 5, 12) — eyebrow + h2 + lede ─────────── */
+
+.sectionHead {
+  width: 100%;
+  text-align: left;
+}
+
+.sectionHeadTitle {
+  margin: 0 0 14px;
+  font-size: clamp(1.8rem, 1.4rem + 3.4vw, 9.2rem);
+}
+
+.sectionHeadTitleTight {
+  margin: 6px 0 12px;
+  font-size: clamp(1.8rem, 1.4rem + 3.4vw, 9.2rem);
+  line-height: 1.02;
+}
+
+.sectionHeadLede {
+  max-width: 60ch;
+}
+
+.sectionHeadLedeWide {
+  margin: 0;
+  max-width: none;
+}
+
+@media (max-width: 640px) {
+  .sectionHeadTitle,
+  .sectionHeadTitleTight {
+    font-size: clamp(1.8rem, 7vw, 2.6rem);
+    line-height: 1.1;
+  }
+}
+
+/* ── Zone 10 — hero video ────────────────────────────────────── */
+
+.videoFrame {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 20px;
+  background: rgba(2, 0, 14, 0.3);
+}
+
+.videoFrame[data-variant='peach'] {
+  background: rgba(255, 198, 176, 0.3);
+}
+
+.videoFrame video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+@media (max-width: 899px) {
+  .videoFrame {
+    aspect-ratio: 16 / 10;
+    height: auto;
+  }
+}
+
+/* ── Zone 11 — TopicsRadar wrapper ───────────────────────────── */
+
+.radarFrame {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+@media (max-width: 899px) {
+  .radarFrame {
+    aspect-ratio: 1;
+    height: auto;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+/* ── Zone 20 — Core builders ─────────────────────────────────── */
+
+.teamRoot {
+  width: 100%;
+  height: 100%;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.teamTitle {
+  margin: 12px 0 18px;
+  font-size: clamp(1.6rem, 1.2rem + 2.4vw, 3.2rem);
+}
+
+.teamList {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.teamMember {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.teamHead {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.teamAvatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: block;
+}
+
+.teamIdentity {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.teamName {
+  font-size: clamp(1rem, 0.85rem + 0.5vw, 1.25rem);
+  font-weight: 500;
+}
+
+.teamHandle {
+  font-size: 11px;
+  margin-top: 4px;
+}
+
+.teamQuote {
+  margin: 0;
+  font-size: clamp(0.85rem, 0.75rem + 0.4vw, 1.05rem);
+  line-height: 1.5;
+}
+
+@media (max-width: 640px) {
+  .teamAvatar {
+    width: 44px;
+    height: 44px;
+  }
+  .teamTitle {
+    font-size: clamp(1.4rem, 6vw, 2rem);
+  }
+}
+
+/* ── Zone 21 — Backed by (grant copy) ────────────────────────── */
+
+.grantRoot {
+  width: 100%;
+  text-align: left;
+}
+
+.grantTitle {
+  margin: 12px 0 16px;
+  font-size: clamp(1.6rem, 1.2rem + 2.4vw, 3.2rem);
+}
+
+.grantPara {
+  margin: 0 0 12px;
+  font-size: clamp(0.85rem, 0.75rem + 0.4vw, 1.05rem);
+  max-width: none;
+}
+
+.grantParaLast {
+  margin: 0 0 18px;
+}
+
+.grantCtaRow {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 640px) {
+  .grantTitle {
+    font-size: clamp(1.4rem, 6vw, 2rem);
+  }
+  .grantCtaRow > * {
+    flex: 1 1 100%;
+    justify-content: center;
+  }
+}
+
+/* ── Zone 31 — Discord arrow (FAQ intro CTA) ─────────────────── */
+
+.faqDiscordArrow {
+  margin-left: 4px;
+}
+
+/* ── Zone 22 — Advisors strip ────────────────────────────────── */
+
+.advisorsRoot {
+  width: 100%;
+  height: 100%;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.advisorsList {
+  margin-top: 12px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.advisorCard {
+  flex: 1 1 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.advisorHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.advisorAvatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: block;
+}
+
+.advisorIdentity {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.advisorCompany {
+  font-size: 9px;
+  margin-bottom: 2px;
+}
+
+.advisorName {
+  font-size: 0.82rem;
+  font-weight: 500;
+}
+
+.advisorHandle {
+  font-size: 0.7rem;
+  opacity: 0.65;
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+
+/* ── Zones 23 / 24 — Community stats (figure + title + lede) ─── */
+
+.statRoot {
+  width: 100%;
+  text-align: left;
+}
+
+.statFigure {
+  margin-top: 12px;
+  font-family: var(--font-mono);
+  font-size: clamp(2.6rem, 1.6rem + 4vw, 6rem);
+  font-weight: 600;
+  line-height: 1;
+}
+
+.statTitle {
+  margin: 10px 0 8px;
+  font-size: clamp(1.1rem, 0.9rem + 0.7vw, 1.6rem);
+}
+
+.statLede {
+  margin: 0;
+  font-size: clamp(0.78rem, 0.7rem + 0.35vw, 1rem);
+}
+
+/* Zone 24 variant — uses absolute positioning on desktop to anchor in
+   the compact 1fr bottom-left cell. Mobile resets to static flow. */
+.statRootAbsolute {
+  position: absolute;
+  top: 2px;
+  left: 28px;
+  right: 28px;
+  bottom: 4px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 6px;
+}
+
+.statFigureTight {
+  font-family: var(--font-mono);
+  font-size: clamp(2rem, 1.2rem + 3vw, 4.4rem);
+  font-weight: 600;
+  line-height: 0.95;
+}
+
+.statTitleTight {
+  margin: 0;
+  font-size: clamp(1rem, 0.85rem + 0.6vw, 1.4rem);
+  line-height: 1.15;
+}
+
+.statLedeTight {
+  margin: 0;
+  font-size: clamp(0.75rem, 0.68rem + 0.25vw, 0.95rem);
+  line-height: 1.35;
+}
+
+@media (max-width: 899px) {
+  .statRootAbsolute {
+    position: static;
+    top: auto;
+    left: auto;
+    right: auto;
+    bottom: auto;
+  }
+}
+
+/* ── Zone 25 — Voices (testimonials list) ────────────────────── */
+
+.voicesRoot {
+  width: 100%;
+  text-align: left;
+}
+
+.voicesTitle {
+  margin: 12px 0 18px;
+  font-size: clamp(1.6rem, 1.2rem + 2vw, 2.8rem);
+}
+
+.voicesList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.voiceItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.25);
+}
+
+.voiceHead {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-family: var(--font-mono);
+}
+
+.voiceHandle {
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.voiceRole {
+  font-size: 9px;
+  opacity: 0.6;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.voiceQuote {
+  margin: 0;
+  font-size: clamp(0.78rem, 0.7rem + 0.35vw, 0.95rem);
+  line-height: 1.45;
+}
+
+/* ── Zone 26 — Values intro ──────────────────────────────────── */
+
+.valuesIntroTitle {
+  margin: 0 0 18px;
+  font-size: clamp(2rem, 1.4rem + 3vw, 4.4rem);
+  line-height: 0.95;
+}
+
+.valuesIntroPara {
+  margin: 0 0 12px;
+  font-size: clamp(0.9rem, 0.78rem + 0.45vw, 1.15rem);
+  max-width: none;
+}
+
+.valuesIntroParaLast {
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .valuesIntroTitle {
+    font-size: clamp(1.8rem, 7vw, 2.6rem);
+  }
+}
+
+/* ── Zone 31 — FAQ intro ─────────────────────────────────────── */
+
+.faqIntroTitle {
+  margin: 0 0 16px;
+  font-size: clamp(1.8rem, 1.3rem + 2.4vw, 3.6rem);
+  line-height: 0.95;
+}
+
+.faqIntroPara {
+  margin: 0 0 14px;
+  font-size: clamp(0.85rem, 0.74rem + 0.4vw, 1.05rem);
+  max-width: none;
+}
+
+.faqIntroCtaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* ── Zone 32 — FAQ list ──────────────────────────────────────── */
+
+.faqList {
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 28px;
+  row-gap: 18px;
+}
+
+.faqItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.35);
+}
+
+.faqQuestion {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: clamp(0.92rem, 0.8rem + 0.45vw, 1.2rem);
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.faqNum {
+  font-size: 10px;
+  opacity: 0.55;
+  letter-spacing: 0.14em;
+}
+
+.faqAnswer {
+  margin: 0;
+  font-size: clamp(0.82rem, 0.72rem + 0.35vw, 1rem);
+  line-height: 1.5;
+  opacity: 0.9;
+  max-width: 48ch;
+}
+
+.faqAnswer a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+@media (max-width: 899px) {
+  .faqList {
+    grid-template-columns: 1fr;
+    column-gap: 0;
+    row-gap: 14px;
+  }
+  .faqAnswer {
+    max-width: none;
+  }
+}
+
+/* ── Zone 33 — Closing CTA ───────────────────────────────────── */
+
+.ctaRoot {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.ctaInner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  max-width: 720px;
+  padding: 0 24px;
+}
+
+.ctaTitle {
+  margin: 0;
+  font-size: clamp(2.6rem, 2vh + 6vw, 7.2rem);
+  line-height: 1;
+}
+
+.ctaLede {
+  margin: 0;
+  font-size: clamp(0.95rem, 0.82rem + 0.45vw, 1.15rem);
+  max-width: 52ch;
+}
+
+.ctaActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 6px;
+}
+
+@media (max-width: 899px) {
+  .ctaRoot {
+    height: auto;
+    min-height: 60vh;
+    padding: 48px 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .ctaTitle {
+    font-size: clamp(2.2rem, 9vw, 3.6rem);
+  }
+  .ctaInner {
+    padding: 0 16px;
+  }
+  .ctaActions {
+    width: 100%;
+  }
+  .ctaActions > * {
+    flex: 1 1 100%;
+    justify-content: center;
+  }
+}
+
+/* ── Generic helpers used across multiple zones ──────────────── */
+
+.fullWidth {
+  width: 100%;
+  text-align: left;
+}
+
+/* ── S.05 in-grid banner — headerContent rendered inside the
+ *  layout's `h` cell. Title + lede stack with tight spacing so the
+ *  banner reads as a single block above the Vision cards quad. */
+
+.s05BannerRoot {
+  width: 100%;
+  text-align: left;
+}
+
+.s05BannerTitle {
+  margin: 0 0 8px;
+  font-size: clamp(1.4rem, 1rem + 1.4vw, 2rem);
+  line-height: 1.15;
+}
+
+.s05BannerLede {
+  margin: 0;
+  font-size: clamp(0.82rem, 0.7rem + 0.4vw, 1rem);
+  max-width: none;
+}
+
+@media (max-width: 640px) {
+  .s05BannerTitle {
+    font-size: clamp(1.3rem, 6vw, 1.8rem);
+  }
+}

--- a/apps/landing/src/scenes/zones.tsx
+++ b/apps/landing/src/scenes/zones.tsx
@@ -9,13 +9,20 @@ import { OpenCard } from '../components/cards/OpenCard'
 import { ProductCard } from '../components/cards/ProductCard'
 import { ValueCard } from '../components/cards/ValueCard'
 import { URLS } from '../lib/config/urls'
+import styles from './zones.module.css'
 
 /* Per-zone custom content. When a zone number has an entry here, the
    placeholder renders the node returned by this function instead of
    the default "<num> / <label>" skeleton text — used to inject real
    graphics or composed content into specific zones while leaving the
    rest of the deck as a wireframe. The function receives the active
-   slide variant so the node can pick palette tokens that match. */
+   slide variant so the node can pick palette tokens that match.
+
+   Per-zone layout lives in `zones.module.css` so the deck can react to
+   viewport changes via media queries. Variant-dependent values that
+   genuinely need JS (e.g. background colour from a runtime token)
+   stay inline; all static layout is class-driven. */
+
 /* Pulled verbatim from `Hero.tsx` so we keep a single source of
    truth on partner identities. */
 const PARTNERS = [
@@ -41,45 +48,11 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
   /* Zone 1 — the cover catch phrase. Headline + Hero's two CTAs
      (Open Explorer + Read the docs) pulled verbatim from `Hero.tsx`. */
   1: (variant) => (
-    <div
-      className={variant === 'peach' ? 'on-peach' : ''}
-      style={{
-        width: '100%',
-        height: '100%',
-        textAlign: 'left',
-        display: 'flex',
-        flexDirection: 'column',
-        /* space-between separates the h1 (top of cell) from the CTA
-         * row (bottom of cell). Buttons get flex-shrink:0 so they
-         * stay rendered; h1 gets flex-shrink:1 so it yields space on
-         * short viewports rather than pushing the buttons out. */
-        justifyContent: 'space-between',
-        gap: 24,
-        minHeight: 0,
-      }}
-    >
-      <h1
-        className="h-display"
-        style={{
-          fontSize: 'clamp(3rem, 4vh + 6vw, 8.8rem)',
-          lineHeight: 1.05,
-          paddingTop: '0.08em',
-          paddingBottom: '0.05em',
-          margin: 0,
-          flexShrink: 1,
-          minHeight: 0,
-        }}
-      >
+    <div className={`${styles.heroRoot} ${variant === 'peach' ? 'on-peach' : ''}`}>
+      <h1 className={`h-display ${styles.heroTitle}`}>
         From surfing the web to <em>owning&nbsp;it.</em>
       </h1>
-      <div
-        style={{
-          display: 'flex',
-          gap: 12,
-          flexWrap: 'wrap',
-          flexShrink: 0,
-        }}
-      >
+      <div className={styles.heroActions}>
         <a
           href="https://explorer.sofia.intuition.box"
           target="_blank"
@@ -104,30 +77,12 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
      deep ink on the peach slab; Phala keeps its native lime + dark
      because flattening would erase the inner "P". */
   2: (variant) => (
-    <div
-      className={variant === 'peach' ? 'on-peach' : ''}
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        justifyContent: 'flex-end',
-        gap: 16,
-      }}
-    >
+    <div className={`${styles.partnersRoot} ${variant === 'peach' ? 'on-peach' : ''}`}>
       <span className="eyebrow">Built with</span>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 28,
-          flexWrap: 'wrap',
-          justifyContent: 'flex-start',
-        }}
-      >
+      <div className={styles.partnersList}>
         {PARTNERS.map((p) => {
           const isPhala = p.name === 'Phala'
+          const shouldFlatten = !isPhala && variant === 'peach'
           return (
             <a
               key={p.name}
@@ -135,20 +90,14 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
               target="_blank"
               rel="noopener noreferrer"
               aria-label={p.name}
-              style={{ opacity: 0.78, display: 'inline-flex' }}
+              className={styles.partnerLink}
             >
               <img
                 src={p.logo}
                 alt={p.name}
-                style={{
-                  height: isPhala ? 'auto' : 28,
-                  maxHeight: 28,
-                  maxWidth: isPhala ? 90 : undefined,
-                  width: 'auto',
-                  display: 'block',
-                  filter:
-                    isPhala || variant === 'dark' ? 'none' : 'brightness(0)',
-                }}
+                className={styles.partnerLogo}
+                data-phala={isPhala ? 'true' : 'false'}
+                data-flatten={shouldFlatten ? 'true' : 'false'}
               />
             </a>
           )
@@ -167,17 +116,11 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
      emphasis + lede paragraph. Sits on the dark slab so default
      `var(--color-text)` ink is correct without any modifier. */
   5: () => (
-    <div style={{ width: '100%', textAlign: 'left' }}>
-      <h2
-        className="h-section"
-        style={{
-          margin: '0 0 14px',
-          fontSize: 'clamp(1.8rem, 1.4rem + 3.4vw, 9.2rem)',
-        }}
-      >
+    <div className={styles.sectionHead}>
+      <h2 className={`h-section ${styles.sectionHeadTitle}`}>
         Four angles, <em>one promise.</em>
       </h2>
-      <p className="lede" style={{ maxWidth: '60ch' }}>
+      <p className={`lede ${styles.sectionHeadLede}`}>
         Sofia answers four real needs — personal, group, watch, and collective
         intelligence. No jargon, no posturing: what you actually get from using
         it.
@@ -216,35 +159,22 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
       desc="Your community's signals — follows, Marks, trust votes — give weight to what you publish. The social side isn't decoration, it's the multiplier."
     />
   ),
-  /* Zone 10 — Sofia hero video demo. Auto-plays muted on loop. */
+  /* Zone 10 — Sofia hero video demo. Auto-plays muted on loop. A poster
+     image stands in on iOS when autoPlay is denied (Low Power Mode,
+     muted toggle off in Safari) so we never show a black rectangle.
+     TODO: ship /sofia-hero-poster.jpg (first frame of the demo, ~50ko
+     JPG/WebP) — browsers ignore the attribute gracefully if missing
+     but the fallback won't render. */
   10: (variant) => (
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        overflow: 'hidden',
-        borderRadius: 20,
-        background:
-          variant === 'peach'
-            ? 'rgba(255, 198, 176, 0.30)'
-            : 'rgba(2, 0, 14, 0.30)',
-      }}
-    >
+    <div className={styles.videoFrame} data-variant={variant}>
       <video
         src="/sofia-hero.mp4"
+        poster="/sofia-hero-poster.jpg"
         autoPlay
         muted
         loop
         playsInline
-        style={{
-          width: '100%',
-          height: '100%',
-          objectFit: 'contain',
-          display: 'block',
-        }}
+        preload="metadata"
       />
     </div>
   ),
@@ -252,15 +182,7 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
      Top-aligned so the plate's frame top edge sits flush with the
      "Personal upside" banner title in zone 12. */
   11: (variant) => (
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        alignItems: 'flex-start',
-        justifyContent: 'flex-start',
-      }}
-    >
+    <div className={styles.radarFrame}>
       <TopicsRadar ink={variant === 'dark' ? 'light' : 'dark'} />
     </div>
   ),
@@ -270,25 +192,12 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
      (Acte 4). Headline + lede + a stat row that echoes the Acte 4
      counters without faking a data tableau. */
   12: () => (
-    <div style={{ width: '100%', textAlign: 'left' }}>
+    <div className={styles.sectionHead}>
       <span className="eyebrow">Product · P.00</span>
-      <h2
-        className="h-section"
-        style={{
-          margin: '6px 0 12px',
-          fontSize: 'clamp(1.8rem, 1.4rem + 3.4vw, 9.2rem)',
-          lineHeight: 1.02,
-        }}
-      >
+      <h2 className={`h-section ${styles.sectionHeadTitleTight}`}>
         One gesture. <em>Your web, mapped.</em>
       </h2>
-      <p
-        className="lede"
-        style={{
-          margin: 0,
-          maxWidth: 'none',
-        }}
-      >
+      <p className={`lede ${styles.sectionHeadLedeWide}`}>
         Mark a page with how it served you — for learning, for work, for
         inspiration — and Sofia remembers. Months later, your reading still has
         shape: which articles taught you something, which podcasts shifted your
@@ -390,34 +299,12 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
   /* Zone 20 — S.06 CONTRIBUTOR base, top-left (2fr height). The two
      core builders pulled from `Team.tsx` with avatar mini + handle. */
   20: () => (
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        textAlign: 'left',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-      }}
-    >
+    <div className={styles.teamRoot}>
       <span className="eyebrow">Team · Core</span>
-      <h2
-        className="h-section"
-        style={{
-          margin: '12px 0 18px',
-          fontSize: 'clamp(1.6rem, 1.2rem + 2.4vw, 3.2rem)',
-        }}
-      >
+      <h2 className={`h-section ${styles.teamTitle}`}>
         Two builders, <em>one open repo.</em>
       </h2>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 18,
-          alignItems: 'flex-start',
-        }}
-      >
+      <div className={styles.teamList}>
         {[
           {
             name: 'Samuel Chauche',
@@ -435,71 +322,25 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
               "10 years as a music producer showed me how streaming platforms manipulate discovery — fake artists, paid algorithms, real creators buried. We're building the alternative.",
           },
         ].map((m) => (
-          <div
-            key={m.name}
-            style={{
-              width: '100%',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 12,
-            }}
-          >
-            <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
-              <img
-                src={m.avatar}
-                alt={m.name}
-                style={{
-                  width: 56,
-                  height: 56,
-                  borderRadius: '50%',
-                  display: 'block',
-                }}
-              />
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  lineHeight: 1.2,
-                }}
-              >
-                <span
-                  style={{
-                    fontSize: 'clamp(1rem, 0.85rem + 0.5vw, 1.25rem)',
-                    fontWeight: 500,
-                  }}
-                >
-                  {m.name}
-                </span>
-                <span
-                  className="eyebrow"
-                  style={{ fontSize: 11, marginTop: 4 }}
-                >
+          <div key={m.name} className={styles.teamMember}>
+            <div className={styles.teamHead}>
+              <img src={m.avatar} alt={m.name} className={styles.teamAvatar} />
+              <div className={styles.teamIdentity}>
+                <span className={styles.teamName}>{m.name}</span>
+                <span className={`eyebrow ${styles.teamHandle}`}>
                   {m.handle}
                 </span>
               </div>
             </div>
-            <p
-              className="lede"
-              style={{
-                margin: 0,
-                fontSize: 'clamp(0.85rem, 0.75rem + 0.4vw, 1.05rem)',
-                lineHeight: 1.5,
-              }}
-            >
-              “{m.quote}”
-            </p>
+            <p className={`lede ${styles.teamQuote}`}>“{m.quote}”</p>
           </div>
         ))}
       </div>
       <SceneBtn
         href="https://doc.sofia.intuition.box/docs/about"
         variant="peach"
-        style={{
-          marginTop: 16,
-          padding: '8px 14px',
-          fontSize: '0.78rem',
-          alignSelf: 'flex-start',
-        }}
+        size="sm"
+        anchor="team-cta"
       >
         About the team <Arrow />
       </SceneBtn>
@@ -510,63 +351,34 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
      first with a diagonal wipe, then Core (idx 0) and Advisors
      (idx 2) cascade in after the revealDelay beat. */
   21: () => (
-    <div style={{ width: '100%', textAlign: 'left' }}>
+    <div className={styles.grantRoot}>
       <span className="eyebrow">Backed by</span>
-      <h2
-        className="h-section"
-        style={{
-          margin: '12px 0 16px',
-          fontSize: 'clamp(1.6rem, 1.2rem + 2.4vw, 3.2rem)',
-        }}
-      >
+      <h2 className={`h-section ${styles.grantTitle}`}>
         Intuition · <em>20K grant.</em>
       </h2>
-      <p
-        className="lede"
-        style={{
-          margin: '0 0 12px',
-          fontSize: 'clamp(0.85rem, 0.75rem + 0.4vw, 1.05rem)',
-          maxWidth: 'none',
-        }}
-      >
+      <p className={`lede ${styles.grantPara}`}>
         Sofia is built on Intuition — the protocol where every meaningful action
         becomes a verifiable record owned by the person who made it. The
         alignment is structural, not commercial: the same infrastructure that
         secures your trail is the one we ship on, and Intuition's builder grant
         carries us through the early miles.
       </p>
-      <p
-        className="lede"
-        style={{
-          margin: '0 0 18px',
-          fontSize: 'clamp(0.85rem, 0.75rem + 0.4vw, 1.05rem)',
-          maxWidth: 'none',
-        }}
-      >
+      <p className={`lede ${styles.grantPara} ${styles.grantParaLast}`}>
         DAO-oriented from day one. Decisions, treasury, and rewards live
         on-chain — contributors who ship and users who curate get TRUST in
         return, and the community owns the roadmap as Sofia grows.
       </p>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'row',
-          flexWrap: 'wrap',
-          gap: 8,
-        }}
-      >
+      <div className={styles.grantCtaRow}>
         <SceneBtn
           href="https://portal.intuition.systems/"
           variant="peach"
-          style={{ padding: '8px 14px', fontSize: '0.78rem' }}
-        >
+          size="sm">
           portal.intuition.systems <Arrow />
         </SceneBtn>
         <SceneBtn
           href="https://app.colony.io/invite/sofia/d3c7b0a4-d168-477c-a176-2b5c4eca68da"
           variant="peach"
-          style={{ padding: '8px 14px', fontSize: '0.78rem' }}
-        >
+          size="sm">
           Join the DAO <Arrow />
         </SceneBtn>
       </div>
@@ -575,26 +387,9 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
   /* Zone 22 — S.06 base, BOTTOM RIGHT of the `left-stack-right`
      layout. Three advisors with avatar + role + company + handle. */
   22: () => (
-    <div
-      style={{
-        width: '100%',
-        height: '100%',
-        textAlign: 'left',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-      }}
-    >
+    <div className={styles.advisorsRoot}>
       <span className="eyebrow">Team · Advisors</span>
-      <div
-        style={{
-          marginTop: 12,
-          display: 'flex',
-          gap: 16,
-          flexWrap: 'wrap',
-          alignItems: 'flex-start',
-        }}
-      >
+      <div className={styles.advisorsList}>
         {[
           {
             name: 'Jeremie Olivier',
@@ -618,53 +413,19 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
             avatar: 'https://unavatar.io/twitter/0xbilly',
           },
         ].map((a) => (
-          <div
-            key={a.name}
-            style={{
-              flex: '1 1 180px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 8,
-            }}
-          >
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <div key={a.name} className={styles.advisorCard}>
+            <div className={styles.advisorHead}>
               <img
                 src={a.avatar}
                 alt={a.name}
-                style={{
-                  width: 36,
-                  height: 36,
-                  borderRadius: '50%',
-                  display: 'block',
-                }}
+                className={styles.advisorAvatar}
               />
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  lineHeight: 1.2,
-                }}
-              >
-                <span
-                  className="eyebrow"
-                  style={{ fontSize: 9, marginBottom: 2 }}
-                >
+              <div className={styles.advisorIdentity}>
+                <span className={`eyebrow ${styles.advisorCompany}`}>
                   {a.company}
                 </span>
-                <span style={{ fontSize: '0.82rem', fontWeight: 500 }}>
-                  {a.name}
-                </span>
-                <span
-                  style={{
-                    fontSize: '0.7rem',
-                    opacity: 0.65,
-                    fontFamily: 'var(--font-mono)',
-                    letterSpacing: '0.04em',
-                    marginTop: 2,
-                  }}
-                >
-                  {a.handle}
-                </span>
+                <span className={styles.advisorName}>{a.name}</span>
+                <span className={styles.advisorHandle}>{a.handle}</span>
               </div>
             </div>
           </div>
@@ -673,38 +434,16 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
     </div>
   ),
   /* Zone 23 — S.06 reveal (COMMUNITY), top-left (2fr). Headline
-     metric: 10K on-chain interactions — proof the community shows
+     metric: 13K on-chain interactions — proof the community shows
      up, beyond the team. */
   23: () => (
-    <div style={{ width: '100%', textAlign: 'left' }}>
+    <div className={styles.statRoot}>
       <span className="eyebrow">T.02</span>
-      <div
-        style={{
-          marginTop: 12,
-          fontFamily: 'var(--font-mono)',
-          fontSize: 'clamp(2.6rem, 1.6rem + 4vw, 6rem)',
-          fontWeight: 600,
-          lineHeight: 1,
-        }}
-      >
-        13K
-      </div>
-      <h3
-        className="h-section"
-        style={{
-          margin: '10px 0 8px',
-          fontSize: 'clamp(1.1rem, 0.9rem + 0.7vw, 1.6rem)',
-        }}
-      >
+      <div className={styles.statFigure}>13K</div>
+      <h3 className={`h-section ${styles.statTitle}`}>
         On-chain interactions, <em>and counting.</em>
       </h3>
-      <p
-        className="lede"
-        style={{
-          margin: 0,
-          fontSize: 'clamp(0.78rem, 0.7rem + 0.35vw, 1rem)',
-        }}
-      >
+      <p className={`lede ${styles.statLede}`}>
         Every certify, every vote, every trust signal lives on Intuition —
         public, permanent, replayable. Our users aren't a metric; they're the
         network.
@@ -713,55 +452,16 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
   ),
   /* Zone 24 — S.06 reveal, bottom-left (1fr). Community reward
      narrative: TRUST distributed back to the people who showed up.
-     Figure sized to match zone 23 (13K) for visual parity. */
+     Absolute-positioned on desktop to fit the compact 1fr cell;
+     mobile resets to static flow (see zones.module.css). */
   24: () => (
-    /* Absolute positioning anchors the wrapper to the top-left of
-       the .zoneContent slot. Compact spacing so the full block
-       (label, figure, title, lede) fits inside the 1fr bottom-left
-       cell of stack-left-tall-right at typical viewports. */
-    <div
-      style={{
-        position: 'absolute',
-        top: 2,
-        left: 28,
-        right: 28,
-        bottom: 4,
-        textAlign: 'left',
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'flex-start',
-        gap: 6,
-      }}
-    >
+    <div className={styles.statRootAbsolute}>
       <span className="eyebrow">T.03</span>
-      <div
-        style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 'clamp(2rem, 1.2rem + 3vw, 4.4rem)',
-          fontWeight: 600,
-          lineHeight: 0.95,
-        }}
-      >
-        2 500 TRUST
-      </div>
-      <h3
-        className="h-section"
-        style={{
-          margin: 0,
-          fontSize: 'clamp(1rem, 0.85rem + 0.6vw, 1.4rem)',
-          lineHeight: 1.15,
-        }}
-      >
+      <div className={styles.statFigureTight}>2 500 TRUST</div>
+      <h3 className={`h-section ${styles.statTitleTight}`}>
         Distributed to <em>the community.</em>
       </h3>
-      <p
-        className="lede"
-        style={{
-          margin: 0,
-          fontSize: 'clamp(0.75rem, 0.68rem + 0.25vw, 0.95rem)',
-          lineHeight: 1.35,
-        }}
-      >
+      <p className={`lede ${styles.statLedeTight}`}>
         Distributed to the early certifiers, curators, and contributors who
         carried Sofia through its first miles — every signal recorded on
         Intuition, every contributor identified by their wallet. No team
@@ -773,24 +473,12 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
   /* Zone 25 — S.06 reveal, right tall (wipe lead). Community voices:
      a couple of testimonials lifted from `Team.tsx`. */
   25: () => (
-    <div style={{ width: '100%', textAlign: 'left' }}>
+    <div className={styles.voicesRoot}>
       <span className="eyebrow">Voices</span>
-      <h2
-        className="h-section"
-        style={{
-          margin: '12px 0 18px',
-          fontSize: 'clamp(1.6rem, 1.2rem + 2vw, 2.8rem)',
-        }}
-      >
+      <h2 className={`h-section ${styles.voicesTitle}`}>
         Heard from the people <em>who showed up.</em>
       </h2>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 16,
-        }}
-      >
+      <div className={styles.voicesList}>
         {[
           {
             handle: 'anniepro',
@@ -823,55 +511,12 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
               'A web extension that lets you Mark websites based on what you use them for, stored on Intuition. A way to promote safe exploring on the web.',
           },
         ].map((v) => (
-          <article
-            key={v.handle}
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 4,
-              paddingBottom: 16,
-              borderBottom: '1px solid rgba(128,128,128,0.25)',
-            }}
-          >
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'baseline',
-                gap: 8,
-                flexWrap: 'wrap',
-                fontFamily: 'var(--font-mono)',
-              }}
-            >
-              <span
-                style={{
-                  fontSize: '0.82rem',
-                  fontWeight: 500,
-                  letterSpacing: '0.02em',
-                }}
-              >
-                @{v.handle}
-              </span>
-              <span
-                style={{
-                  fontSize: 9,
-                  opacity: 0.6,
-                  letterSpacing: '0.16em',
-                  textTransform: 'uppercase',
-                }}
-              >
-                {v.role}
-              </span>
+          <article key={v.handle} className={styles.voiceItem}>
+            <div className={styles.voiceHead}>
+              <span className={styles.voiceHandle}>@{v.handle}</span>
+              <span className={styles.voiceRole}>{v.role}</span>
             </div>
-            <p
-              className="lede"
-              style={{
-                margin: 0,
-                fontSize: 'clamp(0.78rem, 0.7rem + 0.35vw, 0.95rem)',
-                lineHeight: 1.45,
-              }}
-            >
-              {v.quote}
-            </p>
+            <p className={`lede ${styles.voiceQuote}`}>{v.quote}</p>
           </article>
         ))}
       </div>
@@ -880,15 +525,8 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
   /* Zone 26 — S.07 left tall. Intro to the doctrine: this is the
      community-staked values manifesto. Tone: declarative, on-chain. */
   26: () => (
-    <div style={{ width: '100%', textAlign: 'left' }}>
-      <h2
-        className="h-display"
-        style={{
-          margin: '0 0 18px',
-          fontSize: 'clamp(2rem, 1.4rem + 3vw, 4.4rem)',
-          lineHeight: 0.95,
-        }}
-      >
+    <div className={styles.sectionHead}>
+      <h2 className={`h-display ${styles.valuesIntroTitle}`}>
         Values{' '}
         <em>
           the community
@@ -896,26 +534,12 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
           staked into existence.
         </em>
       </h2>
-      <p
-        className="lede"
-        style={{
-          margin: '0 0 12px',
-          fontSize: 'clamp(0.9rem, 0.78rem + 0.45vw, 1.15rem)',
-          maxWidth: 'none',
-        }}
-      >
+      <p className={`lede ${styles.valuesIntroPara}`}>
         Sofia doesn&apos;t pick its principles — you do. Each value below was
         surfaced and ranked by the people who staked TRUST on the ones they
         believe in most.
       </p>
-      <p
-        className="lede"
-        style={{
-          margin: 0,
-          fontSize: 'clamp(0.9rem, 0.78rem + 0.45vw, 1.15rem)',
-          maxWidth: 'none',
-        }}
-      >
+      <p className={`lede ${styles.valuesIntroPara} ${styles.valuesIntroParaLast}`}>
         The more conviction behind a value, the more weight it carries in the
         protocol. No board vote, no manifesto written in a back room — just
         signal recorded on Intuition.
@@ -960,36 +584,18 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
   /* Zone 31 — S.08 narrow left. Q&A intro: brand the FAQ slab as a
      reference desk, set expectations, point to the open channels. */
   31: () => (
-    <div style={{ width: '100%', textAlign: 'left' }}>
-      <h2
-        className="h-display"
-        style={{
-          margin: '0 0 16px',
-          fontSize: 'clamp(1.8rem, 1.3rem + 2.4vw, 3.6rem)',
-          lineHeight: 0.95,
-        }}
-      >
+    <div className={styles.sectionHead}>
+      <h2 className={`h-display ${styles.faqIntroTitle}`}>
         Frequently <em>asked.</em>
       </h2>
-      <p
-        className="lede"
-        style={{
-          margin: '0 0 14px',
-          fontSize: 'clamp(0.85rem, 0.74rem + 0.4vw, 1.05rem)',
-          maxWidth: 'none',
-        }}
-      >
+      <p className={`lede ${styles.faqIntroPara}`}>
         Short answers to the questions that come up most. Need something we
         didn&apos;t cover? Ask us directly.
       </p>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-        <SceneBtn
-          href="https://discord.gg/sofia3"
-          variant="peach"
-          style={{ fontSize: '0.85rem' }}
-        >
+      <div className={styles.faqIntroCtaRow}>
+        <SceneBtn href="https://discord.gg/sofia3" variant="peach">
           Ask on Discord{' '}
-          <span aria-hidden="true" style={{ marginLeft: 4 }}>
+          <span aria-hidden="true" className={styles.faqDiscordArrow}>
             ↗
           </span>
         </SceneBtn>
@@ -1017,7 +623,6 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
               href="https://github.com/intuition-box"
               target="_blank"
               rel="noreferrer noopener"
-              style={{ color: 'inherit', textDecoration: 'underline' }}
             >
               open-source
             </a>
@@ -1038,7 +643,6 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
               href="https://explorer.sofia.intuition.box"
               target="_blank"
               rel="noreferrer noopener"
-              style={{ color: 'inherit', textDecoration: 'underline' }}
             >
               Explorer
             </a>{' '}
@@ -1048,7 +652,6 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
               href="https://doc.sofia.intuition.box/docs/extension"
               target="_blank"
               rel="noreferrer noopener"
-              style={{ color: 'inherit', textDecoration: 'underline' }}
             >
               browser extension
             </a>
@@ -1065,7 +668,6 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
               href="https://discord.gg/sofia3"
               target="_blank"
               rel="noreferrer noopener"
-              style={{ color: 'inherit', textDecoration: 'underline' }}
             >
               Discord
             </a>{' '}
@@ -1075,61 +677,17 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
       },
     ]
     return (
-      <div style={{ width: '100%', textAlign: 'left' }}>
-        <dl
-          style={{
-            margin: 0,
-            display: 'grid',
-            gridTemplateColumns: '1fr 1fr',
-            columnGap: 28,
-            rowGap: 18,
-          }}
-        >
+      <div className={styles.sectionHead}>
+        <dl className={styles.faqList}>
           {items.map((it, i) => (
-            <div
-              key={it.q}
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 4,
-                paddingBottom: 16,
-                borderBottom: '1px solid rgba(128,128,128,0.35)',
-              }}
-            >
-              <dt
-                style={{
-                  display: 'flex',
-                  alignItems: 'baseline',
-                  gap: 8,
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 'clamp(0.92rem, 0.8rem + 0.45vw, 1.2rem)',
-                  fontWeight: 500,
-                  lineHeight: 1.25,
-                }}
-              >
-                <span
-                  style={{
-                    fontSize: 10,
-                    opacity: 0.55,
-                    letterSpacing: '0.14em',
-                  }}
-                >
+            <div key={it.q} className={styles.faqItem}>
+              <dt className={styles.faqQuestion}>
+                <span className={styles.faqNum}>
                   {String(i + 1).padStart(2, '0')}
                 </span>
                 <span>{it.q}</span>
               </dt>
-              <dd
-                className="lede"
-                style={{
-                  margin: 0,
-                  fontSize: 'clamp(0.82rem, 0.72rem + 0.35vw, 1rem)',
-                  lineHeight: 1.5,
-                  opacity: 0.9,
-                  maxWidth: '48ch',
-                }}
-              >
-                {it.a}
-              </dd>
+              <dd className={`lede ${styles.faqAnswer}`}>{it.a}</dd>
             </div>
           ))}
         </dl>
@@ -1140,61 +698,16 @@ export const ZONE_NODES: Record<number, (variant: 'peach' | 'dark') => ReactNode
      CTA exactly (eyebrow + h-display + lede + two buttons) with the
      HexSplit hexagon decoration painted behind. */
   33: () => (
-    <div
-      style={{
-        position: 'relative',
-        width: '100%',
-        height: '100%',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        textAlign: 'center',
-      }}
-    >
-      <HexSplit size="520px" color="rgba(0,0,0,0.05)" />
-      <div
-        style={{
-          position: 'relative',
-          zIndex: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: 18,
-          maxWidth: 720,
-          padding: '0 24px',
-        }}
-      >
+    <div className={styles.ctaRoot}>
+      <HexSplit />
+      <div className={styles.ctaInner}>
         <span className="eyebrow">Beta · Open</span>
-        <h2
-          className="h-display"
-          style={{
-            margin: 0,
-            fontSize: 'clamp(2.6rem, 2vh + 6vw, 7.2rem)',
-            lineHeight: 1,
-          }}
-        >
-          Join the movement.
-        </h2>
-        <p
-          className="lede"
-          style={{
-            margin: 0,
-            fontSize: 'clamp(0.95rem, 0.82rem + 0.45vw, 1.15rem)',
-            maxWidth: '52ch',
-          }}
-        >
+        <h2 className={`h-display ${styles.ctaTitle}`}>Join the movement.</h2>
+        <p className={`lede ${styles.ctaLede}`}>
           Your browsing history is your identity — not a PFP, not a token.
           It&apos;s what you actually do, verified on-chain.
         </p>
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: 12,
-            justifyContent: 'center',
-            marginTop: 6,
-          }}
-        >
+        <div className={styles.ctaActions}>
           <a
             href="https://explorer.sofia.intuition.box"
             target="_blank"

--- a/apps/landing/src/styles/global.css
+++ b/apps/landing/src/styles/global.css
@@ -333,8 +333,7 @@ button {
 }
 
 /* ── Responsive ───────────────────────────────────────── */
-@media (max-width: 640px) {
-  .container {
-    padding: 0 24px;
-  }
-}
+/* .container picks up --gutter from variables.css; the breakpoint
+   cascade there (16px @ <=640px, 24px @ <=900px, 48px desktop)
+   handles the scaling. Kept as a tap-target reminder for future
+   per-element overrides. */

--- a/apps/landing/src/styles/variables.css
+++ b/apps/landing/src/styles/variables.css
@@ -14,6 +14,22 @@
   --maxw: 1240px;
   --gutter: 48px;
   --nav-h: 64px;
+  /* Deck frame paddings — consumed by .frame in App.module.css.
+     Tokenised so a single breakpoint cascade can scale every slide
+     surface without touching the deck CSS. */
+  --frame-margin: 24px;
+  --frame-padding-y: 24px;
+  --frame-padding-x: 32px;
+  --zone-gap: 16px;
+
+  /* ── Breakpoints (reference only — used as values in @media) ── */
+  --bp-tablet: 900px;
+  --bp-mobile: 640px;
+
+  /* ── Scene deck timing — owned by SceneStack.module.css. */
+  --stage-gap: 60vh;
+  --scene-step1-ms: 220ms;
+  --scene-step2-ms: 220ms;
 
   /* ── Radius ─────────────────────────────────────────── */
   --radius-sm: calc(var(--ds-radius) - 4px); /* 6px  */
@@ -52,6 +68,15 @@
   --color-success: var(--trusted, #22c55e);
   --color-error: var(--distrusted, #ef4444);
 
+  /* ── Intent tints — used as the wipe slab colour on each slide.
+     Each slide picks one via its `wipeColor` config; the slide's
+     [data-wipe-tint] attribute resolves to the matching token. */
+  --intent-fun: #e4b95a;
+  --intent-trusted: #6dd4a0;
+  --intent-learning: #5cc4d6;
+  --intent-inspiration: #a78bdb;
+  --intent-work: #7bade0;
+
   /* ── Effects ────────────────────────────────────────── */
   --shadow-lg: 0 20px 60px rgba(0, 0, 0, 0.5);
 
@@ -60,4 +85,26 @@
   --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
   --duration-fast: 0.2s;
   --duration-normal: 0.35s;
+}
+
+/* ── Tablet (<= 900px) — drop gutters + frame spacing one notch. */
+@media (max-width: 900px) {
+  :root {
+    --gutter: 24px;
+    --frame-margin: 12px;
+    --frame-padding-y: 18px;
+    --frame-padding-x: 20px;
+    --zone-gap: 20px;
+  }
+}
+
+/* ── Mobile (<= 640px) — tightest spacing, the deck stacks vertically. */
+@media (max-width: 640px) {
+  :root {
+    --gutter: 16px;
+    --frame-margin: 8px;
+    --frame-padding-y: 14px;
+    --frame-padding-x: 14px;
+    --zone-gap: 24px;
+  }
 }


### PR DESCRIPTION
Mobile: matchMedia gates the desktop snap deck above 900px; below, an IntersectionObserver per slide drives the same data-active entrance choreography over a vertical scroll flow. Each .zones / .revealZones layer paints its own bg edge-to-edge so a slide with a reveal (S.01 HERO → WHY SOFIA) keeps its peach + dark split. Frame chrome is dropped on mobile for a clean seam between layers.

Inline styles removed everywhere in apps/landing/src — the deck's runtime values (slide index, grid area, wipe tint, cascade delay) are now resolved via data-attributes that map to CSS custom-property bindings. wipeColor refactored from hex string to a semantic enum ('fun' | 'trusted' | ...) sourced from --intent-* tokens.