### PR TITLE
fix(pinning): pin-proxy authentifié pour pinThing

### DIFF
--- a/apps/explorer/src/config.ts
+++ b/apps/explorer/src/config.ts
@@ -11,6 +11,11 @@ export const GRAPHQL_URL = import.meta.env.DEV
 export const GRAPHQL_WS_URL =
   (import.meta.env.VITE_GRAPHQL_WS_URL as string) ||
   'wss://mainnet.intuition.sh/v1/graphql'
+// Authenticated pinning endpoint. Intuition gated `pinThing` behind an API
+// key — the read endpoint above no longer accepts mutations. We route pins
+// through the backend pin-proxy (services/pin-proxy) which holds the key
+// server-side, so it never ships in this public bundle. URL only, no secret.
+export const PIN_PROXY_URL = import.meta.env.VITE_PIN_PROXY_URL as string
 export const EXPLORER_URL = 'https://explorer.intuition.systems'
 
 // ── Sofia Proxy Contract ──

--- a/apps/explorer/src/lib/providers.tsx
+++ b/apps/explorer/src/lib/providers.tsx
@@ -4,13 +4,24 @@ import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persist
 import { PrivyProvider } from '@privy-io/react-auth'
 import { BrowserRouter } from 'react-router-dom'
 import { configureClient } from '@0xsofia/graphql'
-import { PRIVY_APP_ID, GRAPHQL_URL, GRAPHQL_WS_URL } from '../config'
+import {
+  PRIVY_APP_ID,
+  GRAPHQL_URL,
+  GRAPHQL_WS_URL,
+  PIN_PROXY_URL,
+} from '../config'
 import { intuitionChain } from './contracts/chainConfig'
 import { CartProvider } from '../hooks/useCart'
 import { ViewAsProvider } from '../hooks/useViewAs'
 
 // HTTP proxy (/v1/graphql) in dev for CORS, direct WSS for subscriptions.
-configureClient({ apiUrl: GRAPHQL_URL, wsUrl: GRAPHQL_WS_URL })
+// `pinApiUrl` routes pin mutations through the backend pin-proxy (the key
+// lives there, server-side — never in this bundle).
+configureClient({
+  apiUrl: GRAPHQL_URL,
+  wsUrl: GRAPHQL_WS_URL,
+  pinApiUrl: PIN_PROXY_URL,
+})
 
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000 // 24h
 

--- a/apps/extension/.env.development
+++ b/apps/extension/.env.development
@@ -12,3 +12,7 @@ PLASMO_PUBLIC_OG_PROXY_URL=https://og.sofia.intuition.box
 PLASMO_PUBLIC_PRIVY_APP_ID=cmj05tjsj03thjs0c3mgxrixm
 PLASMO_PUBLIC_PRIVY_CLIENT_ID=client-WY6U3b3LFEgbveR2FVgiyTTbRWKCZhy6vEVFzQt9NvZYS
 PLASMO_PUBLIC_AUTH_URL=http://localhost:5174/auth
+
+# Pin proxy — backend that holds the Intuition pin API key server-side and
+# relays `pinThing` mutations (services/pin-proxy). The key is NEVER here.
+PLASMO_PUBLIC_PIN_PROXY_URL=http://localhost:8790/pin

--- a/apps/extension/.env.exemple
+++ b/apps/extension/.env.exemple
@@ -18,6 +18,11 @@ PLASMO_PUBLIC_SOFIA_SERVER_URL=http://localhost:3000
 # Leave unset to use the mainnet default baked into the extension.
 PLASMO_PUBLIC_GRAPHQL_WS_URL=wss://mainnet.intuition.sh/v1/graphql
 
+# Pin proxy — backend (services/pin-proxy) that holds the Intuition pin API
+# key server-side and relays `pinThing` mutations. The key is NEVER in the
+# extension; only this URL is. Local dev: http://localhost:8790/pin
+PLASMO_PUBLIC_PIN_PROXY_URL=http://localhost:8790/pin
+
 
 PLASMO_PUBLIC_PRIVY_APP_ID= 0000000000000000000000000000
 PLASMO_PUBLIC_PRIVY_CLIENT_ID= 0000000000000000000000000000

--- a/apps/extension/.env.production
+++ b/apps/extension/.env.production
@@ -9,6 +9,11 @@ PLASMO_PUBLIC_GRAPHQL_WS_URL=wss://mainnet.intuition.sh/v1/graphql
 # with the explorer's VITE_OG_PROXY_URL). Unset → cards fall back to favicons.
 PLASMO_PUBLIC_OG_PROXY_URL=https://og.sofia.intuition.box
 
+# Pin proxy — backend that holds the Intuition pin API key server-side and
+# relays `pinThing` mutations (services/pin-proxy). The key is NEVER here.
+# Must match the Coolify domain assigned to services/pin-proxy.
+PLASMO_PUBLIC_PIN_PROXY_URL=https://pin.sofia.intuition.box/pin
+
 # Privy authentication
 PLASMO_PUBLIC_PRIVY_APP_ID=cmj05tjsj03thjs0c3mgxrixm
 PLASMO_PUBLIC_PRIVY_CLIENT_ID=client-WY6U3b3LFEgbveR2FVgiyTTbRWKCZhy6vEVFzQt9NvZYS

--- a/apps/extension/sidepanel.tsx
+++ b/apps/extension/sidepanel.tsx
@@ -24,9 +24,13 @@ import OnboardingBookmarkSelectPage from "./components/pages/OnboardingBookmarkS
 import OnboardingClaimModal from "./components/modals/OnboardingClaimModal"
 import { IntentionGroupsService } from "./lib/database/indexedDB-methods"
 
-// Configure GraphQL client BEFORE the QueryProvider mounts
+// Configure GraphQL client BEFORE the QueryProvider mounts.
+// `pinApiUrl` routes pin mutations through the backend pin-proxy — Intuition
+// gated `pinThing` behind an API key, and that key must never ship in the
+// published extension bundle, so the proxy holds it server-side.
 configureClient({
-  apiUrl: 'https://mainnet.intuition.sh/v1/graphql'
+  apiUrl: 'https://mainnet.intuition.sh/v1/graphql',
+  pinApiUrl: process.env.PLASMO_PUBLIC_PIN_PROXY_URL
 })
 
 const SidePanelContent = () => {

--- a/bun.lock
+++ b/bun.lock
@@ -358,6 +358,17 @@
         "typescript": "^5.4.0",
       },
     },
+    "services/pin-proxy": {
+      "name": "pin-proxy",
+      "version": "0.1.0",
+      "dependencies": {
+        "hono": "^4.6.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.1.0",
+        "typescript": "^5.4.0",
+      },
+    },
   },
   "overrides": {
     "react": "18.2.0",
@@ -4046,6 +4057,8 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pify": ["pify@6.1.0", "", {}, "sha512-KocF8ve28eFjjuBKKGvzOBGzG8ew2OqOOSxTTZhirkzH7h3BI1vyzqlR0qbfcDBve1Yzo3FVlWUAtCRrbVN8Fw=="],
+
+    "pin-proxy": ["pin-proxy@workspace:services/pin-proxy"],
 
     "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
 

--- a/packages/graphql/src/client.ts
+++ b/packages/graphql/src/client.ts
@@ -13,6 +13,15 @@ const DEFAULT_MAX_CONCURRENT = 4
 
 let globalConfig: {
   apiUrl?: string
+  /** Authenticated pinning endpoint. Intuition gated `pinThing` (the only
+   *  GraphQL mutation we send) behind an API key on a dedicated host. The
+   *  network read endpoint (`apiUrl`) no longer accepts mutations at all, so
+   *  there is NO fallback — mutations must go here. In prod this points at a
+   *  backend proxy that injects the secret key server-side. */
+  pinApiUrl?: string
+  /** Optional Intuition API key, sent as the `apikey` header on mutations.
+   *  Direct mode only — left unset in prod, where the proxy holds the key. */
+  pinApiKey?: string
   maxConcurrent: number
 } = {
   apiUrl: DEFAULT_API_URL,
@@ -22,6 +31,10 @@ let globalConfig: {
 export function configureClient(config: {
   apiUrl: string
   wsUrl?: string
+  /** Authenticated pinning endpoint (e.g. the backend pin proxy URL). */
+  pinApiUrl?: string
+  /** Intuition API key for direct pinning (omit when using a proxy). */
+  pinApiKey?: string
   /** Max parallel HTTP requests through the fetcher.
    *  Defaults to 4 — caps the burst on first paint so the upstream
    *  Hasura/Kong gate doesn't 429 a wave of mounted hooks. */
@@ -30,6 +43,8 @@ export function configureClient(config: {
   globalConfig = {
     ...globalConfig,
     apiUrl: config.apiUrl,
+    pinApiUrl: config.pinApiUrl ?? globalConfig.pinApiUrl,
+    pinApiKey: config.pinApiKey ?? globalConfig.pinApiKey,
     maxConcurrent: config.maxConcurrent ?? globalConfig.maxConcurrent,
   }
   if (config.wsUrl) {
@@ -143,9 +158,18 @@ export function fetcher<TData, TVariables>(
   options?: RequestInit['headers'],
 ) {
   return async () => {
-    if (!globalConfig.apiUrl) {
+    // Intuition gated `pinThing` (our only mutation) behind an authenticated
+    // host — the network read endpoint no longer accepts mutations at all, so
+    // there is NO fallback. Route mutations to `pinApiUrl` (in prod a backend
+    // proxy that injects the secret `apikey` server-side; the key never ships
+    // in the client bundle). Reads stay on the network `apiUrl`.
+    const isMutation = /^\s*mutation\b/.test(query)
+    const url = isMutation ? globalConfig.pinApiUrl : globalConfig.apiUrl
+    if (!url) {
       throw new Error(
-        'GraphQL API URL not configured. Call configureClient first.',
+        isMutation
+          ? 'Pinning endpoint not configured. pinThing requires the authenticated pin proxy — call configureClient({ pinApiUrl }).'
+          : 'GraphQL API URL not configured. Call configureClient first.',
       )
     }
 
@@ -157,10 +181,18 @@ export function fetcher<TData, TVariables>(
     const start = isDev ? performance.now() : 0
     let status = 0
     try {
-      const res = await fetch(globalConfig.apiUrl, {
+      const res = await fetch(url, {
         method: 'POST',
-        ...fetchParams(),
-        ...options,
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          ...(options as Record<string, string> | undefined),
+          // Direct mode only: when a raw key is configured (no proxy) it is
+          // sent as the `apikey` header. In proxy mode `pinApiKey` is unset
+          // and the proxy attaches the key itself.
+          ...(isMutation && globalConfig.pinApiKey
+            ? { apikey: globalConfig.pinApiKey }
+            : {}),
+        },
         body: JSON.stringify({ query, variables }),
       })
       status = res.status

--- a/services/mastra/phala-deploy/Dockerfile
+++ b/services/mastra/phala-deploy/Dockerfile
@@ -43,6 +43,7 @@ COPY packages/quests/package.json ./packages/quests/
 COPY services/mastra/package.json ./services/mastra/
 COPY services/group-api/package.json ./services/group-api/
 COPY services/og-proxy/package.json ./services/og-proxy/
+COPY services/pin-proxy/package.json ./services/pin-proxy/
 
 RUN bun install --frozen-lockfile
 

--- a/services/pin-proxy/Dockerfile
+++ b/services/pin-proxy/Dockerfile
@@ -1,0 +1,27 @@
+# Pin proxy — Bun + Hono. Built as a tiny multi-stage image so Coolify
+# pulls < 100 MB and starts in well under a second.
+
+FROM oven/bun:1.1-alpine AS deps
+WORKDIR /app
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile --production
+
+FROM oven/bun:1.1-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=8790
+
+# Drop privileges — the worker doesn't need root at runtime.
+RUN addgroup -S app && adduser -S app -G app
+COPY --from=deps --chown=app:app /app/node_modules ./node_modules
+COPY --chown=app:app package.json ./
+COPY --chown=app:app src ./src
+
+USER app
+EXPOSE 8790
+
+# Lightweight liveness probe — Coolify hits /health every few seconds.
+HEALTHCHECK --interval=15s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8790/health || exit 1
+
+CMD ["bun", "src/index.ts"]

--- a/services/pin-proxy/README.md
+++ b/services/pin-proxy/README.md
@@ -1,0 +1,88 @@
+# Sofia pin proxy
+
+Bun + Hono HTTP service that relays Intuition pin requests (`pinThing` &
+friends) to the authenticated upstream `https://pin.intuition.systems`,
+injecting the `apikey` header **server-side**.
+
+## Why
+
+Intuition closed anonymous access to the `pinThing` GraphQL mutation: the
+network read endpoint (`mainnet.intuition.sh` / `testnet.intuition.sh`) no
+longer accepts mutations. Pinning now requires an API key on a dedicated
+host. That key must never ship in a client bundle (the extension is on the
+Chrome Web Store, the explorer is a public SPA — both are extractable), and
+in our case it is **not revocable**, so an exposure would be permanent.
+
+This proxy keeps the key in a server-side env var. The extension and
+explorer point their GraphQL client's `pinApiUrl` at `<this-host>/pin` and
+send pin requests with no credentials; the proxy adds the key.
+
+## Endpoint
+
+```
+POST /pin        body: { "query": "...", "variables": {...} }  (GraphQL)
+GET  /health  -> { "ok": true }
+```
+
+Relays the body verbatim to the upstream and returns its JSON response.
+
+## Local dev
+
+```bash
+cd services/pin-proxy
+bun install
+INTUITION_PIN_API_KEY=<key> bun run dev     # http://localhost:8790/pin
+```
+
+```bash
+curl -s http://localhost:8790/pin -H "Content-Type: application/json" \
+  -d '{"query":"mutation($n:String!){pinThing(thing:{name:$n,description:\"x\",image:\"https://provider.example/logo.svg\",url:\"https://provider.example\"}){uri}}","variables":{"n":"Test"}}'
+# -> {"data":{"pinThing":{"uri":"ipfs://bafkrei…"}}}
+```
+
+Then point the clients at it:
+
+```bash
+# apps/extension/.env.development
+PLASMO_PUBLIC_PIN_PROXY_URL=http://localhost:8790/pin
+# apps/explorer/.env
+export VITE_PIN_PROXY_URL=http://localhost:8790/pin
+```
+
+## Deploy on Coolify
+
+1. **Add a new resource** → "Application" → "Dockerfile"
+2. **Build context** : `services/pin-proxy`
+3. **Dockerfile** : `Dockerfile` (default)
+4. **Port** : `8790`
+5. **Healthcheck path** : `/health`
+6. **Domain** : assign a hostname (e.g. `pin.sofia.intuition.box`). TLS via
+   Let's Encrypt.
+7. **Environment variables** (runtime — NOT build-time, the key is a secret):
+   - `INTUITION_PIN_API_KEY` — the Intuition API key (required).
+   - `PIN_ALLOWED_ORIGINS` — CSV of allowed origins; overrides the built-in
+     default (which contains the **dev/test** extension id + explorer/sofia
+     domains). In prod, set this to the **published** extension id, e.g.
+     `chrome-extension://<PUBLISHED_ID>,https://explorer.intuition.systems,https://sofia.intuition.box`
+   - `INTUITION_PIN_URL` — optional, defaults to the upstream.
+8. **Deploy**, then set `PLASMO_PUBLIC_PIN_PROXY_URL` / `VITE_PIN_PROXY_URL`
+   to `https://<host>/pin` and rebuild the clients.
+
+## Env vars
+
+| Name                     | Default                                     | Purpose                                          |
+| ------------------------ | ------------------------------------------- | ------------------------------------------------ |
+| `INTUITION_PIN_API_KEY`  | _(unset → 503)_                             | Intuition API key, sent as `apikey` header       |
+| `PIN_ALLOWED_ORIGINS`    | _(dev/test ext + explorer/sofia domains)_   | CSV allowlist; overrides default; `scheme://*` and `*` supported |
+| `INTUITION_PIN_URL`      | `https://pin.intuition.systems/v1/graphql`  | Upstream pin endpoint                            |
+| `PORT`                   | `8790`                                      | HTTP port                                        |
+
+## Security notes
+
+- The key lives only in `process.env`, server-side. Never logged or bundled.
+- `PIN_ALLOWED_ORIGINS` is a best-effort gate (Origin headers are spoofable
+  by non-browser clients); the durable protection is that the key can't be
+  extracted from a client bundle. Set it anyway to deter casual abuse.
+- The proxy forwards bodies verbatim; the upstream only accepts pin ops, so
+  it can't be turned into a general GraphQL relay.
+- Stateless — rolling redeploys are safe.

--- a/services/pin-proxy/package.json
+++ b/services/pin-proxy/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pin-proxy",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun --watch src/index.ts",
+    "start": "bun src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "hono": "^4.6.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.1.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/services/pin-proxy/src/index.ts
+++ b/services/pin-proxy/src/index.ts
@@ -1,0 +1,142 @@
+/**
+ * Sofia pin proxy — Bun HTTP server (Hono).
+ *
+ * Endpoint: POST /pin   (GraphQL body: { query, variables })
+ *
+ * Intuition gated the `pinThing` mutation (and the other pin/upload ops)
+ * behind an API key on a dedicated host: https://pin.intuition.systems.
+ * The key must NEVER ship in a client bundle — the extension is published
+ * on the Chrome Web Store and the explorer is a public SPA, both publicly
+ * extractable. This proxy holds the key server-side (env var only) and
+ * relays GraphQL pin requests to the upstream, injecting the `apikey`
+ * header. Clients send their pin requests here with no credentials.
+ *
+ * The key is read from `process.env.INTUITION_PIN_API_KEY` and is never
+ * logged, echoed, or written to disk.
+ *
+ * Security:
+ *   - Origin allowlist (best-effort): only configured origins may call
+ *     /pin. A non-browser client can spoof the Origin header, but the
+ *     real win is that the upstream key can't be lifted from a bundle —
+ *     blast radius stays contained to this proxy, which can be rate-
+ *     limited / shut down independently.
+ *   - The proxy forwards the body verbatim; the upstream only accepts pin
+ *     operations, so it can't be used as a general GraphQL relay.
+ *   - 10s timeout on the upstream fetch.
+ *
+ * CORS: open (`*`) for response headers — that only governs which origins
+ * the browser lets read the response; it leaks nothing. The Origin
+ * allowlist above is the actual access gate.
+ */
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+
+const PORT = parseInt(process.env.PORT ?? '8790', 10)
+const PIN_API_KEY = process.env.INTUITION_PIN_API_KEY ?? ''
+const PIN_UPSTREAM =
+  process.env.INTUITION_PIN_URL ?? 'https://pin.intuition.systems/v1/graphql'
+const UPSTREAM_TIMEOUT_MS = 10_000
+
+// Known Sofia client origins — the secure DEFAULT when PIN_ALLOWED_ORIGINS
+// is unset, so the proxy never fails open. The env var (CSV) overrides this
+// entirely when set. In PROD (Coolify), set PIN_ALLOWED_ORIGINS to include
+// the PUBLISHED extension id — the chrome-extension entry below is the local
+// dev/test extension, not the Web Store build.
+const DEFAULT_ALLOWED_ORIGINS = [
+  'chrome-extension://gabdhpllladhcaldpppokfmjafolkppl', // Sofia dev/test extension
+  'https://explorer.intuition.systems',
+  'https://sofia.intuition.box',
+]
+
+// Each entry is matched exactly, or — when it ends in `://*` — by scheme
+// prefix (e.g. `chrome-extension://*` matches any extension id). `*` allows
+// every origin.
+const PIN_ALLOWED_ORIGINS = (() => {
+  const env = (process.env.PIN_ALLOWED_ORIGINS ?? '')
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean)
+  return env.length ? env : DEFAULT_ALLOWED_ORIGINS
+})()
+
+if (!PIN_API_KEY) {
+  console.warn(
+    '[pin-proxy] INTUITION_PIN_API_KEY is unset — /pin will return 503 until it is configured.',
+  )
+}
+
+function originAllowed(origin: string): boolean {
+  return PIN_ALLOWED_ORIGINS.some((allowed) => {
+    if (allowed === '*') return true
+    if (allowed.endsWith('://*')) return origin.startsWith(allowed.slice(0, -1))
+    return origin === allowed
+  })
+}
+
+const app = new Hono()
+
+app.use(
+  '*',
+  cors({
+    origin: '*',
+    allowMethods: ['POST', 'GET', 'OPTIONS'],
+    allowHeaders: ['content-type'],
+  }),
+)
+
+app.get('/health', (c) => c.json({ ok: true }))
+
+app.post('/pin', async (c) => {
+  if (!PIN_API_KEY) {
+    return c.json(
+      { error: 'Pin proxy not configured (missing INTUITION_PIN_API_KEY)' },
+      503,
+    )
+  }
+
+  const origin = c.req.header('origin') ?? ''
+  if (!originAllowed(origin)) {
+    return c.json({ error: 'Forbidden origin' }, 403)
+  }
+
+  let body: string
+  try {
+    body = await c.req.text()
+  } catch {
+    return c.json({ error: 'Invalid request body' }, 400)
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS)
+  try {
+    const res = await fetch(PIN_UPSTREAM, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        apikey: PIN_API_KEY,
+      },
+      body,
+      signal: controller.signal,
+    })
+    const text = await res.text()
+    return new Response(text, {
+      status: res.status,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    })
+  } catch {
+    return c.json({ error: 'Pin upstream unreachable' }, 502)
+  } finally {
+    clearTimeout(timer)
+  }
+})
+
+// Fallback — anything else is a 404.
+app.all('*', (c) => c.json({ error: 'Not found' }, 404))
+
+console.log(`Pin proxy listening on http://0.0.0.0:${PORT}`)
+
+export default {
+  port: PORT,
+  hostname: '0.0.0.0',
+  fetch: app.fetch,
+}

--- a/services/pin-proxy/tsconfig.json
+++ b/services/pin-proxy/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Intuition a fermé pinThing en anonyme (API key requise sur pin.intuition.systems). Nouveau service services/pin-proxy qui détient la clé côté serveur et relaie pinThing avec le header apikey ; client GraphQL câblé sur pinApiUrl (extension + explorer). La clé ne ship jamais dans un bundle. Testé e2e : pinThing renvoie un vrai CID via le proxy.