### PR TITLE
fix(explorer): point extension install CTA to published Chrome Web St…

### DIFF
--- a/apps/explorer/src/utils/sofiaDetect.ts
+++ b/apps/explorer/src/utils/sofiaDetect.ts
@@ -10,8 +10,8 @@
  * cleans the URL, and auto-opens the Sofia side panel.
  */
 
-// TODO: replace with real Chrome Web Store URL once published
-export const CHROME_STORE_URL = 'https://chromewebstore.google.com/detail/sofia'
+export const CHROME_STORE_URL =
+  'https://chromewebstore.google.com/detail/sofia/ldohfencfbbelhgfppgdmgmghodhjodb'
 
 function isSofiaInstalled(): boolean {
   return document.documentElement.dataset.sofiaExtension === 'true'


### PR DESCRIPTION
…ore listing

Replace the placeholder store URL with the real Sofia listing so the "Install or update" nudge on the profile Achievements panel redirects correctly when the extension isn't detected.