### PR TITLE
## Unify pills across the monorepo + circles / market polish

### DIFF
--- a/apps/explorer/src/components/NavSidebar.tsx
+++ b/apps/explorer/src/components/NavSidebar.tsx
@@ -301,9 +301,6 @@ export function NavSidebar({
                 >
                   <div className="ns-circle-head">
                     <span className="ns-circle-name">Trust Circle</span>
-                    <span className="ns-circle-count">
-                      {trustCircle.length}
-                    </span>
                   </div>
                   <div className="ns-circle-avatars">
                     {trustCircle.slice(0, 5).map((a) => {
@@ -357,9 +354,6 @@ export function NavSidebar({
                   >
                     <div className="ns-circle-head">
                       <span className="ns-circle-name">{group.label}</span>
-                      <span className="ns-circle-count">
-                        {group.memberCount}
-                      </span>
                     </div>
                     <div className="ns-circle-avatars">
                       {previewMembers.map((m) => {

--- a/apps/explorer/src/components/NavSidebar.tsx
+++ b/apps/explorer/src/components/NavSidebar.tsx
@@ -300,10 +300,6 @@ export function NavSidebar({
                   title={`Trust Circle — ${trustCircle.length} member${trustCircle.length === 1 ? '' : 's'}`}
                 >
                   <div className="ns-circle-head">
-                    <span
-                      className="ns-circle-dot"
-                      style={{ background: 'var(--trusted, #6dd4a0)' }}
-                    />
                     <span className="ns-circle-name">Trust Circle</span>
                     <span className="ns-circle-count">
                       {trustCircle.length}
@@ -339,9 +335,6 @@ export function NavSidebar({
                         +{trustCircle.length - 5}
                       </span>
                     )}
-                    <span className="ns-mav ns-mav-add" aria-hidden="true">
-                      +
-                    </span>
                   </div>
                 </Link>
               )}
@@ -350,7 +343,6 @@ export function NavSidebar({
                   the rail reads as a single uniform list of "circles
                   this user belongs to". */}
               {joinedGroups.map((group) => {
-                const dotColor = avatarColor(group.termId || group.label)
                 const previewMembers = group.memberships.slice(0, 5)
                 const extra = Math.max(
                   0,
@@ -364,10 +356,6 @@ export function NavSidebar({
                     title={`${group.label} — ${group.memberCount} member${group.memberCount === 1 ? '' : 's'}`}
                   >
                     <div className="ns-circle-head">
-                      <span
-                        className="ns-circle-dot"
-                        style={{ background: dotColor }}
-                      />
                       <span className="ns-circle-name">{group.label}</span>
                       <span className="ns-circle-count">
                         {group.memberCount}

--- a/apps/explorer/src/components/circles/CircleHeaderFree.tsx
+++ b/apps/explorer/src/components/circles/CircleHeaderFree.tsx
@@ -158,7 +158,6 @@ export default function CircleHeaderFree({
         <div className="cf-kpi">
           <span className="cf-kpi-value">{signals}</span>
           <span className="cf-kpi-label">Signals marked</span>
-          <span className="cf-kpi-delta is-up">marked on-chain</span>
         </div>
 
         <div className="cf-kpi">
@@ -167,7 +166,6 @@ export default function CircleHeaderFree({
             <span className="cf-kpi-unit">/ {totalMembers}</span>
           </span>
           <span className="cf-kpi-label">Active curators</span>
-          <span className="cf-kpi-delta is-flat">active in last 7 days</span>
         </div>
 
         {SHOW_DECISIONS && showPlan && (

--- a/apps/explorer/src/components/circles/CircleHeaderFree.tsx
+++ b/apps/explorer/src/components/circles/CircleHeaderFree.tsx
@@ -156,31 +156,17 @@ export default function CircleHeaderFree({
         aria-label="Circle metrics"
       >
         <div className="cf-kpi">
-          <span className="cf-kpi-label">
-            <span
-              className="cf-kpi-dot"
-              style={{ background: 'var(--learning)' }}
-              aria-hidden="true"
-            />
-            Signals marked
-          </span>
           <span className="cf-kpi-value">{signals}</span>
+          <span className="cf-kpi-label">Signals marked</span>
           <span className="cf-kpi-delta is-up">marked on-chain</span>
         </div>
 
         <div className="cf-kpi">
-          <span className="cf-kpi-label">
-            <span
-              className="cf-kpi-dot"
-              style={{ background: 'var(--inspiration)' }}
-              aria-hidden="true"
-            />
-            Active curators
-          </span>
           <span className="cf-kpi-value">
             {active}
             <span className="cf-kpi-unit">/ {totalMembers}</span>
           </span>
+          <span className="cf-kpi-label">Active curators</span>
           <span className="cf-kpi-delta is-flat">active in last 7 days</span>
         </div>
 
@@ -194,14 +180,7 @@ export default function CircleHeaderFree({
             aria-pressed={decisionsActive}
             aria-label="Decisions — a Pro feature. Open to preview."
           >
-            <span className="cf-kpi-label">
-              <span
-                className="cf-kpi-dot"
-                style={{ background: 'var(--ds-accent)' }}
-                aria-hidden="true"
-              />
-              Decisions
-            </span>
+            <span className="cf-kpi-label">Decisions</span>
             <span className="cf-kpi-lock-glyph">
               <Lock aria-hidden="true" />
             </span>
@@ -220,14 +199,7 @@ export default function CircleHeaderFree({
             aria-pressed={decisionsActive}
             aria-label="Open the Decisions room"
           >
-            <span className="cf-kpi-label">
-              <span
-                className="cf-kpi-dot"
-                style={{ background: 'var(--ds-accent)' }}
-                aria-hidden="true"
-              />
-              Decisions
-            </span>
+            <span className="cf-kpi-label">Decisions</span>
             <span className="cf-kpi-value">
               {decisionsMeta?.open ?? 0}
               <span className="cf-kpi-unit">

--- a/apps/explorer/src/components/circles/CircleTopicsTreemap.tsx
+++ b/apps/explorer/src/components/circles/CircleTopicsTreemap.tsx
@@ -182,7 +182,6 @@ function TreemapCell({ cell, onPick }: TreemapCellProps) {
           className="cf-tmap-meta"
           style={{ visibility: med ? 'visible' : 'hidden' }}
         >
-          <span className="cf-tmap-dot" aria-hidden="true" />
           {cell.signals} certifications
         </span>
         <span className="cf-tmap-cell-foot">

--- a/apps/explorer/src/components/circles/MembersFree.tsx
+++ b/apps/explorer/src/components/circles/MembersFree.tsx
@@ -49,12 +49,16 @@ export default function MembersFree({
     <section className="cf-module" aria-labelledby="cf-members-title">
       <div className="cf-module-head">
         <h2 id="cf-members-title" className="cf-module-title">
-          Members
+          Most active members
         </h2>
-        <span className="cf-module-note">
-          Most active · {totalMembers}{' '}
-          {totalMembers === 1 ? 'member' : 'members'}
-        </span>
+        <button
+          type="button"
+          className="cf-module-note cf-module-link"
+          onClick={onViewAll}
+        >
+          View all
+          <ArrowRight className="cf-btn-icon" aria-hidden="true" />
+        </button>
       </div>
 
       <div className="cf-top3">
@@ -86,7 +90,7 @@ export default function MembersFree({
                   ownerLabel={m.label}
                   socials={
                     m.walletAddress
-                      ? (socials[m.walletAddress.toLowerCase()] ?? [])
+                      ? socials[m.walletAddress.toLowerCase()] ?? []
                       : []
                   }
                 />
@@ -98,17 +102,6 @@ export default function MembersFree({
             </div>
           )
         })}
-      </div>
-
-      <div className="cf-module-foot">
-        <button
-          type="button"
-          className="cf-btn cf-btn-ghost"
-          onClick={onViewAll}
-        >
-          View all
-          <ArrowRight className="cf-btn-icon" aria-hidden="true" />
-        </button>
       </div>
     </section>
   )

--- a/apps/explorer/src/components/circles/MembersFree.tsx
+++ b/apps/explorer/src/components/circles/MembersFree.tsx
@@ -90,7 +90,7 @@ export default function MembersFree({
                   ownerLabel={m.label}
                   socials={
                     m.walletAddress
-                      ? socials[m.walletAddress.toLowerCase()] ?? []
+                      ? (socials[m.walletAddress.toLowerCase()] ?? [])
                       : []
                   }
                 />

--- a/apps/explorer/src/components/feed/FeedCardView.tsx
+++ b/apps/explorer/src/components/feed/FeedCardView.tsx
@@ -17,6 +17,20 @@ import {
 } from '@0xsofia/design-system'
 import { UrlPreview } from '@/components/UrlPreview'
 import { TopicPill } from '@/components/profile/FeedPills'
+import { getIntentionIconByLabel } from '@/config/intentionIcons'
+
+/** Inject the intent glyph into every verb chip that doesn't already carry one,
+ *  resolved from the verb label — so feed cards show the colored icon + label
+ *  (matching every other verb pill) instead of a bare label. */
+function withVerbIcons(verbs: FeedCardViewProps['verbs']) {
+  return verbs.map((v) => {
+    if (v.icon) return v
+    const Icon = getIntentionIconByLabel(v.label)
+    return Icon
+      ? { ...v, icon: <Icon className="fc-verb-ic" aria-hidden="true" /> }
+      : v
+  })
+}
 
 export type {
   FeedCardSize,
@@ -61,6 +75,7 @@ export default function FeedCardView(props: FeedCardViewProps) {
   return (
     <DSFeedCardView
       {...props}
+      verbs={withVerbIcons(props.verbs)}
       renderMedia={renderMedia}
       renderTopic={props.renderTopic ?? defaultRenderTopic}
     />

--- a/apps/explorer/src/components/home/FeedCard.tsx
+++ b/apps/explorer/src/components/home/FeedCard.tsx
@@ -16,6 +16,7 @@ import FeedCardView, {
 import ContextPicker from '@/components/ContextPicker'
 import { categoryPills } from '@/config/contextNodes'
 import { getIntentionIconByLabel } from '@/config/intentionIcons'
+import { useCart } from '@/hooks/useCart'
 import '@/components/styles/feed-card.css'
 
 interface FeedCardProps {
@@ -59,6 +60,23 @@ export default function FeedCard({
   const canSupport = item.contextTriples.some((c) => c.termId)
   const canOppose = item.contextTriples.some((c) => c.counterTermId)
 
+  // Queued-in-cart state — a like/dislike goes to the cart first and settles
+  // on-chain at batch submit. Mark the matching thumb as pending (dashed green)
+  // so the click gives immediate feedback while the tx is still unconfirmed.
+  const { items: cartItems } = useCart()
+  const pendingUp = item.contextTriples.some(
+    (c) =>
+      c.termId &&
+      cartItems.some((ci) => ci.termId === c.termId && ci.side === 'support'),
+  )
+  const pendingDown = item.contextTriples.some(
+    (c) =>
+      c.counterTermId &&
+      cartItems.some(
+        (ci) => ci.termId === c.counterTermId && ci.side === 'oppose',
+      ),
+  )
+
   const verbs: FeedCardVerb[] = item.intentions.map((label) => {
     const Icon = getIntentionIconByLabel(label)
     return {
@@ -99,6 +117,8 @@ export default function FeedCard({
       down={opposes}
       userUp={userSupported}
       userDown={userOpposed}
+      pendingUp={pendingUp}
+      pendingDown={pendingDown}
       canUp={canSupport}
       canDown={canOppose}
       onVote={onDeposit ? (side) => onDeposit(side, item) : undefined}

--- a/apps/explorer/src/components/onboarding/FeedPillsDemo.tsx
+++ b/apps/explorer/src/components/onboarding/FeedPillsDemo.tsx
@@ -4,8 +4,9 @@
  * (what it's about) is shown, not just told.
  *
  * Matches the explore feed exactly (see FeedCardView): intentions render as the
- * `.fc-verb` chip (tinted, lucide icon), topics render via <TopicPill> (solid
- * topic color, black glyph) — the same components the feed cards use.
+ * canonical `.fc-verb-tag--sm` chip (outlined, intent-colored text + border +
+ * lucide icon), topics render via <TopicPill> (solid topic color, black glyph)
+ * — the same pills the feed cards use.
  */
 
 import type { CSSProperties } from 'react'
@@ -42,7 +43,7 @@ export default function FeedPillsDemo() {
             return (
               <span
                 key={type}
-                className="fc-verb"
+                className="fc-verb-tag fc-verb-tag--sm"
                 style={{ ['--vc']: cfg.color } as CSSProperties}
               >
                 <Icon className="fc-verb-ic" />

--- a/apps/explorer/src/components/platforms/PlatformsRightRail.tsx
+++ b/apps/explorer/src/components/platforms/PlatformsRightRail.tsx
@@ -18,7 +18,10 @@ import { usePlatformCatalog } from '@/hooks/usePlatformCatalog'
 import { useRedeemCert } from '@/hooks/useRedeemCert'
 import AtomDetailDialog from '@/components/AtomDetailDialog'
 import { ATOM_ID_TO_PLATFORM } from '@/config/atomIds'
-import type { PlatformVaultData } from '@/services/platformMarketService'
+import {
+  resolvePlatformImage,
+  type PlatformVaultData,
+} from '@/services/platformMarketService'
 import '@/components/styles/platforms-right-rail.css'
 
 function formatMCap(raw: string): string {
@@ -178,7 +181,8 @@ export default function PlatformsRightRail() {
                     <span className="prr-row-rank">{i + 1}</span>
                     <FaviconWrapper
                       size={24}
-                      src={`/favicons/${slug}.png`}
+                      src={slug ? `/favicons/${slug}.png` : undefined}
+                      fallbackSrc={resolvePlatformImage(market.image)}
                       alt={market.label}
                     />
                     <span className="prr-row-name">{market.label}</span>
@@ -223,7 +227,12 @@ export default function PlatformsRightRail() {
                 <FaviconWrapper
                   className="prr-mover-fav"
                   size={20}
-                  src={`/favicons/${ATOM_ID_TO_PLATFORM.get(myPositions.best.termId) || ''}.png`}
+                  src={
+                    ATOM_ID_TO_PLATFORM.get(myPositions.best.termId)
+                      ? `/favicons/${ATOM_ID_TO_PLATFORM.get(myPositions.best.termId)}.png`
+                      : undefined
+                  }
+                  fallbackSrc={resolvePlatformImage(myPositions.best.image)}
                   alt={myPositions.best.label}
                 />
                 <span className="prr-mover-name">{myPositions.best.label}</span>
@@ -240,7 +249,12 @@ export default function PlatformsRightRail() {
                   <FaviconWrapper
                     className="prr-mover-fav"
                     size={20}
-                    src={`/favicons/${ATOM_ID_TO_PLATFORM.get(myPositions.worst.termId) || ''}.png`}
+                    src={
+                      ATOM_ID_TO_PLATFORM.get(myPositions.worst.termId)
+                        ? `/favicons/${ATOM_ID_TO_PLATFORM.get(myPositions.worst.termId)}.png`
+                        : undefined
+                    }
+                    fallbackSrc={resolvePlatformImage(myPositions.worst.image)}
                     alt={myPositions.worst.label}
                   />
                   <span className="prr-mover-name">
@@ -268,7 +282,8 @@ export default function PlatformsRightRail() {
                   <li key={market.termId} className="prr-position">
                     <FaviconWrapper
                       size={20}
-                      src={`/favicons/${slug}.png`}
+                      src={slug ? `/favicons/${slug}.png` : undefined}
+                      fallbackSrc={resolvePlatformImage(market.image)}
                       alt={market.label}
                     />
                     <span className="prr-position-name">{market.label}</span>

--- a/apps/explorer/src/components/profile/FeedPills.tsx
+++ b/apps/explorer/src/components/profile/FeedPills.tsx
@@ -1,17 +1,20 @@
 /**
- * FeedPills — the ONE source of truth for the topic + verb pills shown
- * across every feed surface (circle, explore/home, profile Echoes, the
- * ProfileDrawer activity rows and the public-profile rail). Before this,
- * each surface re-styled its own `.fc-tag` / `.group-bento-tag` /
- * `.pd-la-topic` / `.ppa-topic` (and duplicate `.fc-verb-tag`) so the
- * same pill looked different depending on where you were.
+ * FeedPills — thin wrappers over the shared design-system pills so every feed
+ * surface (circle, explore/home, profile Echoes, the ProfileDrawer activity
+ * rows and the public-profile rail) renders the ONE canonical pill. The DS
+ * owns the look (verb-tag.css / topic-pill.css); these wrappers keep the
+ * explorer's ergonomic API — resolving the icon/glyph from the app taxonomy —
+ * and delegate rendering. Previously each pill had its own `.sf-*-pill` CSS.
  *
- * Visual contract (see styles/pills.css):
- *   - VerbPill  : solid intent-colored fill, black text.
- *   - TopicPill : black icon on the topic's color, border of that color.
+ * Visual contract (design-system):
+ *   - VerbPill  : outlined — intent-colored text + border + icon, no fill.
+ *   - TopicPill : filled disc — black glyph + label on the topic color.
  */
-import { getTopicIcon } from '@/config/topicEmoji'
+import { TopicPill as DSTopicPill } from '@0xsofia/design-system'
+import type { CSSProperties } from 'react'
+
 import { getIntentionIconByLabel } from '@/config/intentionIcons'
+import { getTopicIcon } from '@/config/topicEmoji'
 
 interface TopicPillProps {
   topicId: string
@@ -23,45 +26,37 @@ interface TopicPillProps {
   iconOnly?: boolean
 }
 
-/** A topic rendered as a colored pill: black glyph on the topic color,
- *  border of the same color. With `iconOnly`, collapses to a colored disc
- *  carrying just the glyph (label still exposed via the tooltip/aria). */
+/** A topic rendered as a colored disc (black glyph + label), via the shared DS
+ *  <TopicPill>. The glyph name is resolved from the explorer taxonomy. */
 export function TopicPill({ topicId, color, label, iconOnly }: TopicPillProps) {
   return (
-    <span
-      className={`sf-topic-pill${iconOnly ? ' sf-topic-pill--icon' : ''}`}
-      style={{ ['--pill-color' as string]: color || 'var(--ds-accent)' }}
-      title={iconOnly ? label : undefined}
-      aria-label={iconOnly ? label : undefined}
-    >
-      <span
-        className="material-symbols-outlined sf-topic-pill-glyph"
-        aria-hidden="true"
-      >
-        {getTopicIcon(topicId)}
-      </span>
-      {iconOnly ? null : label}
-    </span>
+    <DSTopicPill
+      color={color}
+      label={label}
+      glyph={getTopicIcon(topicId)}
+      iconOnly={iconOnly}
+    />
   )
 }
 
 interface VerbPillProps {
   label: string
   /** Intent color (design-system INTENTION_COLORS) — drives the text +
-   *  border. Undefined → neutral. */
+   *  border + icon. Undefined → neutral. */
   color?: string
 }
 
-/** A verb/intention rendered as an outlined pill: text + border in the
- *  intent color, transparent fill. */
+/** A verb/intention rendered as an outlined pill (intent-colored text + border
+ *  + icon, transparent fill) via the canonical DS `.fc-verb-tag`, colour-driven
+ *  through `--vc` so no intent slug is needed. */
 export function VerbPill({ label, color }: VerbPillProps) {
   const Icon = getIntentionIconByLabel(label)
   return (
     <span
-      className="sf-verb-pill"
-      style={color ? { ['--pill-color' as string]: color } : undefined}
+      className="fc-verb-tag"
+      style={color ? ({ ['--vc']: color } as CSSProperties) : undefined}
     >
-      {Icon ? <Icon className="sf-verb-pill-ic" aria-hidden="true" /> : null}
+      {Icon ? <Icon className="fc-verb-ic" aria-hidden="true" /> : null}
       {label}
     </span>
   )

--- a/apps/explorer/src/components/styles/circles-free.css
+++ b/apps/explorer/src/components/styles/circles-free.css
@@ -533,7 +533,8 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  background: linear-gradient(
+  background:
+    linear-gradient(
       155deg,
       color-mix(in srgb, var(--c) 30%, transparent) 0%,
       color-mix(in srgb, var(--c) 9%, transparent) 60%,

--- a/apps/explorer/src/components/styles/circles-free.css
+++ b/apps/explorer/src/components/styles/circles-free.css
@@ -178,15 +178,10 @@
   border-color: transparent;
   color: #02000e;
 }
-.cf-btn-ghost {
-  background: transparent;
-}
-
 /* ── KPI band ────────────────────────────────────────────────── */
 .cf-kpis {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  border-top: 1px solid var(--ds-border-soft);
 }
 /* Trust Circle has no locked "Decisions" tile — drop to two columns so the
    remaining KPIs fill the band instead of leaving a gap. */
@@ -215,12 +210,6 @@
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--ds-muted);
-}
-.cf-kpi-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  flex-shrink: 0;
 }
 .cf-kpi-value {
   font-family: var(--ds-font-display);
@@ -359,6 +348,25 @@
   text-transform: uppercase;
   color: var(--ds-muted);
 }
+/* Clickable "View all" variant of the note — sits top-right of the module
+   head, replacing the old foot button. */
+.cf-module-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+.cf-module-link:hover {
+  color: var(--ds-ink);
+}
+.cf-module-link .cf-btn-icon {
+  width: 13px;
+  height: 13px;
+}
 .cf-top3 {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -452,14 +460,6 @@
   color: var(--ds-muted-soft);
   margin-top: 4px;
 }
-.cf-module-foot {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-  flex-wrap: wrap;
-}
-
 /* Peach "Pro hint" pill — shared by module foot + panel foot. */
 .cf-prohint {
   display: inline-flex;
@@ -533,8 +533,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  background:
-    linear-gradient(
+  background: linear-gradient(
       155deg,
       color-mix(in srgb, var(--c) 30%, transparent) 0%,
       color-mix(in srgb, var(--c) 9%, transparent) 60%,
@@ -587,13 +586,6 @@
   align-items: center;
   gap: 8px;
   opacity: 0.92;
-}
-.cf-tmap-dot {
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: var(--c);
-  flex-shrink: 0;
 }
 .cf-tmap-spark {
   display: flex;

--- a/apps/explorer/src/components/styles/design-system.css
+++ b/apps/explorer/src/components/styles/design-system.css
@@ -9,6 +9,7 @@
 @import '@0xsofia/design-system/theme.css';
 @import '@0xsofia/design-system/styles/favicon.css';
 @import '@0xsofia/design-system/styles/verb-tag.css';
+@import '@0xsofia/design-system/styles/topic-pill.css';
 @import '@0xsofia/design-system/styles/user-badge.css';
 @import '@0xsofia/design-system/styles/bento.css';
 @import '@0xsofia/design-system/styles/interests.css';
@@ -138,8 +139,7 @@ html {
   background: var(--ds-card);
   color: var(--ds-ink);
   border: 1px solid var(--ds-border);
-  box-shadow: 0 18px 40px -24px
-    color-mix(in srgb, var(--ds-ink) 60%, transparent);
+  box-shadow: 0 18px 40px -24px color-mix(in srgb, var(--ds-ink) 60%, transparent);
 }
 [data-slot='select-item'] {
   color: var(--ds-ink);
@@ -165,8 +165,7 @@ html {
   background: var(--ds-card);
   color: var(--ds-ink);
   border: 1px solid var(--ds-border);
-  box-shadow: 0 30px 80px -40px
-    color-mix(in srgb, var(--ds-ink) 80%, transparent);
+  box-shadow: 0 30px 80px -40px color-mix(in srgb, var(--ds-ink) 80%, transparent);
 }
 
 /* ── Radix DropdownMenu content ──
@@ -176,8 +175,7 @@ html {
   background: color-mix(in srgb, var(--ds-card) 80%, transparent);
   color: var(--ds-ink);
   border: 1px solid var(--ds-border);
-  box-shadow: 0 18px 48px -20px
-    color-mix(in srgb, var(--ds-ink) 60%, transparent);
+  box-shadow: 0 18px 48px -20px color-mix(in srgb, var(--ds-ink) 60%, transparent);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
 }

--- a/apps/explorer/src/components/styles/design-system.css
+++ b/apps/explorer/src/components/styles/design-system.css
@@ -139,7 +139,8 @@ html {
   background: var(--ds-card);
   color: var(--ds-ink);
   border: 1px solid var(--ds-border);
-  box-shadow: 0 18px 40px -24px color-mix(in srgb, var(--ds-ink) 60%, transparent);
+  box-shadow: 0 18px 40px -24px
+    color-mix(in srgb, var(--ds-ink) 60%, transparent);
 }
 [data-slot='select-item'] {
   color: var(--ds-ink);
@@ -165,7 +166,8 @@ html {
   background: var(--ds-card);
   color: var(--ds-ink);
   border: 1px solid var(--ds-border);
-  box-shadow: 0 30px 80px -40px color-mix(in srgb, var(--ds-ink) 80%, transparent);
+  box-shadow: 0 30px 80px -40px
+    color-mix(in srgb, var(--ds-ink) 80%, transparent);
 }
 
 /* ── Radix DropdownMenu content ──
@@ -175,7 +177,8 @@ html {
   background: color-mix(in srgb, var(--ds-card) 80%, transparent);
   color: var(--ds-ink);
   border: 1px solid var(--ds-border);
-  box-shadow: 0 18px 48px -20px color-mix(in srgb, var(--ds-ink) 60%, transparent);
+  box-shadow: 0 18px 48px -20px
+    color-mix(in srgb, var(--ds-ink) 60%, transparent);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
 }

--- a/apps/explorer/src/components/styles/nav-sidebar-trust-circle.css
+++ b/apps/explorer/src/components/styles/nav-sidebar-trust-circle.css
@@ -56,16 +56,6 @@
   text-align: left;
 }
 
-.ns-circle-count {
-  margin-left: auto;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 9px;
-  color: var(--ds-muted);
-  font-weight: 500;
-  font-variant-numeric: tabular-nums;
-  flex-shrink: 0;
-}
-
 .ns-circle-avatars {
   display: flex;
   align-items: center;

--- a/apps/explorer/src/components/styles/nav-sidebar-trust-circle.css
+++ b/apps/explorer/src/components/styles/nav-sidebar-trust-circle.css
@@ -47,13 +47,6 @@
   margin-bottom: 8px;
 }
 
-.ns-circle-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
 .ns-circle-name {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -76,7 +69,6 @@
 .ns-circle-avatars {
   display: flex;
   align-items: center;
-  padding-left: 15px;
 }
 
 .ns-mav {
@@ -108,14 +100,4 @@
 [data-theme='dark'] .ns-mav-more,
 .dark .ns-mav-more {
   background: var(--ds-border);
-}
-
-.ns-mav-add {
-  background: var(--ds-ink);
-  color: var(--ds-bg);
-  cursor: default;
-  font-size: 15px;
-  font-weight: 400;
-  line-height: 1;
-  margin-left: 4px;
 }

--- a/apps/explorer/src/components/styles/page-hint.css
+++ b/apps/explorer/src/components/styles/page-hint.css
@@ -90,8 +90,8 @@
   flex-wrap: wrap;
   gap: 6px;
 }
-/* The pills themselves reuse the feed's .fc-verb class (see FeedPillsDemo) so
-   they render exactly like the real feed pills. */
+/* The pills themselves reuse the feed's canonical `.fc-verb-tag--sm` /
+   <TopicPill> (see FeedPillsDemo) so they render exactly like the real feed. */
 
 .phint-text {
   font-size: 13px;

--- a/apps/explorer/src/components/styles/pills.css
+++ b/apps/explorer/src/components/styles/pills.css
@@ -1,66 +1,10 @@
-/* ── Unified feed pills (topic + verb) ───────────────────────────────
- * One source of truth for the pills rendered by <TopicPill> / <VerbPill>
- * across circle / explore / Echoes / ProfileDrawer / public-profile rail.
- * Imported globally from App.tsx so every surface gets the same look.
+/* ── Feed pills (topic + verb) ───────────────────────────────────────
+ * MOVED TO THE DESIGN SYSTEM during the pill unification.
  *
- *   VerbPill  : solid intent fill, black text.
- *   TopicPill : black icon on the topic color, border of that color. */
-
-.sf-topic-pill,
-.sf-verb-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  line-height: 1;
-  white-space: nowrap;
-}
-/* Verb icon — inherits the pill's intent colour via currentColor. */
-.sf-verb-pill-ic {
-  width: 12px;
-  height: 12px;
-  flex-shrink: 0;
-}
-
-/* ── Verb — outlined: text + border in the intent color, no fill.
-   `--pill-color` is the design-system intent color (INTENTION_COLORS),
-   set inline by <VerbPill>; falls back to neutral when unknown. ── */
-.sf-verb-pill {
-  padding: 4px 10px;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--pill-color, var(--ds-ink));
-  border: 1px solid var(--pill-color, var(--ds-border));
-}
-
-/* ── Topic — black icon on the topic color, border of that color ── */
-.sf-topic-pill {
-  gap: 5px;
-  padding: 4px 10px 4px 7px;
-  border-radius: 999px;
-  color: #000;
-  background: var(--pill-color, var(--ds-accent));
-  border: 1px solid var(--pill-color, var(--ds-border));
-}
-/* Icon-only variant — equal padding so the rounded pill reads as a
-   colored disc carrying just the glyph (no label). */
-.sf-topic-pill--icon {
-  gap: 0;
-  padding: 4px;
-}
-.sf-topic-pill-glyph {
-  font-size: 14px;
-  line-height: 1;
-  color: #000;
-  /* Material Symbols variable-font axes — keep the glyph compact + bold
-     so it reads at 14px the way the old TopicBadge disc did. */
-  font-variation-settings:
-    'FILL' 1,
-    'wght' 500,
-    'GRAD' 0,
-    'opsz' 20;
-}
+ *   VerbPill  → `.fc-verb-tag`  (verb-tag.css)   — outlined, intent color.
+ *   TopicPill → `.sf-topic-pill` (topic-pill.css) — filled disc, black glyph.
+ *
+ * Both stylesheets are imported in styles/design-system.css, so the pills
+ * render identically here and in the extension. <TopicPill> / <VerbPill>
+ * (profile/FeedPills.tsx) are now thin wrappers over the DS components.
+ * This file is intentionally empty — kept so the App.tsx import stays valid. */

--- a/apps/explorer/src/components/styles/platform-market.css
+++ b/apps/explorer/src/components/styles/platform-market.css
@@ -245,16 +245,6 @@
   position: relative;
   color: var(--ds-ink);
 }
-.pm-dex-row::before {
-  /* Topic-colored rail on the left edge of each row. */
-  content: '';
-  position: absolute;
-  inset: 6px auto 6px 0;
-  width: 3px;
-  border-radius: 3px;
-  background: var(--topic-color, var(--ds-accent));
-  opacity: 0.75;
-}
 .pm-dex-row:last-child {
   border-bottom: none;
 }

--- a/apps/explorer/src/components/styles/profile-drawer.css
+++ b/apps/explorer/src/components/styles/profile-drawer.css
@@ -337,16 +337,14 @@
   font-weight: 700;
   letter-spacing: 0.01em;
   cursor: pointer;
-  box-shadow: 0 4px 14px -6px
-    color-mix(in srgb, var(--ds-accent) 65%, transparent);
+  box-shadow: 0 4px 14px -6px color-mix(in srgb, var(--ds-accent) 65%, transparent);
   transition:
     transform 0.18s ease,
     box-shadow 0.18s ease;
 }
 .pd-journey-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 8px 18px -6px
-    color-mix(in srgb, var(--ds-accent) 80%, transparent);
+  box-shadow: 0 8px 18px -6px color-mix(in srgb, var(--ds-accent) 80%, transparent);
 }
 .pd-journey-arrow {
   font-family: 'JetBrains Mono', monospace;
@@ -464,10 +462,10 @@ a.pd-la-row:hover {
   color: var(--ds-ink);
 }
 
-/* Verb + topic use the shared <VerbPill> / <TopicPill> (styles/pills.css).
-   Here they sit inline inside the activity sentence (a -webkit-box), so
-   nudge spacing + baseline alignment for the running-text context. */
-.pd-la-title .sf-verb-pill,
+/* Verb + topic use the shared <VerbPill> (.fc-verb-tag) / <TopicPill>
+   (.sf-topic-pill). Here they sit inline inside the activity sentence (a
+   -webkit-box), so nudge spacing + baseline alignment for the running text. */
+.pd-la-title .fc-verb-tag,
 .pd-la-title .sf-topic-pill {
   margin-right: 6px;
   vertical-align: middle;

--- a/apps/explorer/src/components/styles/profile-drawer.css
+++ b/apps/explorer/src/components/styles/profile-drawer.css
@@ -337,14 +337,16 @@
   font-weight: 700;
   letter-spacing: 0.01em;
   cursor: pointer;
-  box-shadow: 0 4px 14px -6px color-mix(in srgb, var(--ds-accent) 65%, transparent);
+  box-shadow: 0 4px 14px -6px
+    color-mix(in srgb, var(--ds-accent) 65%, transparent);
   transition:
     transform 0.18s ease,
     box-shadow 0.18s ease;
 }
 .pd-journey-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 8px 18px -6px color-mix(in srgb, var(--ds-accent) 80%, transparent);
+  box-shadow: 0 8px 18px -6px
+    color-mix(in srgb, var(--ds-accent) 80%, transparent);
 }
 .pd-journey-arrow {
   font-family: 'JetBrains Mono', monospace;

--- a/apps/explorer/src/components/styles/scores-constellation.css
+++ b/apps/explorer/src/components/styles/scores-constellation.css
@@ -820,7 +820,8 @@
   color: var(--ds-on-accent, #1a1320);
   background: var(--ds-accent);
   border: 1px solid color-mix(in srgb, #000 12%, var(--ds-accent));
-  box-shadow: 0 4px 14px -4px color-mix(in srgb, var(--ds-accent) 70%, transparent);
+  box-shadow: 0 4px 14px -4px
+    color-mix(in srgb, var(--ds-accent) 70%, transparent);
 }
 .sc2-cert-pioneer-ic {
   font-size: 13px;

--- a/apps/explorer/src/components/styles/scores-constellation.css
+++ b/apps/explorer/src/components/styles/scores-constellation.css
@@ -246,19 +246,6 @@
 .sc2-rank-item:hover {
   background: var(--ds-bg-subtle);
 }
-.sc2-rank-dot {
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-.sc2-rank-glyph {
-  font-size: 16px;
-  width: 20px;
-  text-align: center;
-  flex-shrink: 0;
-  color: var(--ds-ink-soft);
-}
 .sc2-rank-label {
   flex: 1;
   min-width: 0;
@@ -833,8 +820,7 @@
   color: var(--ds-on-accent, #1a1320);
   background: var(--ds-accent);
   border: 1px solid color-mix(in srgb, #000 12%, var(--ds-accent));
-  box-shadow: 0 4px 14px -4px
-    color-mix(in srgb, var(--ds-accent) 70%, transparent);
+  box-shadow: 0 4px 14px -4px color-mix(in srgb, var(--ds-accent) 70%, transparent);
 }
 .sc2-cert-pioneer-ic {
   font-size: 13px;

--- a/apps/explorer/src/pages/AllPlatformsPage.tsx
+++ b/apps/explorer/src/pages/AllPlatformsPage.tsx
@@ -22,7 +22,10 @@ import SofiaLoader from '@/components/ui/SofiaLoader'
 import { useProvideRightRail } from '@/contexts/RightRailContext'
 import { PAGE_COLORS } from '@/config/pageColors'
 import { ATOM_ID_TO_PLATFORM } from '@/config/atomIds'
-import type { PlatformVaultData } from '@/services/platformMarketService'
+import {
+  resolvePlatformImage,
+  type PlatformVaultData,
+} from '@/services/platformMarketService'
 import '@/components/styles/pages.css'
 import '@/components/styles/platform-market.css'
 
@@ -63,16 +66,6 @@ function formatMCap(raw: string): string {
 function formatShare(raw: string): string {
   const num = parseFloat(formatEther(BigInt(raw || '0')))
   return num >= 1 ? num.toFixed(2) : num.toFixed(4)
-}
-
-// On-chain atom images may be `ipfs://CID` URIs the browser can't fetch
-// directly — rewrite them to an HTTP gateway so the <img> loads.
-function resolvePlatformImage(url?: string): string | undefined {
-  if (!url) return undefined
-  if (url.startsWith('ipfs://')) {
-    return `https://ipfs.io/ipfs/${url.slice('ipfs://'.length).replace(/^ipfs\//, '')}`
-  }
-  return url
 }
 
 export default function AllPlatformsPage() {

--- a/apps/explorer/src/pages/ScoresPage.tsx
+++ b/apps/explorer/src/pages/ScoresPage.tsx
@@ -55,6 +55,7 @@ import FeedCardView, {
   type FeedCardTopic,
 } from '@/components/feed/FeedCardView'
 import ContextPicker from '@/components/ContextPicker'
+import { TopicPill } from '@/components/profile/FeedPills'
 import { categoryPills } from '@/config/contextNodes'
 import { ScoresDonut, type Seg } from '@/components/scores/ScoresDonut'
 import { useRedeemCert } from '@/hooks/useRedeemCert'
@@ -538,16 +539,12 @@ export default function ScoresPage() {
                 key={r.slug}
                 onClick={() => setSel(r.slug)}
               >
-                <span
-                  className="sc2-rank-dot"
-                  style={{ background: r.color }}
+                <TopicPill
+                  iconOnly
+                  topicId={r.slug}
+                  color={r.color}
+                  label={r.label}
                 />
-                <span
-                  className="material-symbols-outlined sc2-rank-glyph"
-                  aria-hidden="true"
-                >
-                  {getTopicIcon(r.slug)}
-                </span>
                 <span className="sc2-rank-label">{r.label}</span>
                 <span
                   className={`sc2-rank-score${r.score === 0 ? ' zero' : ''}`}

--- a/apps/explorer/src/services/platformMarketService.ts
+++ b/apps/explorer/src/services/platformMarketService.ts
@@ -22,6 +22,19 @@ export interface PlatformVaultData {
   userPnlPct: number | null
 }
 
+// On-chain atom images may be `ipfs://CID` URIs the browser can't fetch
+// directly — rewrite them to an HTTP gateway so an <img> loads. Shared by the
+// platforms list and the right rail so both resolve the same fallback image.
+export function resolvePlatformImage(url?: string): string | undefined {
+  if (!url) return undefined
+  if (url.startsWith('ipfs://')) {
+    return `https://ipfs.io/ipfs/${url
+      .slice('ipfs://'.length)
+      .replace(/^ipfs\//, '')}`
+  }
+  return url
+}
+
 // ── GraphQL ──
 
 const GET_ATOM_VAULT_STATS = `

--- a/apps/extension/components/modals/reward/BatchRewardContent.tsx
+++ b/apps/extension/components/modals/reward/BatchRewardContent.tsx
@@ -16,7 +16,13 @@
 import { FeedCardView, UserBadge, VerbTag } from "@0xsofia/design-system"
 import type { IntentionSlug, UserBadgeTier } from "@0xsofia/design-system"
 import { useGetTriplesWithPositionsQuery } from "@0xsofia/graphql"
-import { Fragment, useEffect, useRef, useState, type CSSProperties } from "react"
+import {
+  Fragment,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties
+} from "react"
 
 import {
   useBatchRewards,
@@ -24,6 +30,7 @@ import {
   useTrustCircle,
   useWalletFromStorage
 } from "~/hooks"
+import { INTENTION_ICONS } from "~/lib/config/intentionIcons"
 import { TOPIC_COLORS, TOPIC_LABELS } from "~/lib/config/topicConfig"
 import type { CartItemRecord } from "~/lib/database"
 import { createHookLogger, getFaviconUrl } from "~/lib/utils"
@@ -47,6 +54,13 @@ const BADGE_IMAGES: Record<UserBadgeTier, string> = {
 const logger = createHookLogger("BatchRewardContent")
 const OG_BASE_URL = "https://sofia-og.vercel.app"
 
+/** Leading intention glyph for a feed verb chip — same helper used by the
+ *  Trust Circle feed so every verb reads the same across the side panel. */
+const verbIcon = (type: IntentionType) => {
+  const Icon = INTENTION_ICONS[type]
+  return Icon ? <Icon className="fc-verb-ic" /> : undefined
+}
+
 const TIER_ORDER = ["pioneer", "explorer", "contributor"] as const
 
 type Phase = "loading" | "animation"
@@ -69,7 +83,11 @@ const ordinal = (n: number): string => {
 }
 
 const avInitials = (label: string): string =>
-  (label || "?").replace(/^0x/i, "").replace(/[^a-z0-9]/gi, "").slice(0, 2).toUpperCase() || "?"
+  (label || "?")
+    .replace(/^0x/i, "")
+    .replace(/[^a-z0-9]/gi, "")
+    .slice(0, 2)
+    .toUpperCase() || "?"
 
 export interface BatchRewardContentProps {
   /** Items submitted in the batch. */
@@ -403,7 +421,8 @@ const BatchRewardContent = ({
                     }
                     alt=""
                     onError={(e) => {
-                      ;(e.target as HTMLImageElement).style.visibility = "hidden"
+                      ;(e.target as HTMLImageElement).style.visibility =
+                        "hidden"
                     }}
                   />
                 </div>
@@ -495,16 +514,34 @@ const BatchRewardContent = ({
       ? TOPIC_LABELS[item.interestContext]
       : null
     const circleStack = circleAccounts.slice(0, 3)
-    const circleOverflow = Math.max(0, circleAccounts.length - circleStack.length)
+    const circleOverflow = Math.max(
+      0,
+      circleAccounts.length - circleStack.length
+    )
     const ladder: {
       tier: UserBadgeTier
       label: string
       rank: string
       color: string
     }[] = [
-      { tier: "pioneer", label: "Pioneer", rank: "1st", color: "var(--rc-pioneer)" },
-      { tier: "explorer", label: "Explorer", rank: "2–10", color: "var(--rc-explorer)" },
-      { tier: "contributor", label: "Contributor", rank: "11+", color: "var(--rc-contributor)" }
+      {
+        tier: "pioneer",
+        label: "Pioneer",
+        rank: "1st",
+        color: "var(--rc-pioneer)"
+      },
+      {
+        tier: "explorer",
+        label: "Explorer",
+        rank: "2–10",
+        color: "var(--rc-explorer)"
+      },
+      {
+        tier: "contributor",
+        label: "Contributor",
+        rank: "11+",
+        color: "var(--rc-contributor)"
+      }
     ]
 
     return (
@@ -559,7 +596,13 @@ const BatchRewardContent = ({
                 domain={hostFromUrl(item.url)}
                 verbs={
                   intentEntry
-                    ? [{ label: intentEntry.label, color: intentEntry.color }]
+                    ? [
+                        {
+                          label: intentEntry.label,
+                          color: intentEntry.color,
+                          icon: intentKey ? verbIcon(intentKey) : undefined
+                        }
+                      ]
                     : []
                 }
                 up={-1}
@@ -644,7 +687,9 @@ const BatchRewardContent = ({
                       </span>
                     ))}
                     {circleOverflow > 0 && (
-                      <span className="rc-av rc-av--more">+{circleOverflow}</span>
+                      <span className="rc-av rc-av--more">
+                        +{circleOverflow}
+                      </span>
                     )}
                   </span>
                 )}
@@ -729,7 +774,13 @@ const BatchRewardContent = ({
                   domain={hostFromUrl(item.url)}
                   verbs={
                     intentEntry
-                      ? [{ label: intentEntry.label, color: intentEntry.color }]
+                      ? [
+                          {
+                            label: intentEntry.label,
+                            color: intentEntry.color,
+                            icon: intentKey ? verbIcon(intentKey) : undefined
+                          }
+                        ]
                       : []
                   }
                   up={-1}

--- a/apps/extension/components/modals/weight/WeightRewardTicket.tsx
+++ b/apps/extension/components/modals/weight/WeightRewardTicket.tsx
@@ -3,11 +3,15 @@
  * reward is claimed: ticket header, the list of marked pages, the Pioneer /
  * Explorer / Contributor tier ladder, the Gold ledger, and share/close actions.
  */
-import { UserBadge } from "@0xsofia/design-system"
+import { TopicPill, UserBadge } from "@0xsofia/design-system"
 
 import type { ModalTriplet } from "~/hooks"
 import { EXPLORER_URLS } from "~/lib/config/chainConfig"
-import { contextLabel } from "~/lib/config/contextDisplay"
+import {
+  contextColor,
+  contextIcon,
+  contextLabel
+} from "~/lib/config/contextDisplay"
 
 import contributorBadge from "../../ui/img/badges/contributor.png"
 import explorerBadge from "../../ui/img/badges/explorer.png"
@@ -91,9 +95,13 @@ export default function WeightRewardTicket({
                   ).map((slug) => {
                     const l = contextLabel(slug)
                     return l ? (
-                      <span className="rc-mark-ctx" key={slug}>
-                        {l}
-                      </span>
+                      <TopicPill
+                        key={slug}
+                        color={contextColor(slug)}
+                        label={l}
+                        glyph={contextIcon(slug)}
+                        size="sm"
+                      />
                     ) : null
                   })}
                   <span className="rc-mark-host">{hostFromUrl(t.url)}</span>
@@ -107,8 +115,14 @@ export default function WeightRewardTicket({
             {TIER_ORDER.map((tier) => {
               const earned = discoveryReward.status.toLowerCase() === tier
               return (
-                <div className={`rc-tier${earned ? " is-earned" : ""}`} key={tier}>
-                  <UserBadge tier={tier} iconUrl={BADGE_IMAGES[tier]} size={32} />
+                <div
+                  className={`rc-tier${earned ? " is-earned" : ""}`}
+                  key={tier}>
+                  <UserBadge
+                    tier={tier}
+                    iconUrl={BADGE_IMAGES[tier]}
+                    size={32}
+                  />
                   <span className="rc-tier-label">
                     {tier.charAt(0).toUpperCase() + tier.slice(1)}
                   </span>

--- a/apps/extension/components/pages/circles-tabs/CircleFeedTab.tsx
+++ b/apps/extension/components/pages/circles-tabs/CircleFeedTab.tsx
@@ -1,10 +1,11 @@
 import {
   FeedCardView,
+  TopicPill,
   type FeedCardTopic,
   type FeedCardVerb
 } from "@0xsofia/design-system"
 import { useFindUserPositionsOnTriplesQuery } from "@0xsofia/graphql"
-import { useMemo, useState, type CSSProperties } from "react"
+import { useMemo, useState } from "react"
 import { getAddress } from "viem"
 
 import {
@@ -23,6 +24,7 @@ import {
   TOPIC_FILTER_OPTIONS,
   VERB_FILTER_OPTIONS
 } from "~/lib/config/filterOptions"
+import { INTENTION_ICONS } from "~/lib/config/intentionIcons"
 import { getFaviconUrl } from "~/lib/utils"
 import type { IntentionPurpose } from "~/types/discovery"
 import type { IntentionType } from "~/types/intentionCategories"
@@ -59,6 +61,13 @@ const formatTimestamp = (timestamp: string) => {
   if (diffHours < 24) return `${diffHours}h ago`
   if (diffDays < 7) return `${diffDays}d ago`
   return date.toLocaleDateString()
+}
+
+/** Leading intention glyph for a feed verb chip — mirrors the Stats panel,
+ *  Amplify Mark chips, and WeightModal so every verb reads the same. */
+const verbIcon = (type: IntentionType) => {
+  const Icon = INTENTION_ICONS[type]
+  return Icon ? <Icon className="fc-verb-ic" /> : undefined
 }
 
 type ViewState =
@@ -338,9 +347,7 @@ const CircleFeedTab = ({ onViewMembers }: CircleFeedTabProps = {}) => {
       )
     ).then((results) => {
       if (results.some(Boolean)) {
-        setLocalVotes((prev) =>
-          new Map(prev).set(group.groupKey, voteAction)
-        )
+        setLocalVotes((prev) => new Map(prev).set(group.groupKey, voteAction))
       }
     })
   }
@@ -437,7 +444,10 @@ const CircleFeedTab = ({ onViewMembers }: CircleFeedTabProps = {}) => {
           />
           <Breadcrumb
             crumbs={[
-              { label: "Circles", onClick: () => setViewState({ type: "feed" }) },
+              {
+                label: "Circles",
+                onClick: () => setViewState({ type: "feed" })
+              },
               { label: viewState.label }
             ]}
           />
@@ -599,7 +609,9 @@ const CircleFeedTab = ({ onViewMembers }: CircleFeedTabProps = {}) => {
               group.contexts.length > 0
                 ? group.contexts.some((c) => c.opposeTermId)
                 : group.intentions.some((i) => i.counterTermId)
-            const hasVotableTriple = group.intentions.some((i) => i.tripleTermId)
+            const hasVotableTriple = group.intentions.some(
+              (i) => i.tripleTermId
+            )
 
             // Topic/category context pills — the triples a vote stakes on.
             const topics: FeedCardTopic[] = group.contextSlugs.flatMap(
@@ -618,7 +630,8 @@ const CircleFeedTab = ({ onViewMembers }: CircleFeedTabProps = {}) => {
                 ? []
                 : group.intentions.map((i) => ({
                     label: INTENTION_CONFIG[i.intentionType].label,
-                    color: INTENTION_CONFIG[i.intentionType].color
+                    color: INTENTION_CONFIG[i.intentionType].color,
+                    icon: verbIcon(i.intentionType)
                   }))
 
             return (
@@ -685,16 +698,11 @@ const CircleFeedTab = ({ onViewMembers }: CircleFeedTabProps = {}) => {
                   />
                 )}
                 renderTopic={(t) => (
-                  <span
-                    className="sf-topic-pill"
-                    style={{ "--pill-color": t.color } as CSSProperties}>
-                    <span
-                      className="material-symbols-outlined sf-topic-pill-glyph"
-                      aria-hidden>
-                      {contextIcon(t.id)}
-                    </span>
-                    {t.label}
-                  </span>
+                  <TopicPill
+                    color={t.color}
+                    label={t.label}
+                    glyph={contextIcon(t.id)}
+                  />
                 )}
               />
             )

--- a/apps/extension/components/pages/core-tabs/HistoryTab.tsx
+++ b/apps/extension/components/pages/core-tabs/HistoryTab.tsx
@@ -1,4 +1,7 @@
-import { useState, useMemo } from 'react'
+import { Trash2 } from "lucide-react"
+import { useMemo, useState } from "react"
+import { getAddress } from "viem"
+
 import {
   getCertificationForUrl,
   useIntuitionTriplets,
@@ -6,56 +9,73 @@ import {
   useUserCertifications,
   useWalletFromStorage,
   useWeightOnChain
-} from '~/hooks'
-import BookmarkButton from '../../ui/BookmarkButton'
-import FilterDropdown from '../../ui/FilterDropdown'
-import WeightModal from '../../modals/WeightModal'
-import SofiaLoader from '../../ui/SofiaLoader'
-import { BondingCurveChart } from '../../charts/BondingCurveChart'
-import { getAddress } from 'viem'
-import { getTripleUrl, getAtomUrl } from '~/lib/utils'
+} from "~/hooks"
+import {
+  contextColor,
+  contextIcon,
+  contextLabel
+} from "~/lib/config/contextDisplay"
 import {
   TOPIC_FILTER_OPTIONS,
   VERB_FILTER_OPTIONS
-} from '~/lib/config/filterOptions'
-import { TOPIC_COLORS, TOPIC_LABELS } from '~/lib/config/topicConfig'
-import ArrowTopRightIcon from '../../ui/icons/arrow-top-right-thick.svg'
-import LinkVariantIcon from '../../ui/icons/link-variant.svg'
-import { Trash2 } from 'lucide-react'
-import '../../styles/CoreComponents.css'
-import '../../styles/CorePage.css'
-import '../../styles/CommonPage.css'
-import '../../styles/CategoryStyles.css'
-import { createHookLogger, getFaviconUrl } from '~/lib/utils'
-import { predicateLabelToIntentionType } from '~/types/intentionCategories'
-import type { IntentionType } from '~/types/intentionCategories'
-import { VerbTag } from '@0xsofia/design-system'
+} from "~/lib/config/filterOptions"
+import { INTENTION_ICONS } from "~/lib/config/intentionIcons"
+import { getAtomUrl, getTripleUrl } from "~/lib/utils"
 
-const logger = createHookLogger('HistoryTab')
+import { BondingCurveChart } from "../../charts/BondingCurveChart"
+import WeightModal from "../../modals/WeightModal"
+import BookmarkButton from "../../ui/BookmarkButton"
+import FilterDropdown from "../../ui/FilterDropdown"
+import ArrowTopRightIcon from "../../ui/icons/arrow-top-right-thick.svg"
+import LinkVariantIcon from "../../ui/icons/link-variant.svg"
+import SofiaLoader from "../../ui/SofiaLoader"
+
+import "../../styles/CoreComponents.css"
+import "../../styles/CorePage.css"
+import "../../styles/CommonPage.css"
+import "../../styles/CategoryStyles.css"
+
+import { TopicPill, VerbTag } from "@0xsofia/design-system"
+
+import { createHookLogger, getFaviconUrl } from "~/lib/utils"
+import { predicateLabelToIntentionType } from "~/types/intentionCategories"
+import type { IntentionType } from "~/types/intentionCategories"
+
+const logger = createHookLogger("HistoryTab")
 
 interface HistoryTabProps {
   expandedTriplet: { tripletId: string } | null
   setExpandedTriplet: (value: { tripletId: string } | null) => void
 }
 
-type SortOption = 'newest' | 'oldest' | 'highest-shares' | 'highest-support' | 'a-z'
+type SortOption =
+  | "newest"
+  | "oldest"
+  | "highest-shares"
+  | "highest-support"
+  | "a-z"
 
 const SORT_OPTIONS: { value: SortOption; label: string }[] = [
-  { value: 'newest', label: 'Newest' },
-  { value: 'oldest', label: 'Oldest' },
-  { value: 'highest-shares', label: 'Shares' },
-  { value: 'highest-support', label: 'Support' },
-  { value: 'a-z', label: 'A-Z' }
+  { value: "newest", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
+  { value: "highest-shares", label: "Shares" },
+  { value: "highest-support", label: "Support" },
+  { value: "a-z", label: "A-Z" }
 ]
 
-const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) => {
+const HistoryTab = ({
+  expandedTriplet,
+  setExpandedTriplet
+}: HistoryTabProps) => {
   const { triplets, isLoading, refreshFromAPI } = useIntuitionTriplets()
   const { depositWithPool } = useWeightOnChain()
   const { walletAddress: address } = useWalletFromStorage()
   const { redeemPosition } = useRedeemTriple()
 
   // Stake modal state
-  const [selectedStakeTriplet, setSelectedStakeTriplet] = useState<typeof triplets[0] | null>(null)
+  const [selectedStakeTriplet, setSelectedStakeTriplet] = useState<
+    (typeof triplets)[0] | null
+  >(null)
   const [isStakeModalOpen, setIsStakeModalOpen] = useState(false)
   const [isProcessingStake, setIsProcessingStake] = useState(false)
   const [transactionSuccess, setTransactionSuccess] = useState(false)
@@ -64,12 +84,14 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
   const [defaultCurve, setDefaultCurve] = useState<1 | 2>(2)
 
   // Chart curve selection state (per triplet)
-  const [selectedChartCurve, setSelectedChartCurve] = useState<{ [tripletId: string]: 1 | 2 }>({})
+  const [selectedChartCurve, setSelectedChartCurve] = useState<{
+    [tripletId: string]: 1 | 2
+  }>({})
 
-  const [sortBy, setSortBy] = useState<SortOption>('newest')
-  const [searchQuery, setSearchQuery] = useState('')
-  const [verbFilter, setVerbFilter] = useState<IntentionType | 'all'>('all')
-  const [topicFilter, setTopicFilter] = useState<string>('all')
+  const [sortBy, setSortBy] = useState<SortOption>("newest")
+  const [searchQuery, setSearchQuery] = useState("")
+  const [verbFilter, setVerbFilter] = useState<IntentionType | "all">("all")
+  const [topicFilter, setTopicFilter] = useState<string>("all")
 
   // On-chain "in context of" topics — same source EchoesTab / Bookmark /
   // the explorer feed use, so the Verb + Topic filters stay coherent.
@@ -80,17 +102,17 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
   const [redeemedIds, setRedeemedIds] = useState<Set<string>>(() => new Set())
 
   const handleRedeem = async (termId: string) => {
-    setRedeemingIds(prev => new Set(prev).add(termId))
+    setRedeemingIds((prev) => new Set(prev).add(termId))
     try {
       const result = await redeemPosition(termId)
       if (!result.success) {
         alert(`Redeem failed: ${result.error}`)
         return
       }
-      setRedeemedIds(prev => new Set(prev).add(termId))
+      setRedeemedIds((prev) => new Set(prev).add(termId))
       refreshFromAPI()
     } finally {
-      setRedeemingIds(prev => {
+      setRedeemingIds((prev) => {
         const next = new Set(prev)
         next.delete(termId)
         return next
@@ -99,28 +121,31 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
   }
 
   const filteredAndSortedTriplets = useMemo(() => {
-    let filtered = redeemedIds.size > 0
-      ? triplets.filter(t => !redeemedIds.has(t.id))
-      : [...triplets]
+    let filtered =
+      redeemedIds.size > 0
+        ? triplets.filter((t) => !redeemedIds.has(t.id))
+        : [...triplets]
 
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase()
-      filtered = filtered.filter(triplet =>
-        triplet.triplet.object.toLowerCase().includes(query) ||
-        triplet.triplet.predicate.toLowerCase().includes(query) ||
-        (triplet.url && triplet.url.toLowerCase().includes(query))
-      )
-    }
-
-    if (verbFilter !== 'all') {
       filtered = filtered.filter(
-        triplet =>
-          predicateLabelToIntentionType(triplet.triplet.predicate) === verbFilter
+        (triplet) =>
+          triplet.triplet.object.toLowerCase().includes(query) ||
+          triplet.triplet.predicate.toLowerCase().includes(query) ||
+          (triplet.url && triplet.url.toLowerCase().includes(query))
       )
     }
 
-    if (topicFilter !== 'all') {
-      filtered = filtered.filter(triplet => {
+    if (verbFilter !== "all") {
+      filtered = filtered.filter(
+        (triplet) =>
+          predicateLabelToIntentionType(triplet.triplet.predicate) ===
+          verbFilter
+      )
+    }
+
+    if (topicFilter !== "all") {
+      filtered = filtered.filter((triplet) => {
         if (!triplet.url) return false
         const entry = getCertificationForUrl(certifications, triplet.url)
         return entry?.interestContexts?.includes(topicFilter) ?? false
@@ -128,26 +153,45 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
     }
 
     switch (sortBy) {
-      case 'highest-shares':
-        return filtered.sort((a, b) => (b.position?.offsetProgressive || 0) - (a.position?.offsetProgressive || 0))
-      case 'highest-support':
-        return filtered.sort((a, b) => (b.position?.linear || 0) - (a.position?.linear || 0))
-      case 'newest':
+      case "highest-shares":
+        return filtered.sort(
+          (a, b) =>
+            (b.position?.offsetProgressive || 0) -
+            (a.position?.offsetProgressive || 0)
+        )
+      case "highest-support":
+        return filtered.sort(
+          (a, b) => (b.position?.linear || 0) - (a.position?.linear || 0)
+        )
+      case "newest":
         return filtered.sort((a, b) => b.timestamp - a.timestamp)
-      case 'oldest':
+      case "oldest":
         return filtered.sort((a, b) => a.timestamp - b.timestamp)
-      case 'a-z':
-        return filtered.sort((a, b) => a.triplet.object.localeCompare(b.triplet.object))
+      case "a-z":
+        return filtered.sort((a, b) =>
+          a.triplet.object.localeCompare(b.triplet.object)
+        )
       default:
         return filtered
     }
-  }, [triplets, sortBy, searchQuery, redeemedIds, verbFilter, topicFilter, certifications])
+  }, [
+    triplets,
+    sortBy,
+    searchQuery,
+    redeemedIds,
+    verbFilter,
+    topicFilter,
+    certifications
+  ])
 
   const handleViewOnPortal = (tripletId: string) => {
-    window.open(getTripleUrl(tripletId), '_blank')
+    window.open(getTripleUrl(tripletId), "_blank")
   }
 
-  const handleStakeClick = (triplet: typeof triplets[0], curve: 1 | 2 = 2) => {
+  const handleStakeClick = (
+    triplet: (typeof triplets)[0],
+    curve: 1 | 2 = 2
+  ) => {
     setSelectedStakeTriplet(triplet)
     setDefaultCurve(curve)
     setIsStakeModalOpen(true)
@@ -162,7 +206,9 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
     setTransactionHash(undefined)
   }
 
-  const handleStakeSubmit = async (customWeights?: (bigint | null)[]): Promise<void> => {
+  const handleStakeSubmit = async (
+    customWeights?: (bigint | null)[]
+  ): Promise<void> => {
     if (!selectedStakeTriplet || !address) return
     const weight = customWeights?.[0] || BigInt(Math.floor(0.5 * 1e18))
 
@@ -170,18 +216,24 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
       setIsProcessingStake(true)
       setTransactionError(undefined)
 
-      const result = await depositWithPool(selectedStakeTriplet.id, weight, BigInt(defaultCurve))
+      const result = await depositWithPool(
+        selectedStakeTriplet.id,
+        weight,
+        BigInt(defaultCurve)
+      )
 
       if (result.success) {
         setTransactionHash(result.txHash)
         setTransactionSuccess(true)
         await refreshFromAPI()
       } else {
-        setTransactionError(result.error || 'Transaction failed')
+        setTransactionError(result.error || "Transaction failed")
       }
     } catch (error) {
-      logger.error('Failed to stake', error)
-      setTransactionError(error instanceof Error ? error.message : 'Transaction failed')
+      logger.error("Failed to stake", error)
+      setTransactionError(
+        error instanceof Error ? error.message : "Transaction failed"
+      )
     } finally {
       setIsProcessingStake(false)
     }
@@ -216,8 +268,7 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
           {searchQuery && (
             <button
               className="category-search-clear"
-              onClick={() => setSearchQuery('')}
-            >
+              onClick={() => setSearchQuery("")}>
               x
             </button>
           )}
@@ -229,16 +280,14 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
       <div
         className="scope-toggle echoes-sort-toggle"
         role="group"
-        aria-label="Sort history by"
-      >
-        {SORT_OPTIONS.map(option => (
+        aria-label="Sort history by">
+        {SORT_OPTIONS.map((option) => (
           <button
             key={option.value}
             type="button"
-            className={`scope-btn ${sortBy === option.value ? 'active' : ''}`}
+            className={`scope-btn ${sortBy === option.value ? "active" : ""}`}
             aria-pressed={sortBy === option.value}
-            onClick={() => setSortBy(option.value)}
-          >
+            onClick={() => setSortBy(option.value)}>
             {option.label}
           </button>
         ))}
@@ -252,7 +301,7 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
         <FilterDropdown
           label="Intention"
           value={verbFilter}
-          onChange={(id) => setVerbFilter(id as IntentionType | 'all')}
+          onChange={(id) => setVerbFilter(id as IntentionType | "all")}
           options={VERB_FILTER_OPTIONS}
         />
         <FilterDropdown
@@ -268,8 +317,11 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
         <div className="history-list">
           {filteredAndSortedTriplets.map((tripletItem) => {
             const isExpanded = expandedTriplet?.tripletId === tripletItem.id
-            const intent = predicateLabelToIntentionType(tripletItem.triplet.predicate)
-            const titleLabel = tripletItem.triplet.object || tripletItem.url || ''
+            const intent = predicateLabelToIntentionType(
+              tripletItem.triplet.predicate
+            )
+            const titleLabel =
+              tripletItem.triplet.object || tripletItem.url || ""
             const contexts = tripletItem.url
               ? getCertificationForUrl(certifications, tripletItem.url)
                   ?.interestContexts ?? []
@@ -278,15 +330,15 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
             return (
               <div
                 key={tripletItem.id}
-                className={`url-row on-chain${isExpanded ? ' expanded' : ''}`}
-              >
+                className={`url-row on-chain${isExpanded ? " expanded" : ""}`}>
                 <button
                   type="button"
                   className="url-row-main"
                   onClick={() =>
-                    setExpandedTriplet(isExpanded ? null : { tripletId: tripletItem.id })
-                  }
-                >
+                    setExpandedTriplet(
+                      isExpanded ? null : { tripletId: tripletItem.id }
+                    )
+                  }>
                   {tripletItem.url && (
                     <img
                       src={getFaviconUrl(tripletItem.url, 16)}
@@ -294,139 +346,167 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
                       className="url-favicon"
                       onError={(e) => {
                         const target = e.target as HTMLImageElement
-                        target.style.display = 'none'
+                        target.style.display = "none"
                       }}
                     />
                   )}
                   <div className="url-info">
                     <span className="url-title">{titleLabel}</span>
                     <div className="url-meta">
-                      {intent && (
-                        <VerbTag intent={intent} label={intent} />
-                      )}
-                      {contexts.map((slug) => {
-                        const label = TOPIC_LABELS[slug] || slug
-                        const color = TOPIC_COLORS[slug] || 'var(--ds-accent)'
-                        return (
-                          <span
-                            key={`ctx-${slug}`}
-                            className="cert-badge cert-badge--context"
-                            style={{ color, borderColor: color }}
-                            title={`Marked in context of ${label}`}
-                          >
-                            {label}
-                          </span>
-                        )
-                      })}
+                      {intent &&
+                        (() => {
+                          const Icon = INTENTION_ICONS[intent]
+                          return (
+                            <VerbTag
+                              intent={intent}
+                              label={intent}
+                              icon={
+                                Icon ? (
+                                  <Icon className="fc-verb-ic" />
+                                ) : undefined
+                              }
+                            />
+                          )
+                        })()}
+                      {contexts.map((slug) => (
+                        <TopicPill
+                          key={`ctx-${slug}`}
+                          color={contextColor(slug)}
+                          label={contextLabel(slug) ?? slug}
+                          glyph={contextIcon(slug)}
+                          size="sm"
+                          title={`Marked in context of ${contextLabel(slug) ?? slug}`}
+                        />
+                      ))}
                       {tripletItem.timestamp ? (
                         <span className="url-date">
-                          {new Date(tripletItem.timestamp).toLocaleDateString('en-US', {
-                            month: 'short',
-                            day: 'numeric'
-                          })}
+                          {new Date(tripletItem.timestamp).toLocaleDateString(
+                            "en-US",
+                            {
+                              month: "short",
+                              day: "numeric"
+                            }
+                          )}
                         </span>
                       ) : null}
                     </div>
                   </div>
-                  <span className={`url-chevron${isExpanded ? ' expanded' : ''}`}>▾</span>
+                  <span
+                    className={`url-chevron${isExpanded ? " expanded" : ""}`}>
+                    ▾
+                  </span>
                 </button>
 
-                {isExpanded && (() => {
-                  const currentCurve = selectedChartCurve[tripletItem.id] || 2
-                  const checksumAddress = address ? getAddress(address) : undefined
+                {isExpanded &&
+                  (() => {
+                    const currentCurve = selectedChartCurve[tripletItem.id] || 2
+                    const checksumAddress = address
+                      ? getAddress(address)
+                      : undefined
 
-                  return (
-                    <div className="history-row-detail">
-                      <div className="history-curve-selector">
-                        <button
-                          type="button"
-                          className={`sort-btn ${currentCurve === 1 ? 'active' : ''}`}
-                          onClick={() => setSelectedChartCurve(prev => ({ ...prev, [tripletItem.id]: 1 }))}
-                        >
-                          Linear (Support)
-                        </button>
-                        <button
-                          type="button"
-                          className={`sort-btn ${currentCurve === 2 ? 'active' : ''}`}
-                          onClick={() => setSelectedChartCurve(prev => ({ ...prev, [tripletItem.id]: 2 }))}
-                        >
-                          Offset (Shares)
-                        </button>
-                      </div>
+                    return (
+                      <div className="history-row-detail">
+                        <div className="history-curve-selector">
+                          <button
+                            type="button"
+                            className={`sort-btn ${currentCurve === 1 ? "active" : ""}`}
+                            onClick={() =>
+                              setSelectedChartCurve((prev) => ({
+                                ...prev,
+                                [tripletItem.id]: 1
+                              }))
+                            }>
+                            Linear (Support)
+                          </button>
+                          <button
+                            type="button"
+                            className={`sort-btn ${currentCurve === 2 ? "active" : ""}`}
+                            onClick={() =>
+                              setSelectedChartCurve((prev) => ({
+                                ...prev,
+                                [tripletItem.id]: 2
+                              }))
+                            }>
+                            Offset (Shares)
+                          </button>
+                        </div>
 
-                      <BondingCurveChart
-                        tripleId={tripletItem.id}
-                        curveId={currentCurve}
-                        walletAddress={checksumAddress}
-                      />
-
-                      <div className="history-actions">
-                        <button
-                          type="button"
-                          className="portal-button"
-                          onClick={() => handleStakeClick(tripletItem, 2)}
-                        >
-                          <img src={ArrowTopRightIcon} alt="" className="portal-button-icon" />
-                          Stake
-                        </button>
-                        <button
-                          type="button"
-                          className="portal-button"
-                          onClick={() => handleViewOnPortal(tripletItem.id)}
-                          title="View on Intuition Portal"
-                        >
-                          <img src={LinkVariantIcon} alt="" className="portal-button-icon" />
-                          Portal
-                        </button>
-                        <BookmarkButton
-                          triplet={tripletItem.triplet}
-                          sourceInfo={{
-                            sourceType: 'published',
-                            sourceId: tripletItem.id,
-                            url: tripletItem.url,
-                            description: tripletItem.description,
-                            sourceMessageId: tripletItem.id
-                          }}
-                          className="portal-button"
+                        <BondingCurveChart
+                          tripleId={tripletItem.id}
+                          curveId={currentCurve}
+                          walletAddress={checksumAddress}
                         />
-                        <button
-                          type="button"
-                          className="portal-button portal-button--danger portal-button--icon"
-                          onClick={() => handleRedeem(tripletItem.id)}
-                          disabled={redeemingIds.has(tripletItem.id)}
-                          title="Redeem position"
-                          aria-label="Redeem position"
-                        >
-                          {redeemingIds.has(tripletItem.id) ? (
-                            '...'
-                          ) : (
-                            <Trash2 size={15} aria-hidden="true" />
-                          )}
-                        </button>
-                      </div>
 
-                      {tripletItem.url ? (
-                        <a
-                          href={tripletItem.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="history-detail-link"
-                        >
-                          {tripletItem.url}
-                        </a>
-                      ) : (
-                        <a
-                          href={getAtomUrl(tripletItem.objectTermId)}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="history-detail-link"
-                        >
-                          View "{tripletItem.triplet.object}" on Portal
-                        </a>
-                      )}
-                    </div>
-                  )
-                })()}
+                        <div className="history-actions">
+                          <button
+                            type="button"
+                            className="portal-button"
+                            onClick={() => handleStakeClick(tripletItem, 2)}>
+                            <img
+                              src={ArrowTopRightIcon}
+                              alt=""
+                              className="portal-button-icon"
+                            />
+                            Stake
+                          </button>
+                          <button
+                            type="button"
+                            className="portal-button"
+                            onClick={() => handleViewOnPortal(tripletItem.id)}
+                            title="View on Intuition Portal">
+                            <img
+                              src={LinkVariantIcon}
+                              alt=""
+                              className="portal-button-icon"
+                            />
+                            Portal
+                          </button>
+                          <BookmarkButton
+                            triplet={tripletItem.triplet}
+                            sourceInfo={{
+                              sourceType: "published",
+                              sourceId: tripletItem.id,
+                              url: tripletItem.url,
+                              description: tripletItem.description,
+                              sourceMessageId: tripletItem.id
+                            }}
+                            className="portal-button"
+                          />
+                          <button
+                            type="button"
+                            className="portal-button portal-button--danger portal-button--icon"
+                            onClick={() => handleRedeem(tripletItem.id)}
+                            disabled={redeemingIds.has(tripletItem.id)}
+                            title="Redeem position"
+                            aria-label="Redeem position">
+                            {redeemingIds.has(tripletItem.id) ? (
+                              "..."
+                            ) : (
+                              <Trash2 size={15} aria-hidden="true" />
+                            )}
+                          </button>
+                        </div>
+
+                        {tripletItem.url ? (
+                          <a
+                            href={tripletItem.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="history-detail-link">
+                            {tripletItem.url}
+                          </a>
+                        ) : (
+                          <a
+                            href={getAtomUrl(tripletItem.objectTermId)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="history-detail-link">
+                            View "{tripletItem.triplet.object}" on Portal
+                          </a>
+                        )}
+                      </div>
+                    )
+                  })()}
               </div>
             )
           })}
@@ -450,17 +530,26 @@ const HistoryTab = ({ expandedTriplet, setExpandedTriplet }: HistoryTabProps) =>
 
       <WeightModal
         isOpen={isStakeModalOpen}
-        triplets={selectedStakeTriplet ? [{
-          id: selectedStakeTriplet.id,
-          triplet: {
-            subject: selectedStakeTriplet.triplet.subject,
-            predicate: selectedStakeTriplet.triplet.predicate,
-            object: selectedStakeTriplet.triplet.object
-          },
-          description: '',
-          url: selectedStakeTriplet.url || '',
-          intention: predicateLabelToIntentionType(selectedStakeTriplet.triplet.predicate) || undefined
-        }] : []}
+        triplets={
+          selectedStakeTriplet
+            ? [
+                {
+                  id: selectedStakeTriplet.id,
+                  triplet: {
+                    subject: selectedStakeTriplet.triplet.subject,
+                    predicate: selectedStakeTriplet.triplet.predicate,
+                    object: selectedStakeTriplet.triplet.object
+                  },
+                  description: "",
+                  url: selectedStakeTriplet.url || "",
+                  intention:
+                    predicateLabelToIntentionType(
+                      selectedStakeTriplet.triplet.predicate
+                    ) || undefined
+                }
+              ]
+            : []
+        }
         isProcessing={isProcessingStake}
         transactionSuccess={transactionSuccess}
         transactionError={transactionError}

--- a/apps/extension/components/styles/CategorisationDropdown.css
+++ b/apps/extension/components/styles/CategorisationDropdown.css
@@ -53,13 +53,36 @@
   min-width: 0;
 }
 
-/* ── chip (selected tag) — a removable variant of the shared .fc-verb-tag.
-   The base look (ink text, colored icon, subtle fill, radius) comes from
-   .fc-verb-tag; this modifier only adds room + the × button. Topic chips get
-   their colored border from --verb-color (verbs get it from the intent rule). */
+/* ── chip (selected tag) — SELF-CONTAINED dropdown chip.
+   The dropdown intentionally keeps its own look (ink text + subtle intent
+   fill + colored icon/border), decoupled from the unified `.fc-verb-tag`
+   pill so the pill unification doesn't alter the combobox. `--verb-color`
+   (the intent/topic color) is set inline by CategorisationDropdown. */
 .ext-cat-chip {
-  padding-right: 5px;
-  border-color: var(--verb-color, var(--ds-border));
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  line-height: 1;
+  color: var(--ds-ink);
+  padding: 5px 5px 5px 11px;
+  border-radius: 5px;
+  border: 1px solid var(--verb-color, var(--ds-border));
+  background: color-mix(
+    in srgb,
+    var(--verb-color, transparent) 12%,
+    transparent
+  );
+}
+.ext-cat-chip .fc-verb-ic {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  color: var(--verb-color, currentColor);
 }
 .ext-cat-chip-glyph {
   font-family: "Material Symbols Outlined", sans-serif;

--- a/apps/extension/components/styles/CommonPage.css
+++ b/apps/extension/components/styles/CommonPage.css
@@ -800,31 +800,10 @@
   align-items: center;
 }
 
-.cert-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 5px 11px;
-  border-radius: 6px;
-  color: #000;
-  font-family: var(--font-family-mono, "JetBrains Mono", monospace);
-  font-size: 10px;
-  font-weight: 700;
-  line-height: 1;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  white-space: nowrap;
-  flex-shrink: 0;
-  border: none;
-}
-
-/* Topic/context badge — same size & font as the verb badge, but the
-   topic color applies to the text + border instead of the background
-   (color + borderColor injected inline from the topic palette). */
-.cert-badge--context {
-  background: transparent;
-  border: 1px solid currentColor;
-}
+/* `.cert-badge` (filled verb badge) and `.cert-badge--context` (outlined topic
+   badge) were removed during the pill unification. UrlRow + HistoryTab now
+   render the shared DS <VerbTag> / <TopicPill>. The `.cert-badges` flex
+   container above is kept — it still wraps those pills. */
 
 .empty-urls {
   text-align: center;
@@ -1097,10 +1076,6 @@
   width: 12px;
   height: 12px;
   margin-left: 4px;
-}
-
-.cert-badge.on-chain {
-  box-shadow: none;
 }
 
 .amplify-btn .loading-text {

--- a/apps/extension/components/styles/ContextPicker.css
+++ b/apps/extension/components/styles/ContextPicker.css
@@ -268,38 +268,6 @@
   min-width: 0;
 }
 
-/* ── Topic / category context pill ───────────────────────────────────
- * Ported 1:1 from the explorer's pills.css (.sf-topic-pill) so context
- * pills read identically everywhere ContextPills renders (Amplify modal,
- * bookmarks, category detail). A filled disc in the topic color with a
- * black glyph + label; a category borrows its parent topic's color.
- * `--pill-color` is set inline by <ContextPills>. */
-.sf-topic-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 4px 10px 4px 7px;
-  border-radius: 999px;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  line-height: 1;
-  white-space: nowrap;
-  color: #000;
-  background: var(--pill-color, var(--ds-accent));
-  border: 1px solid var(--pill-color, var(--ds-border));
-}
-.sf-topic-pill-glyph {
-  font-size: 14px;
-  line-height: 1;
-  color: #000;
-  /* Material Symbols variable-font axes — compact, filled glyph that reads
-     at 14px like the explorer's TopicBadge disc. */
-  font-variation-settings:
-    "FILL" 1,
-    "wght" 500,
-    "GRAD" 0,
-    "opsz" 20;
-}
+/* Topic / category context pill (`.sf-topic-pill`) now comes from the shared
+   DS stylesheet (topic-pill.css, imported in Global.css) — the local 1:1 copy
+   was removed during the pill unification. <ContextPills> renders <TopicPill>. */

--- a/apps/extension/components/styles/Global.css
+++ b/apps/extension/components/styles/Global.css
@@ -12,6 +12,7 @@
 @import "@0xsofia/design-system/theme.css";
 @import "@0xsofia/design-system/styles/feed-card.css";
 @import "@0xsofia/design-system/styles/verb-tag.css";
+@import "@0xsofia/design-system/styles/topic-pill.css";
 @import "@0xsofia/design-system/styles/user-badge.css";
 @import "@0xsofia/design-system/styles/bento.css";
 @import "@0xsofia/design-system/styles/echoes-sort-tabs.css";
@@ -42,56 +43,12 @@
   --ds-font-display: "Poppins", "Hind", system-ui, sans-serif;
 }
 
-/* Unified verb/tag style — extension-scoped theme of the shared DS
-   `.fc-verb-tag` (verb-tag.css). One look everywhere in the side panel:
-   ink text (white on the pinned-dark theme) + colored icon/border + a subtle
-   color fill, tighter radius. `--verb-color` (the intent color) drives the
-   icon + fill so the Categorisation chips and the Stats tags render identically.
-   Scoped here rather than in the DS so the explorer's feed tags keep their own
-   look. Per-intent rules match the DS specificity and win by cascade order. */
-.fc-verb-tag {
-  border-radius: 5px;
-  background: color-mix(
-    in srgb,
-    var(--verb-color, transparent) 12%,
-    transparent
-  );
-}
-.fc-verb-tag .fc-verb-ic {
-  color: var(--verb-color, currentColor);
-}
-.fc-verb-tag.trusted {
-  color: var(--ds-ink);
-  --verb-color: var(--intent-trusted);
-}
-.fc-verb-tag.distrusted {
-  color: var(--ds-ink);
-  --verb-color: var(--intent-distrusted);
-}
-.fc-verb-tag.work {
-  color: var(--ds-ink);
-  --verb-color: var(--intent-work);
-}
-.fc-verb-tag.learning {
-  color: var(--ds-ink);
-  --verb-color: var(--intent-learning);
-}
-.fc-verb-tag.fun {
-  color: var(--ds-ink);
-  --verb-color: var(--intent-fun);
-}
-.fc-verb-tag.inspiration {
-  color: var(--ds-ink);
-  --verb-color: var(--intent-inspiration);
-}
-.fc-verb-tag.buying {
-  color: var(--ds-ink);
-  --verb-color: var(--intent-buying);
-}
-.fc-verb-tag.music {
-  color: var(--ds-ink);
-  --verb-color: var(--intent-music);
-}
+/* Verb pills (`.fc-verb-tag`) + feed-card verb chips (`.fc-verb-tag--sm`) now
+   use the canonical DS look (outlined — intent-colored text + border + icon,
+   transparent fill) straight from verb-tag.css. The extension's old filled /
+   white-ink overrides were removed during the pill unification. The only
+   surface that keeps a filled chip is the Categorisation dropdown, which owns
+   its self-contained `.ext-cat-chip` (CategorisationDropdown.css). */
 
 /* Reset CSS global */
 * {

--- a/apps/extension/components/styles/Modal.css
+++ b/apps/extension/components/styles/Modal.css
@@ -1473,32 +1473,8 @@
   gap: 6px;
   flex-wrap: wrap;
 }
-/* Topic pill — same size & font as the DS <VerbTag> (.fc-verb-tag), but
-   the topic color applies to the text + border, not the background. */
-.rc-mark-ctx {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 11px;
-  border-radius: 6px;
-  background: transparent;
-  border: 1px solid var(--tag-color, var(--ds-accent));
-  font-family: "JetBrains Mono", monospace;
-  font-size: 10px;
-  font-weight: 700;
-  line-height: 1;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--tag-color, var(--ds-accent));
-  white-space: nowrap;
-}
-.rc-mark-ctx-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: var(--tag-color, var(--ds-accent));
-  flex: 0 0 auto;
-}
+/* `.rc-mark-ctx` (reward-ticket topic tag) was removed during the pill
+   unification — WeightRewardTicket now renders the shared DS <TopicPill>. */
 .rc-mark-title {
   font-size: 13px;
   font-weight: 600;
@@ -2550,59 +2526,10 @@
   display: none;
 }
 
-/* Music / topic / intention tag */
-/* Topic tag — same size & font as the DS <VerbTag> (.fc-verb-tag), but
-   the topic color applies to the text + border, not the background. */
-.amp .amp-tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 5px 11px;
-  border-radius: 6px;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 10px;
-  font-weight: 700;
-  line-height: 1;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  background: transparent;
-  border: 1px solid var(--tag-color, var(--ds-accent));
-  color: var(--tag-color, var(--ds-accent));
-}
-
-/* Within the Amplify modal, verb pills match the explorer's WeightModal
-   VerbPill — outlined (intent-color text + border, transparent fill) rather
-   than the filled feed-card VerbTag. `currentColor` ties the border to the
-   per-intent text color so each intent needs only a single color rule. */
-.amp .b3-row-tags .fc-verb-tag {
-  background: transparent;
-  border: 1px solid currentColor;
-  padding: 4px 10px;
-  color: var(--ds-accent);
-}
-.amp .b3-row-tags .fc-verb-tag.trusted {
-  color: var(--trusted);
-}
-.amp .b3-row-tags .fc-verb-tag.distrusted {
-  color: var(--distrusted);
-}
-.amp .b3-row-tags .fc-verb-tag.work {
-  color: var(--work);
-}
-.amp .b3-row-tags .fc-verb-tag.learning {
-  color: var(--learning);
-}
-.amp .b3-row-tags .fc-verb-tag.fun {
-  color: var(--fun);
-}
-.amp .b3-row-tags .fc-verb-tag.inspiration {
-  color: var(--inspiration);
-}
-.amp .b3-row-tags .fc-verb-tag.buying {
-  color: var(--buying);
-}
-.amp .b3-row-tags .fc-verb-tag.music {
-  color: var(--music);
-}
+/* Amplify pills unified: `.amp-tag` (dead) and the `.amp .b3-row-tags
+   .fc-verb-tag` pastel override were removed during the pill unification.
+   The Amplify basket renders the shared DS <VerbTag> (outlined, vivid intent
+   color) + <ContextPills> → <TopicPill>, matching every other surface. */
 
 /* Ticket (foreground, parchment) */
 .amp .b3-ticket {
@@ -3298,8 +3225,7 @@
   border-radius: 16px;
   overflow: hidden;
   padding: 14px 16px 16px;
-  background:
-    radial-gradient(
+  background: radial-gradient(
       120% 100% at 50% -20%,
       color-mix(in srgb, var(--tc, var(--color-success)) 13%, transparent),
       transparent 55%
@@ -3308,7 +3234,8 @@
   border: 1px solid
     color-mix(in srgb, var(--tc, var(--color-success)) 36%, var(--ds-border));
   box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--tc, var(--color-success)) 10%, transparent),
+    0 0 0 1px
+      color-mix(in srgb, var(--tc, var(--color-success)) 10%, transparent),
     0 14px 40px rgba(34, 197, 94, 0.07);
 }
 .tcard-row {
@@ -3383,8 +3310,10 @@
 }
 .bond-p.you .bond-av {
   box-shadow:
-    0 0 0 2px color-mix(in srgb, var(--tc, var(--color-success)) 55%, transparent),
-    0 0 18px color-mix(in srgb, var(--tc, var(--color-success)) 25%, transparent);
+    0 0 0 2px
+      color-mix(in srgb, var(--tc, var(--color-success)) 55%, transparent),
+    0 0 18px
+      color-mix(in srgb, var(--tc, var(--color-success)) 25%, transparent);
 }
 .bond-mid {
   flex: 1;
@@ -3457,7 +3386,8 @@
     color-mix(in srgb, var(--tc, var(--color-success)) 50%, transparent);
   border-radius: 999px;
   padding: 5px 11px;
-  box-shadow: 0 0 14px color-mix(in srgb, var(--tc, var(--color-success)) 20%, transparent);
+  box-shadow: 0 0 14px
+    color-mix(in srgb, var(--tc, var(--color-success)) 20%, transparent);
 }
 .bond-verb svg {
   width: 11px;
@@ -3848,7 +3778,8 @@
   line-height: 0.95;
   letter-spacing: -0.03em;
   color: var(--color-success);
-  text-shadow: 0 0 30px color-mix(in srgb, var(--color-success) 35%, transparent);
+  text-shadow: 0 0 30px
+    color-mix(in srgb, var(--color-success) 35%, transparent);
 }
 .rc-sn-new.is-oppose {
   color: var(--color-error);
@@ -3898,7 +3829,8 @@
   z-index: 2;
   background: radial-gradient(circle at 38% 32%, #ffb59a, #e8628c 70%, #b6407a);
   border-color: var(--color-success);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-success) 30%, transparent);
+  box-shadow: 0 0 0 3px
+    color-mix(in srgb, var(--color-success) 30%, transparent);
 }
 .rc-bk--you.is-oppose {
   border-color: var(--color-error);

--- a/apps/extension/components/styles/Modal.css
+++ b/apps/extension/components/styles/Modal.css
@@ -2748,16 +2748,6 @@
   border-color: rgba(255, 253, 252, 0.226);
   box-shadow: 0 6px 18px -8px rgba(0, 0, 0, 0.5);
 }
-.amp .b3-row.is-on::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 12px;
-  bottom: 12px;
-  width: 3px;
-  border-radius: 0 3px 3px 0;
-  background: var(--ds-accent);
-}
 .amp .b3-check {
   width: 22px;
   height: 22px;

--- a/apps/extension/components/ui/CategorisationDropdown.tsx
+++ b/apps/extension/components/ui/CategorisationDropdown.tsx
@@ -203,13 +203,16 @@ export const CategorisationDropdown = memo(
 
     const noResults = verbRows.length === 0 && topicEntries.length === 0
 
-    // ── chips (field) — reuse the shared .fc-verb-tag look so they render
-    // identically to the Stats tags. Verbs carry their intent class; topics
-    // pass their color through --verb-color. ──
+    // ── chips (field) — SELF-CONTAINED `.ext-cat-chip` (decoupled from the
+    // unified `.fc-verb-tag` pill). Both verbs and topics drive their color
+    // through --verb-color so the dropdown keeps its own look. ──
     const verbChips = selectedIntentions.map((type) => {
       const Icon = INTENTION_ICONS[type]
       return (
-        <span key={`v-${type}`} className={`fc-verb-tag ${type} ext-cat-chip`}>
+        <span
+          key={`v-${type}`}
+          className="ext-cat-chip"
+          style={{ ["--verb-color" as string]: INTENTION_CONFIG[type].color }}>
           <Icon className="fc-verb-ic" aria-hidden />
           <span>{INTENTION_CONFIG[type].label}</span>
           <button
@@ -231,7 +234,7 @@ export const CategorisationDropdown = memo(
       return (
         <span
           key={`c-${slug}`}
-          className="fc-verb-tag ext-cat-chip"
+          className="ext-cat-chip"
           style={{ ["--verb-color" as string]: color }}>
           <span
             className="ext-cat-chip-glyph material-symbols-outlined"

--- a/apps/extension/components/ui/ContextPills.tsx
+++ b/apps/extension/components/ui/ContextPills.tsx
@@ -5,14 +5,17 @@
  * explorer (dot + label per hidden context). Ported from the explorer's
  * ChipOverflowRow (glitch-free: a hidden mirror is measured pre-paint).
  */
-import type { CSSProperties } from "react"
+import {
+  TopicPill,
+  useAnchoredTooltip,
+  useChipOverflow
+} from "@0xsofia/design-system"
 import { createPortal } from "react-dom"
-import { useChipOverflow, useAnchoredTooltip } from "@0xsofia/design-system"
 
 import {
   contextColor,
   contextIcon,
-  contextLabel,
+  contextLabel
 } from "~/lib/config/contextDisplay"
 
 import "../styles/ContextPicker.css"
@@ -30,7 +33,7 @@ export default function ContextPills({ slugs }: { slugs: string[] }) {
       slug,
       label: contextLabel(slug),
       color: contextColor(slug),
-      icon: contextIcon(slug),
+      icon: contextIcon(slug)
     }))
     .filter((c): c is ResolvedPill => Boolean(c.label))
 
@@ -42,24 +45,20 @@ export default function ContextPills({ slugs }: { slugs: string[] }) {
   if (total === 0) return null
 
   const hidden = chips.slice(shown)
+  // Visible pills use the shared DS <TopicPill>; the hidden mirror below keeps
+  // raw `.sf-topic-pill` spans (same class → same width) carrying `data-chip`
+  // for the overflow measure.
   const pill = (c: ResolvedPill) => (
-    <span
-      key={c.slug}
-      className="sf-topic-pill"
-      style={{ "--pill-color": c.color } as CSSProperties}>
-      <span
-        className="material-symbols-outlined sf-topic-pill-glyph"
-        aria-hidden>
-        {c.icon}
-      </span>
-      {c.label}
-    </span>
+    <TopicPill key={c.slug} color={c.color} label={c.label} glyph={c.icon} />
   )
 
   return (
     <div className="ext-cp-wrap">
       {/* hidden mirror — all chips, measured for the first-line fit */}
-      <div className="ext-cp-row ext-cp-row--measure" ref={mirrorRef} aria-hidden>
+      <div
+        className="ext-cp-row ext-cp-row--measure"
+        ref={mirrorRef}
+        aria-hidden>
         {chips.map((c) => (
           <span key={c.slug} data-chip="1" className="sf-topic-pill">
             <span
@@ -111,7 +110,7 @@ export default function ContextPills({ slugs }: { slugs: string[] }) {
               </div>
             ))}
           </div>,
-          document.body,
+          document.body
         )}
     </div>
   )

--- a/apps/extension/components/ui/group-detail/UrlRow.tsx
+++ b/apps/extension/components/ui/group-detail/UrlRow.tsx
@@ -4,9 +4,15 @@
  * metadata, and an expandable section with intention + context selectors.
  */
 
+import { TopicPill, VerbTag } from "@0xsofia/design-system"
 import { useState } from "react"
 
-import { TOPIC_COLORS, TOPIC_LABELS } from "~/lib/config/topicConfig"
+import {
+  contextColor,
+  contextIcon,
+  contextLabel
+} from "~/lib/config/contextDisplay"
+import { INTENTION_ICONS } from "~/lib/config/intentionIcons"
 import {
   formatDuration,
   formatShortDate,
@@ -17,8 +23,8 @@ import {
   CERTIFICATION_LIST,
   INTENTION_CONFIG,
   INTENTION_ITEMS,
-  type IntentionType,
-  TRUST_ITEMS
+  TRUST_ITEMS,
+  type IntentionType
 } from "~/types/intentionCategories"
 import type { GroupUrlRecord } from "~types/database"
 
@@ -187,28 +193,28 @@ function UrlRow({
             {((isCertifiedOnChain && allCertInfos.length > 0) ||
               certifiedContexts.length > 0) && (
               <div className="cert-badges">
-                {allCertInfos.map((certInfo) => (
-                  <span
-                    key={certInfo.type}
-                    className="cert-badge on-chain"
-                    style={{ backgroundColor: certInfo.color }}
-                    title={`Marked as ${certInfo.label} (on-chain)`}>
-                    {certInfo.label}
-                  </span>
-                ))}
-                {certifiedContexts.map((slug) => {
-                  const label = TOPIC_LABELS[slug] || slug
-                  const color = TOPIC_COLORS[slug] || "var(--ds-accent)"
+                {allCertInfos.map((certInfo) => {
+                  const Icon = INTENTION_ICONS[certInfo.type]
                   return (
-                    <span
-                      key={`ctx-${slug}`}
-                      className="cert-badge cert-badge--context"
-                      style={{ color, borderColor: color }}
-                      title={`Marked in context of ${label}`}>
-                      {label}
-                    </span>
+                    <VerbTag
+                      key={certInfo.type}
+                      intent={certInfo.type}
+                      label={certInfo.label}
+                      icon={Icon ? <Icon className="fc-verb-ic" /> : undefined}
+                      title={`Marked as ${certInfo.label} (on-chain)`}
+                    />
                   )
                 })}
+                {certifiedContexts.map((slug) => (
+                  <TopicPill
+                    key={`ctx-${slug}`}
+                    color={contextColor(slug)}
+                    label={contextLabel(slug) ?? slug}
+                    glyph={contextIcon(slug)}
+                    size="sm"
+                    title={`Marked in context of ${contextLabel(slug) ?? slug}`}
+                  />
+                ))}
               </div>
             )}
             <span className="url-date">

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -19,6 +19,7 @@
     "./styles/favicon.css": "./src/styles/favicon.css",
     "./styles/feed-card.css": "./src/styles/feed-card.css",
     "./styles/verb-tag.css": "./src/styles/verb-tag.css",
+    "./styles/topic-pill.css": "./src/styles/topic-pill.css",
     "./styles/user-badge.css": "./src/styles/user-badge.css",
     "./styles/interests.css": "./src/styles/interests.css",
     "./styles/nav-sidebar.css": "./src/styles/nav-sidebar.css",

--- a/packages/design-system/src/components/FaviconWrapper.tsx
+++ b/packages/design-system/src/components/FaviconWrapper.tsx
@@ -1,49 +1,73 @@
+import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 
 export interface FaviconWrapperProps {
   /** Image URL (favicon served by the host site, Google's `s2/favicons`, …). */
   src?: string
-  /** Accessible label — pass the hostname or site name. */
+  /** Tried when `src` is missing or fails to load (e.g. an on-chain image). */
+  fallbackSrc?: string
+  /** Accessible label — pass the hostname or site name. Also seeds the letter
+   *  fallback shown when no image resolves. */
   alt?: string
   /** Pixel size of the wrapper. Defaults to 32. */
   size?: number
   /** Extra classes to compose onto `.favicon`. */
   className?: string
-  /** Inline SVG / fallback node when `src` is omitted. */
+  /** Custom fallback node when no image source loads. When absent, the first
+   *  letter of `alt` is shown. */
   children?: ReactNode
 }
 
 /**
- * `<FaviconWrapper>` — white-background box that keeps dark favicons
- * readable on any theme.
+ * `<FaviconWrapper>` — white-background box that keeps dark favicons readable
+ * on any theme. Tries `src`, then `fallbackSrc`, then degrades to `children`
+ * or a letter tile seeded from `alt`, so the box is never empty.
  *
  * Requires the stylesheet to be imported at least once in the consuming app:
  *   `@import "@0xsofia/design-system/styles/favicon.css";`
  *
  * @example
- *   <FaviconWrapper src={`https://www.google.com/s2/favicons?domain=${host}`} alt={host} />
+ *   <FaviconWrapper src={`/favicons/${slug}.png`} fallbackSrc={onChainImg} alt={name} />
  */
 export function FaviconWrapper({
   src,
+  fallbackSrc,
   alt = '',
   size = 32,
   className,
   children,
 }: FaviconWrapperProps) {
+  // Ordered image candidates; walk to the next one when the current fails.
+  const candidates = [src, fallbackSrc].filter(Boolean) as string[]
+  const [idx, setIdx] = useState(0)
+  // List rows reuse instances across data — restart the chain when the
+  // sources change so a new (valid) favicon isn't hidden by a stale error.
+  useEffect(() => {
+    setIdx(0)
+  }, [src, fallbackSrc])
+
+  const current = candidates[idx]
   const style = { ['--fav-size' as string]: `${size}px` }
   const cls = className ? `favicon ${className}` : 'favicon'
+  const fallback =
+    children ??
+    (alt ? (
+      <span className="favicon-fallback" aria-hidden="true">
+        {alt.slice(0, 1)}
+      </span>
+    ) : null)
+
   return (
     <span className={cls} style={style}>
-      {src ? (
+      {current ? (
         <img
-          src={src}
+          key={current}
+          src={current}
           alt={alt}
-          onError={(e) => {
-            ;(e.currentTarget as HTMLImageElement).style.display = 'none'
-          }}
+          onError={() => setIdx((i) => i + 1)}
         />
       ) : (
-        children
+        fallback
       )}
     </span>
   )

--- a/packages/design-system/src/components/FeedCardView.tsx
+++ b/packages/design-system/src/components/FeedCardView.tsx
@@ -333,12 +333,15 @@ export function FeedCardView({
       label: v.label,
       color: v.color,
       node: (
+        // Canonical verb pill (compact) — outlined, colour-driven via `--vc`.
+        // Shares `.fc-verb-tag` (verb-tag.css) so feed chips match every other
+        // verb pill across the apps.
         <span
           key={`v-${v.label}`}
-          className="fc-verb"
+          className="fc-verb-tag fc-verb-tag--sm"
           style={v.color ? { ['--vc' as string]: v.color } : undefined}
         >
-          {v.icon ?? <i aria-hidden="true" />}
+          {v.icon ?? null}
           {v.label}
         </span>
       ),

--- a/packages/design-system/src/components/FeedCardView.tsx
+++ b/packages/design-system/src/components/FeedCardView.tsx
@@ -228,6 +228,10 @@ export interface FeedCardViewProps {
   down: number
   userUp?: boolean
   userDown?: boolean
+  /** Awaiting on-chain confirmation (queued in the cart). The matching vote
+   *  button shows a dashed accent to signal the pending state. */
+  pendingUp?: boolean
+  pendingDown?: boolean
   canUp?: boolean
   canDown?: boolean
   /** Render the vote thumbs WITHOUT their numeric counts — for toggle-style
@@ -283,6 +287,8 @@ export function FeedCardView({
   down,
   userUp,
   userDown,
+  pendingUp = false,
+  pendingDown = false,
   canUp = true,
   canDown = true,
   hideVoteCounts = false,
@@ -458,7 +464,7 @@ export function FeedCardView({
                 className={`fc-xs-votes${up < 0 ? ' fc-xs-votes--hidden' : ''}`}
               >
                 <span
-                  className={`fc-xs-vote u${userUp ? ' on' : ''}`}
+                  className={`fc-xs-vote u${userUp ? ' on' : ''}${pendingUp ? ' is-pending' : ''}`}
                   onClick={onVote ? vote('support') : undefined}
                   style={onVote ? { cursor: 'pointer' } : undefined}
                 >
@@ -466,7 +472,7 @@ export function FeedCardView({
                   {hideVoteCounts ? null : up}
                 </span>
                 <span
-                  className={`fc-xs-vote d${userDown ? ' on' : ''}`}
+                  className={`fc-xs-vote d${userDown ? ' on' : ''}${pendingDown ? ' is-pending' : ''}`}
                   onClick={onVote ? vote('oppose') : undefined}
                   style={onVote ? { cursor: 'pointer' } : undefined}
                 >
@@ -545,7 +551,7 @@ export function FeedCardView({
           <div className="fc-votes">
             <button
               type="button"
-              className={`fc-vote up${userUp ? ' on' : ''}${canUp ? '' : ' is-disabled'}`}
+              className={`fc-vote up${userUp ? ' on' : ''}${pendingUp ? ' is-pending' : ''}${canUp ? '' : ' is-disabled'}`}
               aria-label={
                 canUp
                   ? `Support (${up})`
@@ -565,7 +571,7 @@ export function FeedCardView({
             </button>
             <button
               type="button"
-              className={`fc-vote down${userDown ? ' on' : ''}${canDown ? '' : ' is-disabled'}`}
+              className={`fc-vote down${userDown ? ' on' : ''}${pendingDown ? ' is-pending' : ''}${canDown ? '' : ' is-disabled'}`}
               aria-label={
                 canDown
                   ? `Oppose (${down})`

--- a/packages/design-system/src/components/TopicPill.tsx
+++ b/packages/design-system/src/components/TopicPill.tsx
@@ -1,0 +1,85 @@
+import type { CSSProperties, ReactNode } from 'react'
+
+export type TopicPillSize = 'md' | 'sm'
+
+export interface TopicPillProps {
+  /** Display label (also used as the tooltip/aria text in icon-only mode). */
+  label: string
+  /** Topic colour — drives the fill + border. Falls back to a neutral accent. */
+  color?: string
+  /** Material Symbols glyph NAME (e.g. "science"). Rendered as a black glyph
+   *  inside the coloured disc. Consumers resolve their own taxonomy → glyph. */
+  glyph?: string
+  /** Pre-built icon node — overrides `glyph` when both are provided. Lets
+   *  callers inject a non-Material-Symbols icon while keeping the pill shell. */
+  icon?: ReactNode
+  /** Collapse to a coloured disc carrying just the glyph (drops the label). */
+  iconOnly?: boolean
+  /** Compact variant for dense rows. */
+  size?: TopicPillSize
+  /** Accessible title tooltip (defaults to `label`). */
+  title?: string
+  /** Extra classes composed onto `.sf-topic-pill`. */
+  className?: string
+}
+
+/**
+ * `<TopicPill>` — a topic/context/category rendered as a filled disc: black
+ * glyph + label on the topic colour, border of the same colour.
+ *
+ * Data-free by design: the caller resolves colour/label/glyph from its own
+ * taxonomy and hands them down, so the design-system stays free of any app
+ * topic config (mirrors the `renderTopic` injection in <FeedCardView>).
+ *
+ * Requires the stylesheet imported once in the consuming app:
+ *   `@import "@0xsofia/design-system/styles/topic-pill.css";`
+ * Material Symbols glyphs require the app to load the Material Symbols font.
+ */
+export function TopicPill({
+  label,
+  color,
+  glyph,
+  icon,
+  iconOnly,
+  size = 'md',
+  title,
+  className,
+}: TopicPillProps) {
+  const cls = [
+    'sf-topic-pill',
+    iconOnly ? 'sf-topic-pill--icon' : '',
+    size === 'sm' ? 'sf-topic-pill--sm' : '',
+    className ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const glyphNode =
+    icon ??
+    (glyph ? (
+      <span
+        className="material-symbols-outlined sf-topic-pill-glyph"
+        aria-hidden="true"
+      >
+        {glyph}
+      </span>
+    ) : null)
+
+  return (
+    <span
+      className={cls}
+      style={
+        {
+          ['--pill-color' as string]: color || 'var(--ds-accent)',
+        } as CSSProperties
+      }
+      title={title ?? (iconOnly ? label : undefined)}
+      aria-label={iconOnly ? label : undefined}
+    >
+      {glyphNode}
+      {iconOnly ? null : label}
+    </span>
+  )
+}
+
+export default TopicPill

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from './FaviconWrapper'
 export * from './FeedCardView'
 export * from './VerbTag'
+export * from './TopicPill'
 export * from './UserBadge'
 export * from './GroupBentoCard'
 export * from './InterestsGrid'

--- a/packages/design-system/src/styles/favicon.css
+++ b/packages/design-system/src/styles/favicon.css
@@ -32,3 +32,18 @@
   object-fit: contain;
   display: block;
 }
+
+/* Letter fallback — shown when the favicon image is missing or fails to load,
+   so the box never renders empty. Dark ink on the white favicon surface. */
+.favicon-fallback {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  font-family: var(--ds-font-display, system-ui, sans-serif);
+  font-weight: 700;
+  font-size: calc(var(--fav-size) * 0.5);
+  line-height: 1;
+  color: #02000e;
+  text-transform: uppercase;
+}

--- a/packages/design-system/src/styles/feed-card.css
+++ b/packages/design-system/src/styles/feed-card.css
@@ -246,58 +246,9 @@
   color: var(--ds-ink);
 }
 
-/* Verb tag — outlined: text + border in the intent colour, no fill.
-   Mirrors the shared <VerbPill> (.sf-verb-pill); kept in sync so the
-   surfaces still on .fc-verb-tag (ProfileClaimCard, BadgeDetailPage,
-   PlatformDetailPage) match the feeds. */
-.fc-verb-tag {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--ds-ink);
-  padding: 5px 11px;
-  border-radius: 6px;
-  border: 1px solid var(--ds-border);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  line-height: 1;
-  background: transparent;
-}
-.fc-verb-tag.trusted {
-  color: var(--intent-trusted);
-  border-color: var(--intent-trusted);
-}
-.fc-verb-tag.distrusted {
-  color: var(--intent-distrusted);
-  border-color: var(--intent-distrusted);
-}
-.fc-verb-tag.work {
-  color: var(--intent-work);
-  border-color: var(--intent-work);
-}
-.fc-verb-tag.learning {
-  color: var(--intent-learning);
-  border-color: var(--intent-learning);
-}
-.fc-verb-tag.fun {
-  color: var(--intent-fun);
-  border-color: var(--intent-fun);
-}
-.fc-verb-tag.inspiration {
-  color: var(--intent-inspiration);
-  border-color: var(--intent-inspiration);
-}
-.fc-verb-tag.buying {
-  color: var(--intent-buying);
-  border-color: var(--intent-buying);
-}
-.fc-verb-tag.music {
-  color: var(--intent-music);
-  border-color: var(--intent-music);
-}
+/* Verb tag (.fc-verb-tag) now lives ONLY in verb-tag.css — single source of
+   truth for the outlined verb pill. The duplicate block that used to sit here
+   was removed during the pill unification; import verb-tag.css to get it. */
 
 /* ── Feed card (Claude Design "Feed Card" handoff) ─────────────────
    The current feed card, shared by the explore feed (home FeedCard) and
@@ -686,8 +637,7 @@
   background: var(--ds-ink);
   color: var(--ds-bg);
   pointer-events: none;
-  box-shadow: 0 10px 28px -10px
-    color-mix(in srgb, var(--ds-ink) 65%, transparent);
+  box-shadow: 0 10px 28px -10px color-mix(in srgb, var(--ds-ink) 65%, transparent);
   z-index: 10000;
 }
 .fc-more-tip::after {
@@ -721,38 +671,10 @@
   text-overflow: ellipsis;
   min-width: 0;
 }
-.fc-verb {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 9.5px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--vc, var(--ds-ink-soft));
-  padding: 4px 9px;
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--vc, var(--ds-muted)) 13%, transparent);
-  border: 1px solid
-    color-mix(in srgb, var(--vc, var(--ds-muted)) 34%, transparent);
-}
-.fc-verb i {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--vc, var(--ds-muted));
-  flex-shrink: 0;
-}
-/* Consumer-provided verb icon (replaces the dot) — inherits the verb colour
-   via currentColor (.fc-verb sets `color: var(--vc)`). */
-.fc-verb-ic {
-  width: 12px;
-  height: 12px;
-  flex-shrink: 0;
-}
-/* Topics reuse the shared <TopicPill> (.sf-topic-pill, styles/pills.css) —
-   black glyph on the topic color — so the feed cards match the topic pills
-   used across echoes / drawer / profile. */
+/* Feed-card verb chips now render the canonical `.fc-verb-tag fc-verb-tag--sm`
+   (verb-tag.css) — outlined, colour-driven via `--vc`. The old `.fc-verb`
+   (tinted fill + dot) was removed during the pill unification.
+   Topics render the shared <TopicPill> (.sf-topic-pill, topic-pill.css). */
 
 /* Masonry column layout (CSS columns — no JS needed). */
 /* Row-major grid (was CSS-columns masonry). Items flow left-to-right
@@ -1090,10 +1012,6 @@
 .fc-card--s-sm .fc-vote svg {
   width: 13px;
   height: 13px;
-}
-.fc-card--s-sm .fc-verb {
-  font-size: 9px;
-  padding: 3px 8px;
 }
 
 /* Extra-small — list row (no full-bleed hero) */

--- a/packages/design-system/src/styles/feed-card.css
+++ b/packages/design-system/src/styles/feed-card.css
@@ -637,7 +637,8 @@
   background: var(--ds-ink);
   color: var(--ds-bg);
   pointer-events: none;
-  box-shadow: 0 10px 28px -10px color-mix(in srgb, var(--ds-ink) 65%, transparent);
+  box-shadow: 0 10px 28px -10px
+    color-mix(in srgb, var(--ds-ink) 65%, transparent);
   z-index: 10000;
 }
 .fc-more-tip::after {
@@ -1122,6 +1123,19 @@
 }
 .fc-xs-vote.d.on {
   color: var(--distrusted, #ef5a5a);
+}
+/* Pending vote — queued in the cart, awaiting on-chain confirmation. A dashed
+   green accent confirms the click registered before the tx settles. */
+.fc-vote.is-pending {
+  border-style: dashed;
+  border-color: var(--intent-trusted, #22c55e);
+  color: var(--intent-trusted, #22c55e);
+}
+.fc-xs-vote.is-pending {
+  border: 1px dashed var(--intent-trusted, #22c55e);
+  border-radius: 6px;
+  padding: 1px 5px;
+  color: var(--intent-trusted, #22c55e);
 }
 .fc-xs-votes--hidden {
   display: none;

--- a/packages/design-system/src/styles/topic-pill.css
+++ b/packages/design-system/src/styles/topic-pill.css
@@ -1,0 +1,59 @@
+/**
+ * Topic pill — FILLED disc: black glyph + label on the topic colour, border
+ * of that colour. Single source of truth for the topic/context/category pills
+ * shown across every surface (circle, explore, Echoes, ProfileDrawer, the
+ * public-profile rail, the extension's ContextPills / bookmark rows). Moved
+ * here from the explorer's `pills.css` so both apps render the same pill.
+ *
+ * `--pill-color` is the topic colour, set inline by <TopicPill>; falls back
+ * to a neutral accent when unknown.
+ *
+ * Usage: <TopicPill color={hex} label="Science" glyph="science" />
+ */
+
+.sf-topic-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--ds-font-mono, 'JetBrains Mono', monospace);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  line-height: 1;
+  white-space: nowrap;
+  padding: 4px 10px 4px 7px;
+  border-radius: 999px;
+  color: #000;
+  background: var(--pill-color, var(--ds-accent));
+  border: 1px solid var(--pill-color, var(--ds-border));
+}
+
+/* Icon-only variant — equal padding so the rounded pill reads as a coloured
+   disc carrying just the glyph (label exposed via title/aria). */
+.sf-topic-pill--icon {
+  gap: 0;
+  padding: 4px;
+}
+
+/* Compact variant — dense rows (feed cards, bookmark/history URL rows). */
+.sf-topic-pill--sm {
+  font-size: 9px;
+  padding: 3px 9px 3px 6px;
+}
+
+.sf-topic-pill-glyph {
+  font-size: 14px;
+  line-height: 1;
+  color: #000;
+  /* Material Symbols variable-font axes — compact, filled glyph that reads at
+     14px like the original TopicBadge disc. */
+  font-variation-settings:
+    'FILL' 1,
+    'wght' 500,
+    'GRAD' 0,
+    'opsz' 20;
+}
+.sf-topic-pill--sm .sf-topic-pill-glyph {
+  font-size: 13px;
+}

--- a/packages/design-system/src/styles/verb-tag.css
+++ b/packages/design-system/src/styles/verb-tag.css
@@ -12,10 +12,12 @@
   font-family: 'JetBrains Mono', monospace;
   font-size: 10px;
   font-weight: 700;
-  color: var(--ds-ink);
+  /* Colour path: the intent slug classes below win by specificity; callers
+     without a slug (e.g. feed cards) drive the colour inline via `--vc`. */
+  color: var(--vc, var(--ds-ink));
   padding: 5px 11px;
   border-radius: 6px;
-  border: 1px solid var(--ds-border);
+  border: 1px solid var(--vc, var(--ds-border));
   letter-spacing: 0.08em;
   text-transform: uppercase;
   display: inline-flex;
@@ -24,11 +26,25 @@
   line-height: 1;
   background: transparent;
 }
-/* Optional leading verb icon (consumer-provided lucide glyph). */
-.fc-verb-tag .fc-verb-ic {
+/* Optional leading verb icon (consumer-provided lucide glyph). Sized both as a
+   descendant of the tag and standalone (some callers render it bare). */
+.fc-verb-tag .fc-verb-ic,
+.fc-verb-ic {
   width: 12px;
   height: 12px;
   flex-shrink: 0;
+}
+
+/* Compact variant — feed-card chips where vertical space is tight. Same
+   outlined look, smaller type + padding (replaces the old `.fc-verb`). */
+.fc-verb-tag--sm {
+  font-size: 9px;
+  padding: 4px 9px;
+  gap: 4px;
+}
+.fc-verb-tag--sm .fc-verb-ic {
+  width: 11px;
+  height: 11px;
 }
 
 /* Canonical intent classes (mirror INTENTION_CONFIG) — colored text + border. */


### PR DESCRIPTION
### Pills — single source of truth in `@0xsofia/design-system`
- New `<TopicPill>` + `topic-pill.css` (filled disc, black glyph).
- `<VerbTag>` gains a compact `sm` variant + a colour-driven `--vc` path; feed cards render `.fc-verb-tag--sm` instead of the old `.fc-verb`. Duplicate `.fc-verb-tag` / `.fc-verb` blocks removed.
- **Extension**: bookmark rows (`UrlRow`), `HistoryTab`, `ContextPills`, the reward ticket and the Amplify basket migrated onto the shared pills. Local overrides + dead CSS removed (`.cert-badge`, `.amp-tag`, `.rc-mark-ctx`, the Global.css verb overrides, the ported `.sf-topic-pill`). The Categorisation dropdown is decoupled into its own `.ext-cat-chip` so it keeps its look.
- **Explorer**: `<VerbPill>` / `<TopicPill>` become thin wrappers over the DS components; `pills.css` emptied; the 11 consumers are unchanged. Feed verb chips now carry the intent icon (adapter injects it). The Scores "All topics" list uses `TopicPill` (icon on a solid disc) instead of a dot + monochrome glyph.

**Design decisions:** verbs = outlined, intent-coloured text + border + icon. Topics = filled disc, black glyph. Dropdown menus keep their own style (untouched).

### Circles / nav polish
- Members module → "Most active members" with a top-right "View all"; footer button dropped.
- KPI band: no top border, no label dots, tiles show the number on top + a single label line.
- Nav sidebar: circle dots, the "+" add chip and the member count removed; avatars aligned with their titles.
- Topics treemap: cell dot removed.

### Favicons & pending votes
- `<FaviconWrapper>` tries `src` → `fallbackSrc` → a letter tile (seeded from `alt`) so the box is never empty. The platforms right rail now falls back to the on-chain image (shared `resolvePlatformImage`) like the list, so its favicons show up. DEX rows drop their coloured left rail.
- `<FeedCardView>` gains `pendingUp` / `pendingDown` → a **dashed green** accent on the vote thumb. The explorer FeedCard marks a like/dislike as pending (queued in the cart, awaiting tx) via `useCart`.

### Verification
- `tsc` clean: design-system, extension, explorer.
- `bun format:check` clean (root Prettier 3.4.2).
- Both apps build: extension (Plasmo) + explorer (Vite).

> Visual QA still recommended on the touched surfaces (feeds, bookmark, history, amplify/reward, echoes, profile, platforms, circles, nav).
